### PR TITLE
[python] add explicit numpy import

### DIFF
--- a/examples/python/keras/candle_uno/candle_uno.py
+++ b/examples/python/keras/candle_uno/candle_uno.py
@@ -8,6 +8,7 @@ from default_utils import finalize_parameters
 from uno_data import CombinedDataLoader, CombinedDataGenerator, DataFeeder
 
 import pandas as pd
+import numpy as np
 
 def initialize_parameters(default_model='uno_default_model.txt'):
   # Build benchmark object

--- a/examples/python/native/alexnet.py
+++ b/examples/python/native/alexnet.py
@@ -4,6 +4,7 @@ from flexflow.keras.datasets import cifar10
 from accuracy import ModelAccuracy
 from PIL import Image
 import argparse
+import numpy as np
 
 
 def top_level_task():

--- a/examples/python/native/bert_proxy_native.py
+++ b/examples/python/native/bert_proxy_native.py
@@ -3,6 +3,7 @@ from flexflow.core import *
 from argparse import ArgumentParser
 
 import sys
+import numpy as np
 
 def parse_args():
     print(sys.argv)

--- a/examples/python/native/inception.py
+++ b/examples/python/native/inception.py
@@ -3,6 +3,7 @@ from flexflow.keras.datasets import cifar10
 
 from accuracy import ModelAccuracy
 from PIL import Image
+import numpy as np
 
 def InceptionA(ffmodel, input, pool_features):
   t1 = ffmodel.conv2d(input, 64, 1, 1, 1, 1, 0, 0)

--- a/examples/python/native/multi_head_attention.py
+++ b/examples/python/native/multi_head_attention.py
@@ -1,5 +1,6 @@
 from flexflow.core import *
 from argparse import ArgumentParser
+import numpy as np
 
 def parse_args():
   parser = ArgumentParser()

--- a/examples/python/native/resnet.py
+++ b/examples/python/native/resnet.py
@@ -2,6 +2,7 @@ from flexflow.core import *
 from flexflow.keras.datasets import cifar10
 
 from PIL import Image
+import numpy as np
 
 def BottleneckBlock(ff, input, out_channels, stride):
   t = ff.conv2d(input, out_channels, 1, 1, 1, 1, 0, 0, ActiMode.AC_MODE_NONE)

--- a/examples/python/onnx/alexnet.py
+++ b/examples/python/onnx/alexnet.py
@@ -4,6 +4,7 @@ from flexflow.onnx.model import ONNXModel
 
 from accuracy import ModelAccuracy
 from PIL import Image
+import numpy as np
 
 def top_level_task():
   ffconfig = FFConfig()

--- a/examples/python/onnx/resnet.py
+++ b/examples/python/onnx/resnet.py
@@ -4,6 +4,7 @@ from flexflow.onnx.model import ONNXModel
 
 from accuracy import ModelAccuracy
 from PIL import Image
+import numpy as np
 
 def top_level_task():
   ffconfig = FFConfig()

--- a/examples/python/pytorch/regnet.py
+++ b/examples/python/pytorch/regnet.py
@@ -2,6 +2,7 @@ from flexflow.core import *
 from flexflow.keras.datasets import cifar10
 from flexflow.torch.model import PyTorchModel
 import os
+import numpy as np
 
 #from accuracy import ModelAccuracy
 from PIL import Image

--- a/examples/python/pytorch/resnet.py
+++ b/examples/python/pytorch/resnet.py
@@ -4,6 +4,7 @@ from flexflow.torch.model import PyTorchModel
 
 #from accuracy import ModelAccuracy
 from PIL import Image
+import numpy as np
 
 def top_level_task():
   ffconfig = FFConfig()

--- a/examples/python/pytorch/torch_vision.py
+++ b/examples/python/pytorch/torch_vision.py
@@ -3,6 +3,7 @@ from flexflow.keras.datasets import cifar10
 from flexflow.torch.model import PyTorchModel
 
 from PIL import Image
+import numpy as np
 
 def top_level_task():
   ffconfig = FFConfig()


### PR DESCRIPTION
Many python files were not import numpy and were instead
picking up numpy from the flexflow.core * import. This will
not work with pybind11 flexflow.core.