### PR TITLE
[CMake] fix cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if(FF_USE_AVX2)
   list(APPEND CC_FLAGS
     -DFF_USE_AVX2
     -mavx2)
-endif
+endif()
   
 list(APPEND NVCC_FLAGS
   -Wno-deprecated-gpu-targets


### PR DESCRIPTION
Fixes the following error:

CMake Error at CMakeLists.txt:103:
  Parse error.  Expected "(", got newline with text "

  ".