### PR TITLE
Add dominator-based bottleneck detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_policy(SET CMP0074 NEW)
 cmake_policy(SET CMP0077 NEW)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake)
 set(FLEXFLOW_ROOT ${CMAKE_CURRENT_LIST_DIR})
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -UNDEBUG")
 
 # Set a default build type if none was specified
 set(default_build_type "Debug")
@@ -121,7 +122,8 @@ set(FLEXFLOW_HDR
   ${FLEXFLOW_ROOT}/include/optimizer.h
   ${FLEXFLOW_ROOT}/include/simulator.h
   ${FLEXFLOW_ROOT}/include/hash_utils.h
-  ${FLEXFLOW_ROOT}/include/dominators.h)
+  ${FLEXFLOW_ROOT}/include/dominators.h
+  ${FLEXFLOW_ROOT}/include/dot_file.h)
 
 set(FLEXFLOW_SRC
   ${FLEXFLOW_ROOT}/src/mapper/mapper.cc
@@ -228,6 +230,10 @@ if(FF_BUILD_ALEXNET OR FF_BUILD_ALL_EXAMPLES)
   add_subdirectory(examples/cpp/AlexNet)
 endif()
 
+if(FF_BUILD_MLP_UNIFY OR FF_BUILD_ALL_EXAMPLES)
+  add_subdirectory(examples/cpp/MLP_Unify)
+endif()
+
 if(FF_BUILD_INCEPTION OR FF_BUILD_ALL_EXAMPLES)
   add_subdirectory(examples/cpp/InceptionV3)
 endif()
@@ -237,7 +243,7 @@ if(FF_BUILD_CANDLE_UNO)
   add_subdirectory(examples/cpp/candle_uno)
 endif()
 
-if(FF_BUILD_DLRM OR BUILD_ALL_EXAMPLES)
+if(FF_BUILD_DLRM OR FF_BUILD_ALL_EXAMPLES)
   add_subdirectory(examples/cpp/DLRM)
 
   add_executable(generate_dlrm_hetero_strategy src/runtime/dlrm_strategy_hetero.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(FlexFlow)
 
-include(ExternalProject) 
+include(ExternalProject)
 
 # Set policy CMP0074 to eliminate cmake warnings
 cmake_policy(SET CMP0074 NEW)
@@ -25,13 +25,13 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static ones" ON)
 
 # option for using Python
-option(FF_USE_PYTHON "Enable Python" ON)  
+option(FF_USE_PYTHON "Enable Python" ON)
 
 # option for using Python
 option(FF_USE_GASNET "Run FlexFlow with GASNet" ON)
 set(FF_GASNET_CONDUITS udp mpi ibv)
 set(FF_GASNET_CONDUIT "mpi" CACHE STRING "Select Gasnet conduit ${FF_GASNET_CONDUITS}")
-set_property(CACHE FF_GASNET_CONDUIT PROPERTY STRINGS ${FF_GASNET_CONDUITS})  
+set_property(CACHE FF_GASNET_CONDUIT PROPERTY STRINGS ${FF_GASNET_CONDUITS})
 
 # option for cuda arch
 set(FF_CUDA_ARCH "" CACHE STRING "Target CUDA Arch")
@@ -54,7 +54,7 @@ include(zlib)
 
 # CUDA
 include(cuda)
- 
+
 # CUDNN
 include(cudnn)
 
@@ -88,12 +88,12 @@ endif()
 list(APPEND CC_FLAGS
   -std=c++11
   -DMAX_TENSOR_DIM=${FF_MAX_DIM})
-  
+
 list(APPEND NVCC_FLAGS
   -Wno-deprecated-gpu-targets
   -std=c++11
   -DMAX_TENSOR_DIM=${FF_MAX_DIM})
-  
+
 list(APPEND LD_FLAGS
   -lrt
   -ldl
@@ -119,20 +119,29 @@ set(FLEXFLOW_HDR
   ${FLEXFLOW_ROOT}/include/metrics_functions.h
   ${FLEXFLOW_ROOT}/include/model.h
   ${FLEXFLOW_ROOT}/include/optimizer.h
-  ${FLEXFLOW_ROOT}/include/simulator.h)  
+  ${FLEXFLOW_ROOT}/include/simulator.h
+  ${FLEXFLOW_ROOT}/include/hash_utils.h
+  ${FLEXFLOW_ROOT}/include/dominators.h)
 
 set(FLEXFLOW_SRC
   ${FLEXFLOW_ROOT}/src/mapper/mapper.cc
   ${FLEXFLOW_ROOT}/src/ops/embedding.cc
   ${FLEXFLOW_ROOT}/src/ops/group_by.cc
   ${FLEXFLOW_ROOT}/src/ops/aggregate.cc
+  ${FLEXFLOW_ROOT}/src/ops/noop.cc
   ${FLEXFLOW_ROOT}/src/metrics_functions/metrics_functions.cc
   ${FLEXFLOW_ROOT}/src/runtime/initializer.cc
   ${FLEXFLOW_ROOT}/src/runtime/model.cc
   ${FLEXFLOW_ROOT}/src/runtime/optimizer.cc
   ${FLEXFLOW_ROOT}/src/runtime/strategy.cc
   ${FLEXFLOW_ROOT}/src/runtime/simulator.cc
-  ${FLEXFLOW_ROOT}/src/runtime/machine_model.cc)
+  ${FLEXFLOW_ROOT}/src/runtime/machine_model.cc
+  ${FLEXFLOW_ROOT}/src/runtime/graph.cc
+  ${FLEXFLOW_ROOT}/src/runtime/substitution.cc
+  ${FLEXFLOW_ROOT}/src/parallel_ops/combine.cc
+  ${FLEXFLOW_ROOT}/src/parallel_ops/partition.cc
+  ${FLEXFLOW_ROOT}/src/parallel_ops/reduction.cc
+  ${FLEXFLOW_ROOT}/src/parallel_ops/replicate.cc)
 
 set(FLEXFLOW_GPU_SRC
   ${FLEXFLOW_ROOT}/src/loss_functions/loss_functions.cu
@@ -161,10 +170,15 @@ set(FLEXFLOW_GPU_SRC
   ${FLEXFLOW_ROOT}/src/runtime/initializer_kernel.cu
   ${FLEXFLOW_ROOT}/src/runtime/model.cu
   ${FLEXFLOW_ROOT}/src/runtime/optimizer_kernel.cu
-  ${FLEXFLOW_ROOT}/src/runtime/simulator.cu)
+  ${FLEXFLOW_ROOT}/src/runtime/simulator.cu
+  ${FLEXFLOW_ROOT}/src/parallel_ops/combine.cu
+  ${FLEXFLOW_ROOT}/src/parallel_ops/partition.cu
+  ${FLEXFLOW_ROOT}/src/parallel_ops/reduction.cu
+  ${FLEXFLOW_ROOT}/src/parallel_ops/replicate.cu
+  )
 
 set(FLEXFLOW_CPP_DRV_SRC
-  ${FLEXFLOW_ROOT}/src/runtime/cpp_driver.cc)  
+  ${FLEXFLOW_ROOT}/src/runtime/cpp_driver.cc)
 
 #message("FLEXFLOW_INCLUDE_DIRS: ${FLEXFLOW_INCLUDE_DIRS}")
 

