### PR TITLE
[cmake] fix cmake build of flexflow_python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(ExternalProject)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake)
 set(FLEXFLOW_ROOT ${CMAKE_CURRENT_LIST_DIR})
+set(LEGION_ROOT ${CMAKE_CURRENT_LIST_DIR}/legion)
 
 # Set a default build type if none was specified
 set(default_build_type "Debug")
@@ -43,6 +44,9 @@ list(JOIN CUDA_GENCODE " " CUDA_GENCODE_FLAG)
 set(CMAKE_CUDA_FLAGS ${CUDA_GENCODE_FLAG})
 
 # Legion
+if(ENABLE_PYTHON)
+  set(Legion_USE_Python ON CACHE BOOL "enable Legion_USE_Python")
+endif()
 set(Legion_MAX_DIM ${MAX_DIM} CACHE STRING "Maximum number of dimensions")
 set(Legion_USE_CUDA ON CACHE BOOL "enable Legion_USE_CUDA")
 add_subdirectory(legion)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(${project_target} -Wl,--whole-archive flexflow ${Legion_LI
 # create legion_cffi.py
 add_custom_command(TARGET ${project_target} 
   PRE_BUILD	
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/legion_cffi_build.py --runtime-dir ${LEGION_ROOT}/include  --output-dir ${CMAKE_CURRENT_SOURCE_DIR}/flexflow/core
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/legion_cffi_build.py --runtime-dir ${LEGION_ROOT}/runtime  --output-dir ${CMAKE_CURRENT_SOURCE_DIR}/flexflow/core
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Creating legion_cffi.py..."
 )

--- a/python/main.cc
+++ b/python/main.cc
@@ -80,8 +80,6 @@ int main(int argc, char **argv)
   }
 #endif
 
-  Realm::Python::PythonModule::import_python_module("flexflow.core");
-
 #ifdef FF_USE_NCCL
   // Set NCCL environment
   // This needs to be set, otherwise NCCL will try to use group kernel launches,


### PR DESCRIPTION
Removed unnecessary import of flexflow.core. This is required because
Realm::Python::PythonModule::import_python_module is not an
exported symbol of the Realm shared library.

nm legion/lib/librealm.so | grep import_python_module | c++filt
0000000000fefb10 t Realm::Python::PythonModule::import_python_module(char const*)

flexflow.core is explictly imported by user python code.

Testing:
mkdir build
cd build
cmake .. -G Ninja -DCUDA_ARCH="60,70" -DCUDNN_ROOT="${CUDNN_ROOT_DIR}"
ninja flexflow_python
cd ..
./python/flexflow_python examples/python/onnx/mnist_mlp.py -ll:py 1 -ll:gpu 2 -ll:fsize 3072 -ll:zsize 12192 -t 1