### PR TITLE
updates to readme and install process after testing from new repo clone

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,8 +7,10 @@ FlexFlow can be built from source code using the following instructions.
 ```
 git clone --recursive https://github.com/flexflow/FlexFlow.git
 cd FlexFlow
+git submodule init
+git submodule update -r
 ```
-The `FF_HOME` exvirnoment is used for building and running FlexFlow. You can add the following line in `~/.bashrc`.
+The `FF_HOME` environment variable is used for building and running FlexFlow. You can add the following line in `~/.bashrc`.
 ```
 export FF_HOME=/path/to/FlexFlow
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ FlexFlow is a deep learning framework that accelerates distributed DNN training 
 
 ## Prerequisties
 * [CUDNN](https://developer.nvidia.com/cudnn) is used to perform low-level operations.
+Download CUDNN and install it locally or at the system level.
+```
+export CUDNN=/path/to/cudnn
+```
 
 * [Legion](http://legion.stanford.edu) is the underlying runtime FlexFlow built on.
 
@@ -20,6 +24,7 @@ See [instructions](INSTALL.md) to install FlexFlow from source.
 See the [examples](examples) folders for existing FlexFlow applications. Use the following command line to build a DNN model (e.g., InceptionV3).
 ```
 ./ffcompile.sh examples/InceptionV3
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CUDNN_HOME/lib64:$FF_HOME/protobuf/src/libs
 ```
 
 ## Train a DNN model

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FlexFlow is a deep learning framework that accelerates distributed DNN training 
 * [CUDNN](https://developer.nvidia.com/cudnn) is used to perform low-level operations.
 Download CUDNN and install it locally or at the system level.
 ```
