### PR TITLE
[Op] Deleted FLOOR_DIV for tensors

### DIFF
--- a/include/model.h
+++ b/include/model.h
@@ -312,10 +312,6 @@ public:
 		  const float scalar,
 		  bool inplace = true,
 		  const char *name = NULL);
-  Tensor scalar_floordiv(const Tensor& x,
-		  const float scalar,
-		  bool inplace = true,
-		  const char *name = NULL);
   // Add an activation layer
   Tensor relu(const Tensor& x,
               bool inplace = true,

--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -263,7 +263,6 @@ PYBIND11_MODULE(flexflow_bindings, m) {
       .def("scalar_add", &FFModel::scalar_add, "x"_a, "scalar"_a, "inplace"_a = true, "name"_a = nullptr)
       .def("scalar_sub", &FFModel::scalar_add, "x"_a, "scalar"_a, "inplace"_a = true, "name"_a = nullptr)
       .def("scalar_truediv", &FFModel::scalar_add, "x"_a, "scalar"_a, "inplace"_a = true, "name"_a = nullptr)
-      .def("scalar_floordiv", &FFModel::scalar_add, "x"_a, "scalar"_a, "inplace"_a = true, "name"_a = nullptr)
       // Activations
       .def("relu", &FFModel::relu, "x"_a, "inplace"_a = true, "name"_a = nullptr)
       .def("identity", &FFModel::identity, "x"_a, "name"_a = nullptr)

--- a/python/flexflow/core/flexflow_cbinding.py
+++ b/python/flexflow/core/flexflow_cbinding.py
@@ -261,13 +261,6 @@ class ScalarTrueDiv(Op):
     super(ScalarTrueDiv, self).__init__(handle, idx, name)
 
 # -----------------------------------------------------------------------
-# ScalarFloorDiv
-# -----------------------------------------------------------------------
-class ScalarFloorDiv(Op):
-  def __init__(self, handle, idx=None, name=None):
-    super(ScalarFloorDiv, self).__init__(handle, idx, name)
-
-# -----------------------------------------------------------------------
 # Relu
 # -----------------------------------------------------------------------
 class Relu(Op):
@@ -1390,25 +1383,6 @@ class FFModel(object):
     self.add_layer(OpType.SCALAR_TRUEDIV, name)
     return Tensor(handle, owner_op_type=OpType.SCALAR_TRUEDIV)
 
-  def scalar_floor_divide(self, input, scalar, inplace=True, name=None):
-    """Scalar floor division of a tensor by an scalar.
-             
-    :param input: the input Tensor.
-    :type input: Tensor
-
-    :param input: the scalar
-    :type scalar: float
-             
-    :param name: the name of the layer. Default is None.
-    :type name: string
-
-    :returns:  Tensor -- the output tensor.
-    """
-    c_name = get_c_name(name)
-    handle = ffc.flexflow_model_add_scalar_floordiv(self.handle, input.handle, scalar, inplace, c_name)
-    self.add_layer(OpType.SCALAR_FLOORDIV, name)
-    return Tensor(handle, owner_op_type=OpType.SCALAR_FLOORDIV)
-  
   def gelu(self, input, inplace=True, name=None):
     """Gaussian Error Linear Unit activation function.
              

--- a/python/flexflow/torch/fx.py
+++ b/python/flexflow/torch/fx.py
@@ -272,11 +272,6 @@ def parse_mul(op_str,node):
   op_str = op_str + enum_to_str(OpType, OpType.MULTIPLY) + "\n"
   return op_str
 
-def parse_floordiv(op_str,node):
-  assert len(node.inedges) == 2, "wrong number of inputs"
-  op_str = op_str + enum_to_str(OpType, OpType.FLOOR_DIVIDE) + "\n"
-  return op_str
-
 def parse_batchmatmul(op_str,node):
   assert len(node.inedges) == 2, "wrong number of inputs"
   op_str = op_str + enum_to_str(OpType, OpType.BATCH_MATMUL) + "\n"
@@ -435,8 +430,7 @@ def torch_to_flexflow_str(model):
             op_str = parse_inoutedge(op_str, (node.inedges[0],), node.outedges)
             op_str = parse_scalarfloordiv(op_str,node)
         else:
-            op_str = parse_inoutedge(op_str, (node.inedges[0],), node.outedges)
-            op_str = parse_floordiv(op_str,node)
+            assert 0, "Tensor floor division is not supported."
 
       elif function_name.find('reshape') >= 0:
         op_str = parse_inoutedge(op_str, (node.inedges[0],), node.outedges)

--- a/python/flexflow/torch/model.py
+++ b/python/flexflow/torch/model.py
@@ -135,7 +135,7 @@ class PyTorchModel(object):
         if type(input_tensor) is float or type(input_tensor) is int:
             output = input_tensor // float(items[4])
         else:
-            output = ffmodel.scalar_floor_divide(input=input_tensor, scalar=float(items[4]), name=op_name)
+            assert 0, "Tensor floor division is not supported."
         output = FXTensor(output)
     
       elif op_type == OpType.SCALAR_ADD:

--- a/python/flexflow_c.cc
+++ b/python/flexflow_c.cc
@@ -687,22 +687,6 @@ flexflow_model_add_scalar_truediv(
 }
 
 flexflow_tensor_t
-flexflow_model_add_scalar_floordiv(
-  flexflow_model_t handle_,
-  const flexflow_tensor_t input_,
-  const float scalar,
-  bool inplace,
-  const char *name)
-{
-  FFModel *handle = FFCObjectWrapper::unwrap(handle_);
-  Tensor *input = FFCObjectWrapper::unwrap(input_);
-  Tensor *tensor = new Tensor();
-  *tensor = handle->scalar_floordiv(*input, scalar, inplace, name);
-  DEBUG_PRINT("[Scalar floor division] new Tensor %p, input %p, scalar %f, name %s", tensor, input, scalar,  name);
-  return FFCObjectWrapper::wrap(tensor);
-}
-
-flexflow_tensor_t
 flexflow_model_add_gelu(
   flexflow_model_t handle_,
   const flexflow_tensor_t input_,

--- a/python/flexflow_c.h
+++ b/python/flexflow_c.h
@@ -334,14 +334,6 @@ flexflow_model_add_scalar_truediv(
   const char *name);
 
 flexflow_tensor_t
-flexflow_model_add_scalar_floordiv(
-  flexflow_model_t handle,
-  const flexflow_tensor_t input,
-  const float scalar,
-  bool inplace,
-  const char *name);
-
-flexflow_tensor_t
 flexflow_model_add_gelu(
   flexflow_model_t handle,
   const flexflow_tensor_t input,

--- a/src/ops/element_unary.cu
+++ b/src/ops/element_unary.cu
@@ -53,11 +53,6 @@ Tensor FFModel::scalar_truediv(const Tensor& x,const float scalar ,bool inplace,
   return this->unary(OP_SCALAR_TRUE_DIV, x, inplace, name, scalar);
 }
 
-Tensor FFModel::scalar_floordiv(const Tensor& x,const float scalar ,bool inplace, const char *name)
-{
-  return this->unary(OP_SCALAR_FLOOR_DIV, x, inplace, name, scalar);
-}
-
 Tensor FFModel::relu(const Tensor& x, bool inplace, const char *name)
 {
   return this->unary(OP_RELU, x, inplace, name);
@@ -342,11 +337,6 @@ void elewise_unary_forward_kernel(coord_t volume,
 	out[i] = in[i] / scalar;
 	break;
       }
-      case OP_SCALAR_FLOOR_DIV:
-      {
-	out[i] = floor(in[i] / scalar);
-	break;
-      }
       case OP_GELU:
       {
 	out[i] = in[i] * 0.5 * erfc(-in[i]*M_SQRT1_2);
@@ -502,11 +492,6 @@ void elewise_unary_backward_kernel(coord_t volume,
 	break;
       }
       case OP_SCALAR_TRUE_DIV:
-      {
-	input_grad[i] = output_grad[i]/scalar;
-	break;
-      }
-      case OP_SCALAR_FLOOR_DIV:
       {
 	input_grad[i] = output_grad[i]/scalar;
 	break;


### PR DESCRIPTION
- Deleted FLOOR_DIV operator for tensors as it is not supported on pytorch, there is no easy way to compute it's backwards step gradient.