### PR TITLE
[Python] add support for being able to run with native python

### DIFF
--- a/flexflow
+++ b/flexflow
@@ -1,0 +1,1 @@
+python/flexflow

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,24 +5,26 @@ set(project_target flexflow_python)
 
 set(CPU_SRC
   flexflow_c.cc
-  flexflow_dataloader.cc
-  main.cc)
+  flexflow_dataloader.cc)
 
 set(GPU_SRC
   flexflow_dataloader.cu)
 
-cuda_add_executable(${project_target} ${CPU_SRC} ${GPU_SRC})
+cuda_add_library(flexflow_dataloader SHARED ${GPU_SRC} ${CPU_SRC} OPTIONS ${CUDA_GENCODE})
+target_include_directories(flexflow_dataloader PRIVATE ${FLEXFLOW_INCLUDE_DIRS} ${CMAKE_INSTALL_INCLUDEDIR})
+
+cuda_add_executable(${project_target} main.cc)
 set_target_properties(${project_target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
 target_include_directories(${project_target} PRIVATE ${FLEXFLOW_INCLUDE_DIRS} ${CMAKE_INSTALL_INCLUDEDIR})
-target_link_libraries(${project_target} -Wl,--whole-archive flexflow -Wl,--no-whole-archive ${FLEXFLOW_EXT_LIBRARIES})
+target_link_libraries(${project_target} -Wl,--whole-archive flexflow -Wl,--no-whole-archive flexflow_dataloader ${FLEXFLOW_EXT_LIBRARIES})
 
 # create pybind bindings
 if(FF_USE_PYBIND)
   pybind11_add_module(flexflow_bindings
     bindings.cc
   )
-  set_target_properties(flexflow_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-  target_link_libraries(flexflow_bindings PRIVATE flexflow)
+  set_target_properties(flexflow_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/flexflow/core)
+  target_link_libraries(flexflow_bindings PRIVATE flexflow flexflow_dataloader ${FLEXFLOW_EXT_LIBRARIES})
 endif()
 
 # create legion_cffi.py

--- a/python/flexflow/core/__init__.py
+++ b/python/flexflow/core/__init__.py
@@ -17,11 +17,16 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+import atexit
 import os
+import sys
 
 if 'FF_USE_PYBIND' in os.environ:
   print("Using pybind11 flexflow bindings.")
-  from flexflow_bindings import *
+  from flexflow.core.flexflow_bindings import *
+  if not "FLEXFLOW_PYTHON" in os.environ:
+    begin_flexflow_task(sys.argv)
+    atexit.register(finish_flexflow_task)
 else:
   print("Using cffi flexflow bindings.")
   from flexflow.core.flexflow_cbinding import *

--- a/python/main.cc
+++ b/python/main.cc
@@ -85,6 +85,8 @@ int main(int argc, char **argv)
   // which are not compatible with the Realm CUDA hijack.
   setenv("NCCL_LAUNCH_MODE", "PARALLEL", true);
 #endif
+  // Used by python/flexflow/core/__init__.py to detect flexflow_python.
+  setenv("FLEXFLOW_PYTHON", "1", true);
 
   Runtime::set_top_level_task_id(PYTHON_TOP_LEVEL_TASK_ID);
   {


### PR DESCRIPTION
FlexFlow now works with the native python. FlexFlow could now
be run from Jupyter notebooks.

Testing:

FF_USE_PYBIND=1 PYTHONPATH=$(pwd) python ./examples/python/native/alexnet.py  -ll:gpu 2 -ll:fsize 3072 -ll:zsize 12192 --epochs 1