### PR TITLE
Add an ifdef around MPI_Init

### DIFF
--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -2591,7 +2591,7 @@ int main(int argc, char** argv)
            "GASNet MPI conduit or the Realm MPI network layer "
            "with the Legion-MPI Interop!\n");
   assert(provided == MPI_THREAD_MULTIPLE);
-#else
+#elif defined(FF_ENABLE_NCCL)
   // Perform MPI start-up like normal for most GASNet conduits
   MPI_Init(&argc, &argv);
 #endif


### PR DESCRIPTION
Otherwise with `FF_ENABLE_NCCL=0` and `USE_GASNET=0`, you get the following error message:
```
/home/users/unger/FlexFlow/src/runtime/model.cc: In function 'int main(int, char**)':
/home/users/unger/FlexFlow/src/runtime/model.cc:2602:24: error: 'MPI_Init' was not declared in this scope
   MPI_Init(&argc, &argv);
```