### PR TITLE
[FFConfig] calling ffconfig.parse_args() is no longer required

### DIFF
--- a/examples/python/keras/candle_uno/candle_uno.py
+++ b/examples/python/keras/candle_uno/candle_uno.py
@@ -100,7 +100,6 @@ def top_level_task():
   params = initialize_parameters()
   args = Struct(**params)
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   ffmodel = FFModel(ffconfig)
   loader = CombinedDataLoader(seed=args.rng_seed)
   print(loader)

--- a/examples/python/native/alexnet.py
+++ b/examples/python/native/alexnet.py
@@ -10,7 +10,6 @@ def top_level_task():
     ffconfig = FFConfig()
     alexnetconfig = NetConfig()
     print(alexnetconfig.dataset_path)
-    ffconfig.parse_args()
     print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" % (
         ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
     ffmodel = FFModel(ffconfig)

--- a/examples/python/native/bert_proxy_native.py
+++ b/examples/python/native/bert_proxy_native.py
@@ -67,7 +67,6 @@ def top_level_task():
     ffconfig = FFConfig()
     netconfig = NetConfig()
 
-    ffconfig.parse_args()
     print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)"
           %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
 

--- a/examples/python/native/cifar10_cnn.py
+++ b/examples/python/native/cifar10_cnn.py
@@ -9,7 +9,6 @@ def top_level_task():
     ffconfig = FFConfig()
     alexnetconfig = NetConfig()
     print(alexnetconfig.dataset_path)
-    ffconfig.parse_args()
     print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" % (
         ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
     ffmodel = FFModel(ffconfig)

--- a/examples/python/native/cifar10_cnn_attach.py
+++ b/examples/python/native/cifar10_cnn_attach.py
@@ -52,7 +52,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/native/cifar10_cnn_concat.py
+++ b/examples/python/native/cifar10_cnn_concat.py
@@ -7,7 +7,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/native/dlrm.py
+++ b/examples/python/native/dlrm.py
@@ -3,7 +3,6 @@ from flexflow.core import *
 def top_level_task():
   ffconfig = FFConfig()
   dlrmconfig = DLRMConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   print(dlrmconfig.dataset_path, dlrmconfig.arch_interaction_op)
   print(dlrmconfig.sparse_feature_size, dlrmconfig.sigmoid_bot, dlrmconfig.sigmoid_top, dlrmconfig.embedding_bag_size, dlrmconfig.loss_threshold)

--- a/examples/python/native/inception.py
+++ b/examples/python/native/inception.py
@@ -67,7 +67,6 @@ def InceptionE(ffmodel, input):
 
 def inception():
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/native/mnist_cnn.py
+++ b/examples/python/native/mnist_cnn.py
@@ -23,7 +23,6 @@ import argparse
 
 def top_level_task():
     ffconfig = FFConfig()
-    ffconfig.parse_args()
     print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" % (
         ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
     ffmodel = FFModel(ffconfig)

--- a/examples/python/native/mnist_mlp.py
+++ b/examples/python/native/mnist_mlp.py
@@ -8,7 +8,6 @@ import argparse
 
 def top_level_task():
     ffconfig = FFConfig()
-    ffconfig.parse_args()
     print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" % (
         ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
     ffmodel = FFModel(ffconfig)

--- a/examples/python/native/mnist_mlp_attach.py
+++ b/examples/python/native/mnist_mlp_attach.py
@@ -54,7 +54,6 @@ def next_batch_label(idx, x_train, input1, ffconfig, ffmodel):
 def top_level_task():
   alexnetconfig = NetConfig()
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/native/multi_head_attention.py
+++ b/examples/python/native/multi_head_attention.py
@@ -12,7 +12,6 @@ def parse_args():
 def attention():
   args = parse_args()
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API: batch_size(%d) GPUs/node(%d) nodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
   batch_size = ffconfig.batch_size

--- a/examples/python/native/print_input.py
+++ b/examples/python/native/print_input.py
@@ -4,7 +4,6 @@ import numpy as np
 
 def top_level_task():
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/native/print_layers.py
+++ b/examples/python/native/print_layers.py
@@ -4,7 +4,6 @@ import numpy as np
 
 def top_level_task():
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/native/resnet.py
+++ b/examples/python/native/resnet.py
@@ -21,7 +21,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/native/split.py
+++ b/examples/python/native/split.py
@@ -7,7 +7,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/native/tensor_attach.py
+++ b/examples/python/native/tensor_attach.py
@@ -5,7 +5,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/onnx/alexnet.py
+++ b/examples/python/onnx/alexnet.py
@@ -9,7 +9,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
   

--- a/examples/python/onnx/cifar10_cnn.py
+++ b/examples/python/onnx/cifar10_cnn.py
@@ -9,7 +9,6 @@ def top_level_task(test_type=1):
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
   

--- a/examples/python/onnx/mnist_mlp.py
+++ b/examples/python/onnx/mnist_mlp.py
@@ -8,7 +8,6 @@ from accuracy import ModelAccuracy
 
 def top_level_task(test_type=1):
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
   

--- a/examples/python/onnx/resnet.py
+++ b/examples/python/onnx/resnet.py
@@ -9,7 +9,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
   

--- a/examples/python/pytorch/cifar10_cnn.py
+++ b/examples/python/pytorch/cifar10_cnn.py
@@ -6,7 +6,6 @@ from flexflow.torch.model import PyTorchModel
 
 def top_level_task():
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/pytorch/mnist_mlp.py
+++ b/examples/python/pytorch/mnist_mlp.py
@@ -7,7 +7,6 @@ from flexflow.torch.model import PyTorchModel
 
 def top_level_task():
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/pytorch/mnist_mlp_torch2.py
+++ b/examples/python/pytorch/mnist_mlp_torch2.py
@@ -24,7 +24,6 @@ class MLP(nn.Module):
 
 def top_level_task():
   ffconfig = FFConfig()
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
 

--- a/examples/python/pytorch/regnet.py
+++ b/examples/python/pytorch/regnet.py
@@ -10,7 +10,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
   

--- a/examples/python/pytorch/resnet.py
+++ b/examples/python/pytorch/resnet.py
@@ -9,7 +9,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
   

--- a/examples/python/pytorch/torch_vision.py
+++ b/examples/python/pytorch/torch_vision.py
@@ -8,7 +8,6 @@ def top_level_task():
   ffconfig = FFConfig()
   alexnetconfig = NetConfig()
   print(alexnetconfig.dataset_path)
-  ffconfig.parse_args()
   print("Python API batchSize(%d) workersPerNodes(%d) numNodes(%d)" %(ffconfig.batch_size, ffconfig.workers_per_node, ffconfig.num_nodes))
   ffmodel = FFModel(ffconfig)
   


### PR DESCRIPTION
The FFConfig constructor now parses args.