### PR TITLE
[python] simplify dataloader code in examples

### DIFF
--- a/examples/python/native/alexnet.py
+++ b/examples/python/native/alexnet.py
@@ -65,22 +65,8 @@ def top_level_task():
     y_train = y_train.astype('int32')
     full_label_np = y_train
 
-    dims_full_input = [num_samples, 3, 229, 229]
-    full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-    dims_full_label = [num_samples, 1]
-    full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-    full_input.attach_numpy_array(ffconfig, full_input_np)
-    full_label.attach_numpy_array(ffconfig, full_label_np)
-
-    dataloader_input = SingleDataLoader(
-        ffmodel, input_tensor, full_input, num_samples, DataType.DT_FLOAT)
-    dataloader_label = SingleDataLoader(
-        ffmodel, label_tensor, full_label, num_samples, DataType.DT_INT32)
-
-    full_input.detach_numpy_array(ffconfig)
-    full_label.detach_numpy_array(ffconfig)
+    dataloader_input = ffmodel.create_data_loader(input_tensor, full_input_np)
+    dataloader_label = ffmodel.create_data_loader(label_tensor, full_label_np)
 
     num_samples = dataloader_input.get_num_samples()
     assert dataloader_input.get_num_samples() == dataloader_label.get_num_samples()

--- a/examples/python/native/cifar10_cnn_concat.py
+++ b/examples/python/native/cifar10_cnn_concat.py
@@ -48,20 +48,8 @@ def top_level_task():
   y_train = y_train.astype('int32')
   full_label_array = y_train
 
-  dims_full_input = [num_samples, 3, 32, 32]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_array)
-  full_label.attach_numpy_array(ffconfig, full_label_array)
-
-  dataloader_input = SingleDataLoader(ffmodel, input_tensor, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label_tensor, full_label, num_samples, DataType.DT_INT32)
-
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input_tensor, full_input_array)
+  dataloader_label = ffmodel.create_data_loader(label_tensor, full_label_array)
 
   num_samples = dataloader_input.get_num_samples()
 

--- a/examples/python/native/inception.py
+++ b/examples/python/native/inception.py
@@ -126,20 +126,8 @@ def inception():
   y_train = y_train.astype('int32')
   full_label_np = y_train
 
-  dims_full_input = [num_samples, 3, 299, 299]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_np)
-  full_label.attach_numpy_array(ffconfig, full_label_np)
-
-  dataloader_input = SingleDataLoader(ffmodel, input, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input, full_input_np)
+  dataloader_label = ffmodel.create_data_loader(label, full_label_np)
 
   num_samples = dataloader_input.get_num_samples()
   assert dataloader_input.get_num_samples() == dataloader_label.get_num_samples()

--- a/examples/python/native/multi_head_attention.py
+++ b/examples/python/native/multi_head_attention.py
@@ -43,14 +43,10 @@ def attention():
   dims = [batch_size * 10, args.seq_length, args.hidden_size]
   np_input = np.zeros(dims, dtype=np.float32)
   np_label = np.zeros(dims, dtype=np.float32)
-  full_input = ffmodel.create_tensor(dims, DataType.DT_FLOAT)
-  full_label = ffmodel.create_tensor(dims, DataType.DT_FLOAT)
-  full_input.attach_numpy_array(ffconfig, np_input)
-  full_label.attach_numpy_array(ffconfig, np_label)
 
-  dl_input = SingleDataLoader(ffmodel, input, full_input, batch_size * 10, DataType.DT_FLOAT)
-  dl_label = SingleDataLoader(ffmodel, label_tensor, full_label, batch_size * 10, DataType.DT_FLOAT)
-  
+  dl_input = ffmodel.create_data_loader(input, np_input)
+  dl_label = ffmodel.create_data_loader(label, np_label)
+
   ffmodel.init_layers()
   epochs = ffconfig.epochs
 

--- a/examples/python/native/resnet.py
+++ b/examples/python/native/resnet.py
@@ -85,20 +85,8 @@ def top_level_task():
   y_train = y_train.astype('int32')
   full_label_np = y_train
 
-  dims_full_input = [num_samples, 3, 229, 229]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_np)
-  full_label.attach_numpy_array(ffconfig, full_label_np)
-
-  dataloader_input = SingleDataLoader(ffmodel, input, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input, full_input_np)
+  dataloader_label = ffmodel.create_data_loader(label, full_label_np)
 
   num_samples = dataloader_input.get_num_samples()
   assert dataloader_input.get_num_samples() == dataloader_label.get_num_samples()

--- a/examples/python/native/split.py
+++ b/examples/python/native/split.py
@@ -51,20 +51,8 @@ def top_level_task():
   #print(full_label_array[0, 0:64])
   print(full_label_array.__array_interface__["strides"])
 
-  dims_full_input = [num_samples, 3, 32, 32]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_array)
-  full_label.attach_numpy_array(ffconfig, full_label_array)
-
-  dataloader_input = SingleDataLoader(ffmodel, input_tensor, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label_tensor, full_label, num_samples, DataType.DT_INT32)
-
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input_tensor, full_input_array)
+  dataloader_label = ffmodel.create_data_loader(label_tensor, full_label_array)
 
   num_samples = dataloader_input.get_num_samples()
 

--- a/examples/python/onnx/alexnet.py
+++ b/examples/python/onnx/alexnet.py
@@ -43,21 +43,9 @@ def top_level_task():
   y_train = y_train.astype('int32')
   full_label_np = y_train
   