--- a/examples/cpp/MLP_Unify/CMakeLists.txt
+++ b/examples/cpp/MLP_Unify/CMakeLists.txt
@@ -1,16 +1,15 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(FlexFlowExample_AlexNet)
-set(project_target alexnet)
+project(FlexFlowExample_MLPUnify)
+set(project_target mlp_unify)
 
 set(CPU_SRC
   ${FLEXFLOW_CPP_DRV_SRC}
-  mlp.cc
-  mlp.h)
+  mlp.cc)
 
-set(GPU_SRC
-  mlp.cu)
+# set(GPU_SRC
+#   mlp.cu)
 
-cuda_add_executable(${project_target} ${CPU_SRC} ${GPU_SRC})
+cuda_add_executable(${project_target} ${CPU_SRC})
 target_include_directories(${project_target} PRIVATE ${FLEXFLOW_INCLUDE_DIRS} ${CMAKE_INSTALL_INCLUDEDIR})
 target_link_libraries(${project_target} -Wl,--whole-archive flexflow -Wl,--no-whole-archive ${FLEXFLOW_EXT_LIBRARIES})

--- a/gdb/pretty_print.py
+++ b/gdb/pretty_print.py
@@ -1,0 +1,25 @@
+import gdb.printing
+
+class NodePrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return f'Node<guid={self.val["guid"]} ptr={self.val["ptr"]}>'
+
+class EdgePrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return f'Edge<src={self.val["srcOp"]["guid"]} dst={self.val["dstOp"]["guid"]}>'
+
+def build_pretty_printer():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter(
+        "flexflow")
+    pp.add_printer('Node', '^Node$', NodePrinter)
+    pp.add_printer('Edge', '^Edge$', EdgePrinter)
+    return pp
+
+gdb.printing.register_pretty_printer(
+        gdb.current_objfile(), build_pretty_printer())

