### PR TITLE
[Python] extend pybind11 to support keras models

### DIFF
--- a/python/flexflow/keras/models/base_model.py
+++ b/python/flexflow/keras/models/base_model.py
@@ -30,7 +30,7 @@ tracing_id = 100
 class BaseModel(object):
   __slots__ = ['_ffconfig', '_ffmodel', '_ffoptimizer', '_layers', '_nb_layers', \
                '_input_layers', '_input_tensors', '_output_tensor', '_label_tensor', \
-               '_full_input_tensors', '_full_label_tensor', '_num_samples',\
+               '_num_samples',\
                '_input_dataloaders', '_input_dataloaders_dim', \
                '_label_dataloader', '_label_dataloader_dim', \
                '_loss', '_metrics', '_label_type', '__tracing_id']
@@ -47,8 +47,6 @@ class BaseModel(object):
     self._input_tensors = []
     self._output_tensor = 0
     self._label_tensor = 0
-    self._full_input_tensors = []
-    self._full_label_tensor = 0
     self._num_samples = 0
     self._input_dataloaders = []
     self._input_dataloaders_dim = []
@@ -133,8 +131,9 @@ class BaseModel(object):
               loss_weights=None,
               weighted_metrics=None,
               run_eagerly=None,
-              comp_mode=None,
+              comp_mode=ff.CompMode.TRAINING,
               **kwargs):
+
     if loss_weights != None:
       assert 0, "loss_weights is not supported"
     if weighted_metrics != None:
@@ -187,7 +186,8 @@ class BaseModel(object):
     metrics_type = []
     for metric in self._metrics:
       metrics_type.append(metric.type)
-    self._ffmodel.compile(optimizer=self._ffoptimizer.ffhandle, loss_type=self._loss.type, metrics=metrics_type, comp_mode=comp_mode)
+    self._ffmodel.optimizer = optimizer.ffhandle
+    self._ffmodel.compile(loss_type=self._loss.type, metrics=metrics_type, comp_mode=comp_mode)
     self._create_label_tensor()
     fflogger.debug("%s, %s, %s, %s" %( str(self._input_tensors[0]), str(self._output_tensor), str(self._input_tensors[0].ffhandle), str(self._output_tensor.ffhandle)))
 
@@ -326,30 +326,6 @@ class BaseModel(object):
     else:
       assert 0, "unknown optimizer"
 
-  def __create_single_data_loader(self, batch_tensor, full_array):
-    array_shape = full_array.shape
-    num_dim = len(array_shape)
-    print("dataloader type:", full_array.dtype)
-    if (full_array.dtype == "float32"):
-      datatype = ff.DataType.DT_FLOAT
-    elif (full_array.dtype == "int32"):
-      datatype = ff.DataType.DT_INT32
-    else:
-      assert 0, "unsupported datatype"
-
-    if (num_dim == 2):
-      full_tensor = Tensor(self._ffmodel, batch_shape=[self._num_samples, array_shape[1]], name="", dtype=datatype)
-    elif (num_dim == 4):
-      full_tensor = Tensor(self._ffmodel, batch_shape=[self._num_samples, array_shape[1], array_shape[2], array_shape[3]], name="", dtype=datatype)
-    else:
-      assert 0, "unsupported dims"
-
-    full_tensor.ffhandle.attach_numpy_array(self._ffconfig, full_array)
-    dataloader = ff.SingleDataLoader(self._ffmodel, batch_tensor.ffhandle, full_tensor.ffhandle, self._num_samples, datatype)
-    full_tensor.ffhandle.detach_numpy_array(self._ffconfig)
-
-    return full_tensor, dataloader
-
   def _create_data_loaders(self, x_trains, y_train):
     # Todo: check all num_samples, should be the same
     input_shape = x_trains[0].shape
@@ -360,13 +336,11 @@ class BaseModel(object):
 
     idx = 0
     for x_train in x_trains:
-      full_tensor, dataloader = self.__create_single_data_loader(self._input_tensors[idx], x_train)
-      self._full_input_tensors.append(full_tensor)
+      dataloader = self._ffmodel.create_data_loader(self._input_tensors[idx].ffhandle, x_train)
       self._input_dataloaders.append(dataloader)
       self._input_dataloaders_dim.append(len(input_shape))
       idx += 1
-    full_tensor, dataloader = self.__create_single_data_loader(self._label_tensor, y_train)
-    self.__full_label_tensor = full_tensor
+    dataloader = self._ffmodel.create_data_loader(self._label_tensor.ffhandle, y_train)
     self._label_dataloader = dataloader
     self._label_dataloader_dim = len(input_shape)
 


### PR DESCRIPTION
With this change, Keras models now work with pybind11.

Testing:

FF_USE_PYBIND=1 ./python/flexflow_python examples/python/keras/func_cifar10_alexnet.py -ll:py 1 -ll:gpu 2 -ll:fsize 3072 -ll:zsize 12192 --epochs 1