### PR TITLE
[FX] Refactored floor_divide and reshape operators so they reuse existing structure.

### DIFF
--- a/python/flexflow/core/flexflow_type.py
+++ b/python/flexflow/core/flexflow_type.py
@@ -83,6 +83,7 @@ class OpType(Enum):
   GELU = 2085
   PERMUTE = 2086
   SCALAR_MULTIPLY = 2087
+  SCALAR_FLOOR_DIVIDE = 2088
 
 def enum_to_int(enum, enum_item):
   for item in enum:

--- a/python/flexflow/torch/fx.py
+++ b/python/flexflow/torch/fx.py
@@ -205,9 +205,9 @@ def parse_layernorm(op_str, node):
   op_str = op_str + enum_to_str(OpType, OpType.LAYER_NORM) + "\n"
   return op_str
 
-def parse_floordiv(op_str, node):
+def parse_scalarfloordiv(op_str, node):
   assert len(node.inedges) == 2, "wrong number of inputs"
-  op_str = op_str + enum_to_str(OpType, OpType.FLOOR_DIVIDE) + ", "
+  op_str = op_str + enum_to_str(OpType, OpType.SCALAR_FLOOR_DIVIDE) + ", "
   op_str = op_str + str(node.inedges[1]) + "\n"
   return op_str
 
@@ -252,6 +252,11 @@ def parse_scalarmul(op_str,node):
 def parse_mul(op_str,node):
   assert len(node.inedges) == 2, "wrong number of inputs"
   op_str = op_str + enum_to_str(OpType, OpType.MULTIPLY) + "\n"
+  return op_str
+
+def parse_floordiv(op_str,node):
+  assert len(node.inedges) == 2, "wrong number of inputs"
+  op_str = op_str + enum_to_str(OpType, OpType.FLOOR_DIVIDE) + "\n"
   return op_str
 
 def parse_batchmatmul(op_str,node):
@@ -382,8 +387,12 @@ def torch_to_flexflow_str(model):
         op_str = parse_expand(op_str, node)
 
       elif function_name.find('floordiv') >= 0:
-        op_str = parse_inoutedge(op_str, (node.inedges[0],), node.outedges)
-        op_str = parse_floordiv(op_str,node)
+        if type(node.inedges[1]) is float or type(node.inedges[1]) is int:
+            op_str = parse_inoutedge(op_str, (node.inedges[0],), node.outedges)
+            op_str = parse_scalarfloordiv(op_str,node)
+        else:
+            op_str = parse_inoutedge(op_str, (node.inedges[0],), node.outedges)
+            op_str = parse_floordiv(op_str,node)
 
       elif function_name.find('reshape') >= 0:
         op_str = parse_inoutedge(op_str, (node.inedges[0],), node.outedges)

--- a/python/flexflow/torch/fx.py
+++ b/python/flexflow/torch/fx.py
@@ -273,11 +273,15 @@ def parse_permute(op_str,node):
     return op_str
         
 def parse_reshape(op_str,node):
-    assert len(node.inedges) == 2
+    assert len(node.inedges) >= 2
     op_str = op_str + enum_to_str(OpType, OpType.RESHAPE) + ", "
-    for dim in node.inedges[1][:-1]:
+    if len(node.inedges) == 2:
+        input_shape = node.inedges[1]
+    else:
+        input_shape = node.inedges[1:]
+    for dim in input_shape[:-1]:
         op_str = op_str + (str(dim) if type(dim) is int else (str(dim)+":"))+ ", "
-    op_str = op_str + (str(node.inedges[1][-1]) if type(node.inedges[1][-1]) is int else (str(node.inedges[1][-1])+":"))+ "\n"
+    op_str = op_str + (str(input_shape[-1]) if type(input_shape[-1]) is int else (str(input_shape[-1])+":"))+ "\n"
     return op_str 
   
 def parse_inoutedge(op_str, inedges, outedges):

--- a/python/flexflow/torch/model.py
+++ b/python/flexflow/torch/model.py
@@ -128,6 +128,16 @@ class PyTorchModel(object):
         output = ffmodel.scalar_multiply(input=input_tensor, scalar=float(items[4]), name=op_name)
         output = FXTensor(output)
       
+    elif op_type == OpType.SCALAR_FLOOR_DIVIDE:
+        assert len(items) == 5, "wrong format"
+        assert len(self.input_ops_list) == 1, "wrong format"
+        input_tensor = self.tensor_dict[self._get_input_key(op_name, 0)].fftensor
+        if type(input_tensor) is float or type(input_tensor) is int:
+            output = input_tensor // float(items[4])
+        else:
+            output = ffmodel.scalar_floor_divide(input=input_tensor, scalar=float(items[4]), name=op_name)
+        output = FXTensor(output)
+      
       elif op_type == OpType.RELU:
         assert len(items) == 4, "wrong format"
         assert len(self.input_ops_list) == 1, "wrong format"

--- a/python/flexflow/torch/model.py
+++ b/python/flexflow/torch/model.py
@@ -34,7 +34,6 @@ class PyTorchModel(object):
     
   def apply(self, ffmodel, input_tensors):
     output_tensors = []
-    intermediate_values = {}
     input_idx = 0
     for line in self.lines:
       items = line.strip().split(",")
@@ -177,7 +176,7 @@ class PyTorchModel(object):
             try:
                 shape[idx] = int(dim)
             except:
-                shape[idx] = intermediate_values[dim]
+                 shape[idx] = self.tensor_dict[dim+op_name].fftensor
 
         output = ffmodel.reshape(input=input_tensor,shape=shape,name=op_name)
         output = FXTensor(output)
@@ -246,8 +245,6 @@ class PyTorchModel(object):
         assert type(input_tensor) == list or type(input_tensor) == tuple
         idx = int(items[4])
         output = input_tensor[idx]
-        print(items[0]+":")
-        intermediate_values[items[0]+":"] = output        
         output = FXTensor(output)
         
       elif op_type == OpType.GETATTR:


### PR DESCRIPTION
-  Deleted the intermediate_values dictionary added previously as its use was redundant with the existing tensor_dict object.
-  Separated the functionality of floor_divide into floor_divide and scalar_floordivide and made that last one so that it can handle operations between scalars.
- Finally changed the parsing of the reshape operator so that it can handle different forms in which reshape is used in torch.fx, effectively supporting polymorphism.