--- a/include/config.h
+++ b/include/config.h
@@ -157,7 +157,6 @@ public:
   float search_alpha;
   bool search_overlap_backward_update;
   CompMode computationMode;
-  std::string export_strategy_task_graph_file;
   //Control parallelizable dimensions
   bool enable_sample_parallel;
   bool enable_parameter_parallel;
@@ -167,6 +166,8 @@ public:
   std::string dataset_path;
   std::string import_strategy_file;
   std::string export_strategy_file;
+  std::string export_strategy_task_graph_file;
+  std::string export_strategy_computation_graph_file;
   // We use MappingTagID as the key since we will pass the tag to the mapper
   std::map<Legion::MappingTagID, ParallelConfig> strategies;
   int machine_model_version;

--- a/include/dominators.h
+++ b/include/dominators.h
@@ -1,0 +1,189 @@
+#ifndef _DOMINATORS_H
+#define _DOMINATORS_H
+
+#include <queue>
+#include <unordered_set>
+#include <unordered_map>
+
+namespace flexflow {
+  namespace dominators {
+    template <typename G, typename N = typename G::Node, typename E = typename G::Edge>
+    struct GraphStructure {
+      using Graph = G;
+      using Node = N;
+      using Edge = E;
+
+      std::unordered_set<N> get_nodes(G const &) const;
+      std::unordered_set<E> get_incoming_edges(G const &, N const &) const;
+      std::unordered_set<E> get_outgoing_edges(G const &, N const &) const;
+      N get_src(G const &, E const &) const;
+      N get_dst(G const &, E const &) const;
+    };
+
+    template <typename BaseStructure, typename G = typename BaseStructure::Node, typename N = typename BaseStructure::Node, typename E = typename BaseStructure::Edge>
+    struct ReverseStructure {
+      std::unordered_set<N> get_nodes(G const &g) const {
+        return this->base.get_nodes(g);
+      }
+
+      std::unordered_set<E> get_incoming_edges(G const &g, N const &n) const {
+        return this->base.get_outgoing_edges(g, n);
+      }
+
+      std::unordered_set<E> get_outgoing_edges(G const &g, N const &n) const {
+        return this->base.get_incoming_edges(g, n);
+      }
+
+      N get_src(G const &g, E const &e) const {
+        return this->base.get_dst(g, e);
+      }
+
+      N get_dst(G const &g, E const &e) const {
+        return this->base.get_src(g, e);
+      }
+
+      BaseStructure base;
+    };
+
+    template <typename G, typename N = typename G::Node, typename E = typename G::Edge, typename Structure = GraphStructure<G, N, E>>
+    void successors(G const &g, N const &node, std::unordered_set<N> *succ) {
+      Structure s;
+      for (auto const &edge : s.get_outgoing_edges(g, node)) {
+        succ->insert(s.get_dst(g, edge));
+      }
+    }
+
+    template <typename G, typename N = typename G::Node, typename E = typename G::Edge, typename Structure = GraphStructure<G, N, E>>
+    void predecessors(G const &g, N const &node, std::unordered_set<N> *pred) {
+      Structure s;
+      for (auto const &edge : s.get_incoming_edges(g, node)) {
+        pred->insert(s.get_src(g, edge));
+      }
+    }
+
+    template <typename G, typename N = typename G::Node, typename E = typename G::Edge, typename Structure = GraphStructure<G, N, E>>
+    void topo_sort(G const &g, std::vector<N> *ordering) {
+      Structure s;
+      std::unordered_map<N, std::unordered_set<N>> predecessors;
+
+      std::queue<N> q;
+      for (auto const &node : s.get_nodes(g)) {
+        predecessors[node];
+        for (auto const &edge : s.get_incoming_edges(g, node)) {
+          predecessors.at(node).insert(s.get_src(g, edge));
+        }
+      }
+
+      for (auto it = predecessors.begin(); it != predecessors.end(); ) {
+        if (it->second.empty()) {
+          q.push(it->first);
+          it = predecessors.erase(it);
+        } else {
+          it++;
+        }
+      }
+
+      std::unordered_set<N> node_successors;
+      while (!q.empty()) {
+        N const &current = q.front();
+
+        ordering->push_back(current);
+
+        node_successors.clear();
+        successors<G, N, E, Structure>(g, current, &node_successors);
+        for (auto const &succ : node_successors) {
+          if (predecessors.find(succ) != predecessors.end()) {
+            predecessors.at(succ).erase(current);
+            if (predecessors.at(succ).empty()) {
+              predecessors.erase(succ);
+              q.push(succ);
+            }
+          }
+        }
+
+        q.pop();
+      }
+    }
+
+    template <typename G, typename N = typename G::Node, typename E = typename G::Edge, typename Structure = GraphStructure<G, N, E>>
+    std::unordered_map<N, std::unordered_set<N>> dominators(G const &g) {
+      Structure s;
+
+      std::vector<N> nodes;
+      topo_sort<G, N, E, Structure>(g, &nodes);
+      std::unordered_map<N, std::unordered_set<N>> dom;
+
+      std::unordered_set<N> pred_part;
+      for (auto const &node : nodes) {
+        pred_part.clear();
+        predecessors<G, N, E, Structure>(g, node, &pred_part);
+        for (auto const &p : pred_part) {
+          if (dom.find(node) == dom.end()) {
+            dom[node] = dom.at(p);
+          } else {
+            auto &node_dom_set = dom.at(node);
+            auto const &p_dom_set = dom.at(p);
+            for (auto it = node_dom_set.begin(); it != node_dom_set.end();) {
+              if (p_dom_set.find(*it) == p_dom_set.end()) {
+                it = node_dom_set.erase(it);
+              } else {
+                it++;
+              }
+            }
+          }
+        }
+        dom[node].insert(node);
+      }
+
+      return dom;
+    }
+
+    template <typename G, typename N = typename G::Node, typename E = typename G::Edge, typename Structure = GraphStructure<G, N, E>>
+    std::unordered_map<N, std::unordered_set<N>> post_dominators(G const &g) {
+      return dominators<G, N, E, ReverseStructure<Structure, G, N, E>>(g);
+    }
+
+    template <typename G, typename N = typename G::Node, typename E = typename G::Edge, typename Structure = GraphStructure<G, N, E>>
+    std::unordered_map<N, N> imm_dominators(G const &g) {
+      std::vector<N> topo;
+      topo_sort<G, N, E, Structure>(g, &topo);
+      std::unordered_map<N, int> topo_rank;
+      for (int i = 0; i < topo.size(); i++) {
+        topo_rank[topo[i]] = i;
+      }
+      std::unordered_map<N, std::unordered_set<N>> dom = dominators<G, N, E, Structure>(g);
+
+      std::unordered_map<N, N> imm_dom;
+      for (auto const &kv : dom) {
+        N const &n = kv.first;
+        std::unordered_set<N> const &n_doms = kv.second;
+
+        // if a node is only dominated by itself, set the dominator to itself to
+        // signify that it has no immediate dominator
+        if (n_doms.size() == 1) {
+          imm_dom[n] = n;
+          continue;
+        }
+
+        N const *n_imm_dom = nullptr;
+        int current_topo_rank = std::numeric_limits<int>::min();
+        for (auto const &d : n_doms) {
+          if (topo_rank.at(d) > current_topo_rank && d != n) {
+            n_imm_dom = &d;
+            current_topo_rank = topo_rank.at(d);
+          }
+        }
+        imm_dom[n] = *n_imm_dom;
+      }
+
+      return imm_dom;
+    }
+
+    template <typename G, typename N = typename G::Node, typename E = typename G::Edge, typename Structure = GraphStructure<G, N, E>>
+    std::unordered_map<N, N> imm_post_dominators(G const &g) {
+      return imm_dominators<G, N, E, ReverseStructure<Structure, G, N, E>>(g);
+    }
+  }
+}
+
+#endif // _DOMINATORS_H

