### PR TITLE
[Configuration] Change python_data_loader_type to 2

### DIFF
--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -2251,7 +2251,7 @@ struct DefaultConfig {
   const static int simulator_segment_size = 16777216; // 16 MB
   const static int simulator_max_num_segments = 1;
   const static bool enable_control_replication = true;
-  const static int python_data_loader_type = 1;
+  const static int python_data_loader_type = 2;
 };
 
 FFConfig::FFConfig()


### PR DESCRIPTION
Current default configuration is not possible.

https://github.com/flexflow/FlexFlow/commit/735a1161002f95ade7f4762d7e383ff1ece0dc69 switched the default of `enable_control_replication` to true. However https://github.com/flexflow/FlexFlow/blob/master/python/bindings.cc#L235 shows that it's impossible to have both `enable_control_replication` to true and `python_data_loader_type` to 1.