-export CUDNN=/path/to/cudnn
+export CUDNN_HOME=/path/to/cudnn
 ```
 
 * [Legion](http://legion.stanford.edu) is the underlying runtime FlexFlow built on.

--- a/examples/AlexNet/Makefile
+++ b/examples/AlexNet/Makefile
@@ -38,11 +38,11 @@ GEN_GPU_SRC	?= ../../src/ops/conv_2d.cu ../../src/runtime/model.cu ../../src/ops
 		../../src/runtime/cuda_helper.cu# .cu files
 
 # You can modify these variables, some will be appended to by the runtime makefile
-INC_FLAGS	?= -I../../include/ -I/autofs/nccs-svm1_home1/zhihao/tools/protobuf/src
+INC_FLAGS	?= -I../../include/ -I${FF_HOME}/protobuf/src -I${CUDNN_HOME}/include
 CC_FLAGS	?=
 NVCC_FLAGS	?=
 GASNET_FLAGS	?=
-LD_FLAGS	?= -lcudnn -lcublas -lcurand -lprotobuf -L/usr/local/lib -L/autofs/nccs-svm1_home1/zhihao/tools/protobuf/src/.libs
+LD_FLAGS	?= -lcudnn -lcublas -lcurand -lprotobuf -L/usr/local/lib -L${FF_HOME}/protobuf/src/.libs -L${CUDNN_HOME}/lib64
 # For Point and Rect typedefs
 CC_FLAGS	+= -std=c++11
 NVCC_FLAGS  	+= -std=c++11

--- a/examples/DLRM/Makefile.devgpu
+++ b/examples/DLRM/Makefile.devgpu
@@ -38,11 +38,11 @@ GEN_GPU_SRC	?= ../../src/ops/conv_2d.cu ../../src/runtime/model.cu ../../src/ops
 		../../src/runtime/cuda_helper.cu $(app).cu# .cu files
 
 # You can modify these variables, some will be appended to by the runtime makefile
-INC_FLAGS	?= -I../../include/ -I/mnt/homedir/zhihao/tools/protobuf/src -I/mnt/homedir/zhihao/tools/hdf5-1.10.5-linux-centos7-x86_64-shared/include/
+INC_FLAGS	?= -I../../include/ -I${FF_HOME}/protobuf/src -I/mnt/homedir/zhihao/tools/hdf5-1.10.5-linux-centos7-x86_64-shared/include/
 CC_FLAGS	?=
 NVCC_FLAGS	?=
 GASNET_FLAGS	?=
-LD_FLAGS	?= -lcudnn -lcublas -lcurand -lprotobuf -L/usr/local/lib -lhdf5 -L/mnt/homedir/zhihao/tools/protobuf/src/.libs -L/mnt/homedir/zhihao/tools/hdf5-1.10.5-linux-centos7-x86_64-shared/lib
+LD_FLAGS	?= -lcudnn -lcublas -lcurand -lprotobuf -L/usr/local/lib -lhdf5 -L${FF_HOME}/protobuf/src/.libs -L/mnt/homedir/zhihao/tools/hdf5-1.10.5-linux-centos7-x86_64-shared/lib
 # For Point and Rect typedefs
 CC_FLAGS	+= -std=c++11
 NVCC_FLAGS  += -std=c++11

--- a/examples/InceptionV3/Makefile
+++ b/examples/InceptionV3/Makefile
@@ -38,11 +38,11 @@ GEN_GPU_SRC	?= ../../src/ops/conv_2d.cu ../../src/runtime/model.cu ../../src/ops
 		../../src/runtime/cuda_helper.cu# .cu files
 
 # You can modify these variables, some will be appended to by the runtime makefile
-INC_FLAGS	?= -I../../include/ -I/autofs/nccs-svm1_home1/zhihao/tools/protobuf/src
+INC_FLAGS	?= -I../../include/ -I${FF_HOME}/protobuf/src -I${CUDNN_HOME}/include
 CC_FLAGS	?=
 NVCC_FLAGS	?=
 GASNET_FLAGS	?=
-LD_FLAGS	?= -lcudnn -lcublas -lcurand -lprotobuf -L/usr/local/lib -L/autofs/nccs-svm1_home1/zhihao/tools/protobuf/src/.libs
+LD_FLAGS	?= -lcudnn -lcublas -lcurand -lprotobuf -L/usr/local/lib -L${FF_HOME}/protobuf/src/.libs -L${CUDNN_HOME}/lib64
 # For Point and Rect typedefs
 CC_FLAGS	+= -std=c++11
 NVCC_FLAGS  	+= -std=c++11

--- a/examples/candle_uno/Makefile
+++ b/examples/candle_uno/Makefile
@@ -39,11 +39,11 @@ GEN_GPU_SRC	?= ../../src/ops/conv_2d.cu ../../src/runtime/model.cu ../../src/ops
 		../../src/runtime/cuda_helper.cu $(app).cu# .cu files
 
 # You can modify these variables, some will be appended to by the runtime makefile
-INC_FLAGS	?= -I../../include/ -I/autofs/nccs-svm1_home1/zhihao/tools/protobuf/src
+INC_FLAGS	?= -I../../include/ -I${FF_HOME}/protobuf/src -I${CUDNN_HOME}/include
 CC_FLAGS	?=
 NVCC_FLAGS	?=
 GASNET_FLAGS	?=
-LD_FLAGS	?= -lcudnn -lcublas -lcurand -lprotobuf -L/usr/local/lib -L/autofs/nccs-svm1_home1/zhihao/tools/protobuf/src/.libs
+LD_FLAGS	?= -lcudnn -lcublas -lcurand -lprotobuf -L/usr/local/lib -L${FF_FLOW}/protobuf/src/.libs -L${CUDNN_HOME}/lib64
 # For Point and Rect typedefs
 CC_FLAGS	+= -std=c++11
 NVCC_FLAGS  += -std=c++11

--- a/ffcompile.sh
+++ b/ffcompile.sh
@@ -6,13 +6,8 @@ if [ -z "$APP" ]; then echo "Usage: ./ffcompile app_dir"; exit; fi
 
 if [ -z "$FF_HOME" ]; then echo "FF_HOME variable is not defined, aborting compile"; exit; fi
 
-if hash protoc 2>/dev/null; then
-    echo "Use the system protoc"
-    protoc -I=$FF_HOME/src/runtime --cpp_out=$FF_HOME/src/runtime $FF_HOME/src/runtime/strategy.proto
-else
-    echo "Use the FlexFlow protoc"
-    $FF_HOME/protobuf/src/protoc -I=$FF_HOME/src/runtime --cpp_out=$FF_HOME/src/runtime $FF_HOME/src/runtime/strategy.proto
-fi
+echo "Use the FlexFlow protoc"
+$FF_HOME/protobuf/src/protoc -I=$FF_HOME/src/runtime --cpp_out=$FF_HOME/src/runtime $FF_HOME/src/runtime/strategy.proto
 
 cd $APP
 make -j 12


### PR DESCRIPTION
add submodule commands to README
define CUDNN_HOME location of CUDNN
update LD_LIBRARY_PATH after building examples
remove hardcoded directory paths to protobuf in includes and libs all Makefiles
always use the local protoc because if you use the systeem protoc it might have a version conflict with your protobuf sources


Note that examples camera_uno and DLRM do not build.  AlexNet and InceptionV3 build ok.