--- a/include/dot_file.h
+++ b/include/dot_file.h
@@ -1,0 +1,107 @@
+#ifndef _DOT_FILE_H
+#define _DOT_FILE_H
+
+#include <fstream>
+#include <sstream>
+
+class RecordFormatter {
+  friend RecordFormatter &operator<<(RecordFormatter &r, std::string const &tok) {
+    r.pieces.push_back(tok);
+
+    return r;
+  }
+
+  friend RecordFormatter &operator<<(RecordFormatter &r, RecordFormatter const &sub_r) {
+    std::ostringstream oss;
+    oss << sub_r;
+    r << oss.str();
+
+    return r;
+  }
+
+  friend RecordFormatter &operator<<(RecordFormatter &r, std::ostringstream &oss) {
+    r << oss.str();
+
+    return r;
+  }
+
+  friend std::ostream &operator<<(std::ostream &s, RecordFormatter const &r) {
+    s << "{ ";
+    for (int i = 0; i < r.pieces.size(); i++) {
+      s << r.pieces[i];
+      if (i + 1 < r.pieces.size()) {
+        s << " | ";
+      }
+    }
+    s << " }";
+
+    return s;
+  }
+private:
+  std::vector<std::string> pieces;
+};
+
+template <typename T>
+class DotFile {
+private:
+  size_t node_id;
+  std::map<T,size_t> node_ids;
+  std::unique_ptr<std::ostream> out;
+  std::string get_node_name(size_t node_id) const {
+    std::ostringstream s;
+    s << "node" << node_id;
+    return s.str();
+  }
+public:
+  DotFile() : node_id(0) {}
+  DotFile(std::string const &filename) : DotFile(std::unique_ptr<std::ostream>(new std::ofstream(filename))) {}
+  DotFile(std::unique_ptr<std::ostream> s)
+    : node_id(0), out(std::move(s))
+  {
+    *out << "digraph taskgraph {";
+  }
+
+  void set_filename(std::string filename) {
+    this->out = std::unique_ptr<std::ostream>(new std::ofstream(filename));
+    *out << "digraph taskgraph {";
+  }
+  void reserve_node(T const &t) {
+    if (this->node_ids.find(t) == this->node_ids.end()) {
+      this->node_ids[t] = this->node_id++;
+    }
+  }
+  void add_node(T const &t, std::map<std::string, std::string> const &params) {
+    this->reserve_node(t);
+    *out << "  " << this->get_node_name(this->node_ids.at(t)) << " [";
+    for (auto it = params.begin(); it != params.end(); ++it)  {
+      *out << it->first << "=" << it->second;
+      if (std::next(it) != params.end()) {
+        *out << ",";
+      }
+    }
+    *out << "];" << std::endl;
+  }
+  void add_record_node(T const &t, RecordFormatter const &rf) {
+    std::ostringstream oss;
+    oss << "\"" << rf << "\"";
+    this->add_node(t,
+      {
+        {"shape", "record"},
+        {"label", oss.str()}
+      }
+    );
+  }
+  void add_edge(T const &src, T const &dst) {
+    this->reserve_node(src);
+    this->reserve_node(dst);
+    auto src_name = this->get_node_name(this->node_ids.at(src));
+    auto dst_name = this->get_node_name(this->node_ids.at(dst));
+    *out << "  " << src_name << " -> " << dst_name << ";" << std::endl;
+  }
+  void close() {
+    *out << "}";
+    out->flush();
+  }
+};
+
+#endif // _DOT_FILE_H

