### PR TITLE
[FX] Added placeholder ops and corrected TRANSPOSE operator

### DIFF
--- a/python/flexflow/torch/model.py
+++ b/python/flexflow/torch/model.py
@@ -180,13 +180,27 @@ class PyTorchModel(object):
         output = ffmodel.identity(input=input_tensor, name=op_name)
         output = FXTensor(output)
       
+      elif op_type == OpType.LAYER_NORM:
+        assert len(items) == 4, "wrong format"
+        assert len(self.input_ops_list) == 1, "wrong format"
+        input_tensor = self.tensor_dict[self._get_input_key(op_name, 0)].fftensor
+        output = ffmodel.identity(input=input_tensor, name=op_name)
+        output = FXTensor(output)
+
+      elif op_type == OpType.EXPAND:
+        assert len(items) >= 4, "wrong format"
+        assert len(self.input_ops_list) == 1, "wrong format"
+        input_tensor = self.tensor_dict[self._get_input_key(op_name, 0)].fftensor
+        output = ffmodel.identity(input=input_tensor, name=op_name)
+        output = FXTensor(output)
+
       elif op_type == OpType.TRANSPOSE:
         assert len(items) >= 6
         assert len(self.input_ops_list) == 1, "wrong format"
         input_tensor = self.tensor_dict[self._get_input_key(op_name, 0)].fftensor
-        perm = list(range(0,len(input_tensor.dims)))
+        perm = list(range(1,len(input_tensor.dims)+1))
         a,b = int(items[4]),int(items[5])
-        perm[a],perm[b] = perm[b],perm[a]
+        perm[a-1],perm[b-1] = perm[b-1],perm[a-1]
         output = ffmodel.transpose(input=input_tensor,perm=perm,name=op_name)
         output = FXTensor(output)
       


### PR DESCRIPTION
- Added placeholder for LAYER_NORM on FX that only executes a IDENTITY operator in its place, this will in turn be changed when the operator is added to FF
- Added placeholder for EXPAND operator placeholder in the same way as for LAYER_NORM.
- Corrected how the transpose operator parameters are used, just a problem with indexing.