### PR TITLE
[ONNX] Added new operator handler handleGlobalAveragePool to the ONNNXModel class

### DIFF
--- a/python/flexflow/onnx/model.py
+++ b/python/flexflow/onnx/model.py
@@ -134,6 +134,12 @@ class ONNXModel(object):
         self.symbol_table[node.output[0]] = output
         logging.debug("ffmodel.pool2d({}, {}, {}, {}, {}, {}, {}, PoolType.POOL_AVG, name={})".format(node.input[0], kernel[0], kernel[1], stride[0], stride[1], padding[0], padding[1], node.name))
 
+    def handleGlobalAveragePool(self,ffmodel,node):
+        input = self.symbol_table[node.input[0]]
+        output = ffmodel.pool2d(input, input.dims[2], input.dims[3], 1, 1, 0, 0, PoolType.POOL_AVG, name=node.name)
+        self.symbol_table[node.output[0]] = output
+        logging.debug("ffmodel.pool2d({}, {}, {}, {}, {}, {}, {}, PoolType.POOL_AVG, name={})".format(node.input[0], input.dims[2], input.dims[3], 1, 1, 0, 0, node.name))
+
     def handleBatchNormalization(self, ffmodel, node):
         input = self.symbol_table[node.input[0]]
         output = ffmodel.batch_norm(input)


### PR DESCRIPTION
New operator handler added to the ONNXModel class. This allows one to import certain models directly such as [RegNet](https://github.com/facebookresearch/ClassyVision/blob/master/classy_vision/models/regnet.py) and ResNet from torchhub.