--- a/include/hash_utils.h
+++ b/include/hash_utils.h
@@ -1,0 +1,66 @@
+#ifndef _FLEXFLOW_HASH_UTILS_H
+#define _FLEXFLOW_HASH_UTILS_H
+
+#include <tuple>
+#include <functional>
+#include <type_traits>
+
+// tuple hashing pulled from https://www.variadic.xyz/2018/01/15/hashing-stdpair-and-stdtuple/
+template <class T>
+inline void hash_combine(std::size_t& seed, const T& v)
+{
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+}
+
+namespace std {
+  template<class... TupleArgs>
+  struct hash<std::tuple<TupleArgs...>>
+  {
+  private:
+      //  this is a termination condition
+      //  N == sizeof...(TupleTypes)
+      //
+      template<size_t Idx, typename... TupleTypes>
+      inline typename std::enable_if<Idx == sizeof...(TupleTypes), void>::type
+      hash_combine_tup(size_t& seed, const std::tuple<TupleTypes...>& tup) const
+      {
+      }
+
+      //  this is the computation function
+      //  continues till condition N < sizeof...(TupleTypes) holds
+      //
+      template<size_t Idx, typename... TupleTypes>
+      inline typename std::enable_if <Idx < sizeof...(TupleTypes), void>::type
+      hash_combine_tup(size_t& seed, const std::tuple<TupleTypes...>& tup) const
+      {
+        hash_combine(seed, std::get<Idx>(tup));
+
+          //  on to next element
+          hash_combine_tup<Idx + 1>(seed, tup);
+      }
+
+  public:
+      size_t operator()(const std::tuple<TupleArgs...>& tupleValue) const
+      {
+          size_t seed = 0;
+          //  begin with the first iteration
+          hash_combine_tup<0>(seed, tupleValue);
+          return seed;
+      }
+  };
+
+  template <typename L, typename R>
+  struct hash<std::pair<L, R>> {
+    size_t operator()(const std::pair<L, R> &p) const {
+      size_t seed = 283746;
+
+      hash_combine(seed, p.first);
+      hash_combine(seed, p.second);
+
+      return seed;
+    }
+  };
+}
+
+#endif // _FLEXFLOW_HASH_UTILS_H

--- a/include/model.h
+++ b/include/model.h
@@ -1634,7 +1634,7 @@ class SoftmaxMeta : public OpMeta {
 public:
   SoftmaxMeta(FFHandler handle,
               const Softmax* softmax,
-              const Legion::Domain& input_domain); 
+              const Legion::Domain& input_domain);
   cudnnTensorDescriptor_t inputTensor;
   bool profiling;
   int dim;