-  dims_full_input = [num_samples, 3, 229, 229]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
+  dataloader_input = ffmodel.create_data_loader(input, full_input_np)
+  dataloader_label = ffmodel.create_data_loader(label, full_label_np)
 
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_np)
-  full_label.attach_numpy_array(ffconfig, full_label_np)
-  
-  dataloader_input = SingleDataLoader(ffmodel, input, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-  
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
-  
   num_samples = dataloader_input.get_num_samples()
   assert dataloader_input.get_num_samples() == dataloader_label.get_num_samples()
 

--- a/examples/python/onnx/cifar10_cnn.py
+++ b/examples/python/onnx/cifar10_cnn.py
@@ -39,20 +39,8 @@ def top_level_task(test_type=1):
   y_train = y_train.astype('int32')
   full_label_array = y_train
   
-  dims_full_input = [num_samples, 3, 32, 32]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-  
-  full_input.attach_numpy_array(ffconfig, full_input_array)
-  full_label.attach_numpy_array(ffconfig, full_label_array)
-  
-  dataloader_input = SingleDataLoader(ffmodel, input, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-  
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input, full_input_array)
+  dataloader_label = ffmodel.create_data_loader(label, full_label_array)
   
   num_samples = dataloader_input.get_num_samples()
 

--- a/examples/python/onnx/mnist_mlp.py
+++ b/examples/python/onnx/mnist_mlp.py
@@ -36,20 +36,8 @@ def top_level_task(test_type=1):
   y_train = y_train.astype('int32')
   y_train = np.reshape(y_train, (len(y_train), 1))
 
-  dims_full_input = [num_samples, 784]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, x_train)
-  full_label.attach_numpy_array(ffconfig, y_train)
-
-  dataloader_input = SingleDataLoader(ffmodel, input1, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input1, x_train)
+  dataloader_label = ffmodel.create_data_loader(label, y_train)
 
   ffmodel.init_layers()
 

--- a/examples/python/onnx/resnet.py
+++ b/examples/python/onnx/resnet.py
@@ -44,20 +44,8 @@ def top_level_task():
   y_train = y_train.astype('int32')
   full_label_np = y_train
   
-  dims_full_input = [num_samples, 3, 229, 229]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_np)
-  full_label.attach_numpy_array(ffconfig, full_label_np)
-  
-  dataloader_input = SingleDataLoader(ffmodel, input, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-  
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input, full_input_np)
+  dataloader_label = ffmodel.create_data_loader(label, full_label_np)
   
   num_samples = dataloader_input.get_num_samples()
   assert dataloader_input.get_num_samples() == dataloader_label.get_num_samples()

--- a/examples/python/pytorch/regnet.py
+++ b/examples/python/pytorch/regnet.py
@@ -45,20 +45,8 @@ def top_level_task():
   y_train = y_train.astype('int32')
   full_label_np = y_train
   
-  dims_full_input = [num_samples, 3, 229, 229]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_np)
-  full_label.attach_numpy_array(ffconfig, full_label_np)
-  
-  dataloader_input = SingleDataLoader(ffmodel, input, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-  
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input, full_input_np)
+  dataloader_label = ffmodel.create_data_loader(label, full_label_np)
   
   num_samples = dataloader_input.get_num_samples()
   assert dataloader_input.get_num_samples() == dataloader_label.get_num_samples()

--- a/examples/python/pytorch/resnet.py
+++ b/examples/python/pytorch/resnet.py
@@ -44,20 +44,8 @@ def top_level_task():
   y_train = y_train.astype('int32')
   full_label_np = y_train
   
-  dims_full_input = [num_samples, 3, 229, 229]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_np)
-  full_label.attach_numpy_array(ffconfig, full_label_np)
-  
-  dataloader_input = SingleDataLoader(ffmodel, input, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-  
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input, full_input_np)
+  dataloader_label = ffmodel.create_data_loader(label, full_label_np)
   
   num_samples = dataloader_input.get_num_samples()
   assert dataloader_input.get_num_samples() == dataloader_label.get_num_samples()

--- a/examples/python/pytorch/torch_vision.py
+++ b/examples/python/pytorch/torch_vision.py
@@ -42,20 +42,8 @@ def top_level_task():
   y_train = y_train.astype('int32')
   full_label_np = y_train
   
-  dims_full_input = [num_samples, 3, 229, 229]
-  full_input = ffmodel.create_tensor(dims_full_input, DataType.DT_FLOAT)
-
-  dims_full_label = [num_samples, 1]
-  full_label = ffmodel.create_tensor(dims_full_label, DataType.DT_INT32)
-
-  full_input.attach_numpy_array(ffconfig, full_input_np)
-  full_label.attach_numpy_array(ffconfig, full_label_np)
-  
-  dataloader_input = SingleDataLoader(ffmodel, input_tensor, full_input, num_samples, DataType.DT_FLOAT)
-  dataloader_label = SingleDataLoader(ffmodel, label, full_label, num_samples, DataType.DT_INT32)
-  
-  full_input.detach_numpy_array(ffconfig)
-  full_label.detach_numpy_array(ffconfig)
+  dataloader_input = ffmodel.create_data_loader(input_tensor, full_input_np)
+  dataloader_label = ffmodel.create_data_loader(label, full_label_np)
   
   num_samples = dataloader_input.get_num_samples()
   assert dataloader_input.get_num_samples() == dataloader_label.get_num_samples()


### PR DESCRIPTION
This will ease the burden of migrating to pybind11.