### PR TITLE
[Python] throw an exception when -ll:py is passed to native python

### DIFF
--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -26,6 +26,9 @@ void begin_flexflow_task(std::vector<std::string> args) {
   std::vector<const char *> argvec;
   argvec.push_back("python");
   for (auto &arg: args) {
+    if (arg == "-ll:py") {
+      throw std::invalid_argument("-ll:py is not supported when using native python");
+    }
     argvec.push_back(arg.data());
   }
   int argc = argvec.size();


### PR DESCRIPTION
Fixes: #139

Testing:

% FF_USE_PYBIND=1 PYTHONPATH=$(pwd) python ./examples/python/native/alexnet.py -ll:py 1 -ll:gpu 2 -ll:fsize 3072 -ll:zsize 12192 --epochs 1
Using pybind11 flexflow bindings.
Traceback (most recent call last):
  File "./examples/python/native/alexnet.py", line 1, in <module>
    from flexflow.core import *
  File "/private/home/msb/code/FlexFlow/flexflow/core/__init__.py", line 28, in <module>
    begin_flexflow_task(sys.argv)
ValueError: -ll:py is not supported when using native python