--- a/include/simulator.h
+++ b/include/simulator.h
@@ -259,59 +259,6 @@ public:
   std::string get_type_str() const;
 };
 
-template <typename T>
-class DotFile {
-private:
-  size_t node_id;
-  std::map<T,size_t> node_ids;
-  std::unique_ptr<std::ostream> out;
-  std::string get_node_name(size_t node_id) const {
-    std::ostringstream s;
-    s << "node" << node_id;
-    return s.str();
-  }
-public:
-  DotFile() : node_id(0) {}
-  DotFile(std::string const &filename) : DotFile(std::unique_ptr<std::ostream>(new std::ofstream(filename))) {}
-  DotFile(std::unique_ptr<std::ostream> s)
-    : node_id(0), out(std::move(s))
-  {
-    *out << "digraph taskgraph {";
-  }
-
-  void set_filename(std::string filename) {
-    this->out = std::unique_ptr<std::ostream>(new std::ofstream(filename));
-    *out << "digraph taskgraph {";
-  }
-  void reserve_node(T const &t) {
-    if (this->node_ids.find(t) == this->node_ids.end()) {
-      this->node_ids[t] = this->node_id++;
-    }
-  }
-  void add_node(T const &t, std::map<std::string, std::string> const &params) {
-    this->reserve_node(t);
-    *out << "  " << this->get_node_name(this->node_ids.at(t)) << " [";
-    for (auto it = params.begin(); it != params.end(); ++it)  {
-      *out << it->first << "=" << it->second;
-      if (std::next(it) != params.end()) {
-        *out << ",";
-      }
-    }
-    *out << "];" << std::endl;
-  }
-  void add_edge(T const &src, T const &dst) {
-    this->reserve_node(src);
-    this->reserve_node(dst);
-    auto src_name = this->get_node_name(this->node_ids.at(src));
-    auto dst_name = this->get_node_name(this->node_ids.at(dst));
-    *out << "  " << src_name << " -> " << dst_name << ";" << std::endl;
-  }
-  void close() {
-    *out << "}";
-    out->flush();
-  }
-};
-
 class SimTaskCompare {
 public:
   bool operator() (SimTask* lhs, SimTask* rhs) {

--- a/src/parallel_ops/combine.cc
+++ b/src/parallel_ops/combine.cc
@@ -44,6 +44,7 @@ Combine::Combine(
   for (int i = 0; i < numdim; i++) {
     dims[i] = _input->dims[i];
   }
+  assert (combine_degree > 0 && "Must use combine_degree > 0");
   assert(dims[combine_dim].degree % combine_degree == 0);
   dims[combine_dim].degree /= combine_degree;
   TensorBase::update_parallel_ids(numdim, dims);

--- a/src/runtime/graph.cc
+++ b/src/runtime/graph.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 #include "graph.h"
+#include "dominators.h"
 
 const MachineView MachineView::NO_VIEW = MachineView();
 

--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -606,7 +606,7 @@ void Op::create_input_partition_with_dim(FFModel& model)
       input_grad_lps[i] = inputs[i]->part_grad;
     }
     else {
-      // Assert that this input must be activations 
+      // Assert that this input must be activations
       assert(inputs[i]->sync_type == ParameterSyncType::NONE);
       model.create_disjoint_partition(
           inputs[i], (IndexSpaceT<NDIM>)task_is,

--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -2970,6 +2970,7 @@ FFConfig::FFConfig()
   import_strategy_file = "";
   export_strategy_file = "";
   export_strategy_task_graph_file = "";
+  export_strategy_computation_graph_file = "";
   dataset_path = "";
   syntheticInput = false;
   perform_fusion = false;
@@ -3086,6 +3087,10 @@ void FFConfig::parse_args(char **argv, int argc)
     }
     if (!strcmp(argv[i], "--taskgraph")) {
       export_strategy_task_graph_file = std::string(argv[++i]);
+      continue;
+    }
+    if (!strcmp(argv[i], "--compgraph")) {
+      export_strategy_computation_graph_file = std::string(argv[++i]);
       continue;
     }
     if (!strcmp(argv[i], "--machine-model-version")) {

--- a/src/runtime/simulator.cc
+++ b/src/runtime/simulator.cc
@@ -16,6 +16,7 @@
 #include "simulator.h"
 #include "model.h"
 #include "queue"
+#include "dot_file.h"
 
 using namespace Legion;
 

--- a/src/runtime/substitution.cc
+++ b/src/runtime/substitution.cc
@@ -620,7 +620,7 @@ void Graph::export_strategy_computation_graph(std::unordered_map<Node, MachineVi
 }
 
 void Graph::export_strategy_computation_graph(std::unordered_map<Node, MachineView> const &strategy, DotFile<Node> &dot) const {
-  GraphStructure<Graph, Node, Edge> s;
+  GraphStructure<Graph> s;
 
   for (auto const &node : s.get_nodes(*this)) {
     if (strategy.find(node) == strategy.end()) {

--- a/tests/unit/test_dominators.cc
+++ b/tests/unit/test_dominators.cc
@@ -1,0 +1,247 @@
+#include "gtest/gtest.h"
+#include "dominators.h"
+#include "hash_utils.h"
+
+using namespace flexflow::dominators;
+
+struct BasicGraph {
+
+  using Node = int;
+  using Edge = std::pair<Node, Node>;
+
+  std::unordered_set<int> nodes;
+  std::unordered_map<int, std::unordered_set<Edge>> in_edges, out_edges;
+
+  void add_edge(Node const &src, Node const &dst) {
+    nodes.insert(src);
+    nodes.insert(dst);
+    out_edges[src].insert({src, dst});
+    in_edges[dst].insert({src, dst});
+  }
+
+  void add_edge(Edge const &e) {
+    nodes.insert(e.first);
+    nodes.insert(e.second);
+    out_edges[e.first].insert(e);
+    in_edges[e.second].insert(e);
+  }
+
+  void add_node(Node const &n) {
+    nodes.insert(n);
+  }
+
+  void add_nodes(std::vector<Node> const &nodes) {
+    for (auto const &n : nodes) {
+      this->add_node(n);
+    }
+  }
+
+  void add_edges(std::vector<Edge> const &edges) {
+    for (auto const &e : edges) {
+      this->add_edge(e);
+    }
+  }
+};
+
+namespace flexflow::dominators {
+  template <>
+  struct GraphStructure<BasicGraph> {
+    using N = typename BasicGraph::Node;
+    using E = typename BasicGraph::Edge;
+
+    std::unordered_set<N> get_nodes(BasicGraph const &g) const {
+      std::unordered_set<N> nodes(g.nodes);
+      return nodes;
+    }
+
+    std::unordered_set<E> get_incoming_edges(BasicGraph const &g, N const &n) const {
+      std::unordered_set<E> edges;
+      if (g.in_edges.find(n) != g.in_edges.end()) {
+        edges.insert(g.in_edges.at(n).begin(), g.in_edges.at(n).end());
+      }
+      return edges;
+    }
+
+    std::unordered_set<E> get_outgoing_edges(BasicGraph const &g, N const &n) const {
+      std::unordered_set<E> edges;
+      if (g.out_edges.find(n) != g.out_edges.end()) {
+        edges.insert(g.out_edges.at(n).begin(), g.out_edges.at(n).end());
+      }
+      return edges;
+    }
+
+    N get_src(BasicGraph const &g, E const &e) const {
+      return e.first;
+    }
+
+    N get_dst(BasicGraph const &g, E const &e) const {
+      return e.second;
+    }
+  };
+}
+
+TEST(pred_succ_cessors, basic) {
+  BasicGraph g;
+  g.add_node(0);
+  g.add_node(1);
+  g.add_node(2);
+  g.add_node(3);
+  g.add_node(4);
+
+  g.add_edge(0, 2);
+  g.add_edge(1, 2);
+  g.add_edge(2, 3);
+  g.add_edge(2, 4);
+
+  using AnswerMap = std::unordered_map<BasicGraph::Node, std::unordered_set<BasicGraph::Node>>;
+
+  AnswerMap expected_predecessors;
+
+  expected_predecessors = {
+    {0, { }},
+    {1, { }},
+    {2, {0, 1}},
+    {3, {2}},
+    {4, {2}}
+  };
+
+  AnswerMap expected_successors = {
+    {0, {2}},
+    {1, {2}},
+    {2, {3, 4}},
+    {3, { }},
+    {4, { }}
+  };
+
+  std::unordered_set<int> answer;
+  for (auto const &kv : expected_predecessors) {
+    answer.clear();
+    predecessors<BasicGraph>(g, kv.first, &answer);
+    EXPECT_EQ(kv.second, answer) << "^^^ Predecessors for node " << kv.first << std::endl;
+  }
+  for (auto const &kv : expected_successors) {
+    answer.clear();
+    successors<BasicGraph>(g, kv.first, &answer);
+    EXPECT_EQ(kv.second, answer) << "^^^ Successors for node " << kv.first << std::endl;
+  }
+}
+
+TEST(topo_sort, basic) {
+  BasicGraph g;
+  g.add_nodes({0, 1, 2, 3});
+  g.add_edges({
+    {3, 1},
+    {3, 0},
+    {1, 0},
+    {0, 2}
+  });
+
+  std::vector<int> topo_answer = { 3, 1, 0, 2 };
+
+  std::vector<int> topo_result;
+  topo_sort(g, &topo_result);
+  EXPECT_EQ(topo_result, topo_answer);
+}
+
+BasicGraph get_dominator_test_graph() {
+  BasicGraph g;
+  g.add_nodes({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+  g.add_edges({
+    {1, 2},
+    {1, 7},
+    {2, 3},
+    {2, 4},
+    {3, 6},
+    {4, 5},
+    {4, 6},
+    {5, 6},
+    {6, 8},
+    {7, 8},
+    {8, 9},
+    {8, 10},
+    {9, 11},
+    {10, 11}
+  });
+
+  return g;
+}
+
+TEST(dominators, basic) {
+  BasicGraph g = get_dominator_test_graph();
+
+  std::unordered_map<int, std::unordered_set<int>> answer = {
+    {1, {1}},
+    {2, {1, 2}},
+    {3, {1, 2, 3}},
+    {4, {1, 2, 4}},
+    {5, {1, 2, 4, 5}},
+    {6, {1, 2, 6}},
+    {7, {1, 7}},
+    {8, {1, 8}},
+    {9, {1, 8, 9}},
+    {10, {1, 8, 10}},
+    {11, {1, 8, 11}}
+  };
+
+  EXPECT_EQ(dominators(g), answer);
+}
+
+TEST(post_dominators, basic) {
+  BasicGraph g = get_dominator_test_graph();
+
+  std::unordered_map<int, std::unordered_set<int>> answer = {
+    {1, {1, 8, 11}},
+    {2, {2, 6, 8, 11}},
+    {3, {3, 6, 8, 11}},
+    {4, {4, 6, 8, 11}},
+    {5, {5, 6, 8, 11}},
+    {6, {6, 8, 11}},
+    {7, {7, 8, 11}},
+    {8, {8, 11}},
+    {9, {9, 11}},
+    {10, {10, 11}},
+    {11, {11}}
+  };
+
+  EXPECT_EQ(post_dominators(g), answer);
+}
+
+TEST(imm_dominators, basic) {
+  BasicGraph g = get_dominator_test_graph();
+
+  std::unordered_map<int, int> answer = {
+    {1, 1}, // no immediate dominator
+    {2, 1},
+    {3, 2},
+    {4, 2},
+    {5, 4},
+    {6, 2},
+    {7, 1},
+    {8, 1},
+    {9, 8},
+    {10, 8},
+    {11, 8}
+  };
+
+  EXPECT_EQ(imm_dominators(g), answer);
+}
+
+TEST(imm_post_dominators, basic) {
+  BasicGraph g = get_dominator_test_graph();
+
+  std::unordered_map<int, int> answer = {
+    {1, 8},
+    {2, 6},
+    {3, 6},
+    {4, 6},
+    {5, 6},
+    {6, 8},
+    {7, 8},
+    {8, 11},
+    {9, 11},
+    {10, 11},
+    {11, 11} // no immediate post dominator
+  };
+
+  EXPECT_EQ(imm_post_dominators(g), answer);
+}

--- a/tests/unit/test_dot.cc
+++ b/tests/unit/test_dot.cc
@@ -1,0 +1,25 @@
+#include "gtest/gtest.h"
+#include "dot_file.h"
+
+TEST(record_formatters, basic) {
+  RecordFormatter rf, rf2, rf3;
+  std::ostringstream oss;
+  oss << "Wo" << "rld";
+  rf << "Hello" << "World"
+     << (rf2
+       << "Inner" << "World"
+       << (rf3
+         << "Even" << "More" << "Inner World"
+       )
+    )
+    << "Goodbye"
+    << oss
+  ;
+
+  std::ostringstream oss_final;
+  oss_final << rf;
+  EXPECT_EQ(
+    oss_final.str(),
+    "{ Hello | World | { Inner | World | { Even | More | Inner World } } | Goodbye | World }"
+  );
+}


### PR DESCRIPTION
I haven't determined if this actually speeds up the dp algorithm, and the implementation itself is not perfectly efficient (a bunch of unnecessary copies in the implementations of `GraphStructure`), but it at least makes the implementation a lot cleaner and provides an asymptotic speedup to the existing way of finding the bottleneck.

Also added: 
- `gdb/pretty_print.py` is a gdb pretty-printing module that can be built on to make gdb's printing of FlexFlow types much more readable
- the `--compgraph` can be used to output the final unify graph as a dot file