### PR TITLE
Fix bug in Graph::split_horizontal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ option(FF_BUILD_SPLIT_TEST_2 "build split test 2 example" OFF)
 option(FF_BUILD_ALL_EXAMPLES "build all examples. Overrides others" OFF)
 option(FF_BUILD_UNIT_TESTS "build non-operator unit tests" OFF)
 
-if(FF_BUILD_TESTS)
+if(FF_BUILD_UNIT_TESTS)
   set(BUILD_GMOCK OFF)
   add_subdirectory(deps/googletest)
   enable_testing()

--- a/include/flexflow/graph.h
+++ b/include/flexflow/graph.h
@@ -239,7 +239,7 @@ public:
                 int dstIdx);
   void add_node(const Node&);
   void add_edge(const Edge& e);
-  void remove_node(const Node&);
+  void remove_node(const Node&, bool purge_edges = false);
   void remove_edge(const Edge& e, bool remove_node_if_unused = true);
   bool has_edge(const Node& srcOp,
                 const Node& dstOp,

--- a/include/flexflow/graph_structures.h
+++ b/include/flexflow/graph_structures.h
@@ -42,6 +42,125 @@ namespace FlexFlow::PCG::Utils {
     BaseStructure base;
   };
 
+  template <typename NotReversed, typename Reversed>
+  struct UndirectedEdge {
+    union Edge {
+      NotReversed not_reversed;
+      Reversed reversed;
+
+      Edge() {}
+    };
+
+    bool is_reversed;
+    Edge edge;
+
+    UndirectedEdge() {}
+
+    bool operator==(UndirectedEdge<NotReversed, Reversed> const &other) const {
+      if (other.is_reversed != this->is_reversed) {
+        return false;
+      }
+      if (this->is_reversed) {
+        return this->edge.reversed == other.edge.reversed;
+      } else {
+        return this->edge.not_reversed == other.edge.not_reversed;
+      }
+    }
+  };
+
+  template <typename G, typename BaseStructure = GraphStructure<G>>
+  struct UndirectedStructure {
+    using graph_type = typename BaseStructure::graph_type; 
+    using vertex_type = typename BaseStructure::vertex_type;
+    using not_reversed_edge_type = typename BaseStructure::edge_type;
+    using reversed_edge_type = typename ReverseStructure<BaseStructure>::edge_type;
+    using edge_type = UndirectedEdge<not_reversed_edge_type, reversed_edge_type>;
+
+    std::unordered_set<vertex_type> get_nodes(G const &g) const {
+      return this->base.get_nodes(g);
+    }
+
+    std::unordered_set<edge_type> get_incoming_edges(G const &g, vertex_type const &n) const {
+      std::unordered_set<edge_type> incoming;
+      auto base_edges = this->base.get_incoming_edges(g, n);
+      auto reversed_edges = this->reversed.get_incoming_edges(g, n);
+
+      for (auto const &e: base_edges) {
+        edge_type lifted;
+        lifted.is_reversed = false;
+        lifted.edge.not_reversed = e;
+        incoming.insert(lifted);
+      }
+
+      for (auto const &e: reversed_edges) {
+        edge_type lifted;
+        lifted.is_reversed = true;
+        lifted.edge.reversed = e;
+        incoming.insert(lifted);
+      }
+
+      return incoming;
+    }
+
+    std::unordered_set<edge_type> get_outgoing_edges(G const &g, vertex_type const &n) const {
+      std::unordered_set<edge_type> outgoing;
+      auto base_edges = this->base.get_outgoing_edges(g, n);
+      auto reversed_edges = this->reversed.get_outgoing_edges(g, n);
+
+      for (auto const &e: base_edges) {
+        edge_type lifted;
+        lifted.is_reversed = false;
+        lifted.edge.not_reversed = e;
+        outgoing.insert(lifted);
+      }
+
+      for (auto const &e: reversed_edges) {
+        edge_type lifted;
+        lifted.is_reversed = true;
+        lifted.edge.reversed = e;
+        outgoing.insert(lifted);
+      }
+
+      return outgoing;
+    }
+
+    vertex_type get_src(G const &g, edge_type const &e) const {
+      if (e.is_reversed) {
+        return this->reversed.get_src(g, e.edge.reversed);
+      } else {
+        return this->base.get_src(g, e.edge.not_reversed);
+      }
+    }
+
+    vertex_type get_dst(G const &g, edge_type const &e) const {
+      if (e.is_reversed) {
+        return this->reversed.get_dst(g, e.edge.reversed);
+      } else {
+        return this->base.get_dst(g, e.edge.not_reversed);
+      }
+    }
+
+    void set_src(G const &g, edge_type &e, vertex_type const &n) const {
+      if (e.is_reversed) {
+        this->reversed.set_src(g, e.edge.reversed, n);
+      } else {
+        this->base.set_src(g, e.edge.not_reversed, n);
+      }
+    }
+
+    void set_dst(G const &g, edge_type &e, vertex_type const &n) const {
+      if (e.is_reversed) {
+        this->reversed.set_src(g, e.edge.reversed, n);
+      } else {
+        this->base.set_src(g, e.edge.not_reversed, n);
+      }
+    }
+
+    BaseStructure base;
+    ReverseStructure<BaseStructure> reversed;
+  };
+
+
   template <
     typename G,
     typename Structure = GraphStructure<G>
@@ -118,5 +237,24 @@ namespace FlexFlow::PCG::Utils {
     BaseStructure base;
   };
 }
+
+namespace std {
+  using FlexFlow::PCG::Utils::UndirectedEdge;
+
+  template <typename NotReversed, typename Reversed>
+  struct hash<UndirectedEdge<NotReversed, Reversed>> {
+    size_t operator()(UndirectedEdge<NotReversed, Reversed> const &e) const {
+      size_t result;
+      result = std::hash<bool>()(e.is_reversed);
+      if (e.is_reversed) {
+        hash_combine(result, e.edge.reversed);
+      } else {
+        hash_combine(result, e.edge.not_reversed);
+      }
+      return result;
+    }
+  };
+}
+
 
 #endif // _GRAPH_STRUCTURES_H

--- a/tests/unit/test_disjoint_set.cc
+++ b/tests/unit/test_disjoint_set.cc
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "disjoint_set.h"
+#include "flexflow/utils/disjoint_set.h"
 
 TEST(disjoint_set, basic) {
   int ctr = 0;

--- a/tests/unit/test_dominators.cc
+++ b/tests/unit/test_dominators.cc
@@ -1,11 +1,11 @@
 #include "gtest/gtest.h"
-#include "dominators.h"
-#include "hash_utils.h"
-#include "graph.h"
+#include "flexflow/dominators.h"
+#include "flexflow/utils/hash_utils.h"
+#include "flexflow/basic_graph.h"
 
-using namespace flexflow::graph;
+using namespace FlexFlow::PCG::Utils;
 
-namespace flexflow::graph {
+namespace FlexFlow::PCG::Utils {
   template <>
   struct invalid_node<::BasicGraph<int>, GraphStructure<::BasicGraph<int>>> {
     int operator()() const {
@@ -327,4 +327,81 @@ TEST(leaves, basic) {
   auto result = leaves(g);
 
   EXPECT_EQ(result, answer);
+}
+
+TEST(descendants, directed) {
+  BasicGraph<int> g(
+    {1, 2, 3, 4, 5, 6},
+    {
+      {1, 2},
+      {2, 3},
+      {2, 4},
+      {3, 5},
+      {4, 5}
+    }
+  );
+
+  std::unordered_set<int> answer { 2, 3, 4, 5 };
+
+  auto result = descendants(g, 2);
+
+  EXPECT_EQ(result, answer);
+}
+
+TEST(descendants, undirected) {
+  BasicGraph<int> g(
+    {1, 2, 3, 4, 5, 6},
+    {
+      {1, 2},
+      {2, 3},
+      {2, 4},
+      {3, 5},
+      {4, 5}
+    }
+  );
+
+  std::unordered_set<int> answer { 1, 2, 3, 4, 5 };
+
+  auto result = descendants<decltype(g), UndirectedStructure<decltype(g)>>(g, 2);
+
+  EXPECT_EQ(result, answer);
+}
+
+TEST(weakly_connected_components, basic) {
+  BasicGraph<int> g(
+    {1, 2, 3, 4, 5, 6},
+    {
+      {1, 3},
+      {2, 3}, 
+      {4, 5},
+      {5, 4}
+    }
+  );
+
+
+  std::unordered_set<int> component1 { 1, 2, 3 };
+  std::unordered_set<int> component2 { 4, 5 };
+  std::unordered_set<int> component3 { 6 };
+  auto result = weakly_connected_components(g);
+
+  EXPECT_EQ(result.size(), 3);
+  bool component1_found = false;
+  bool component2_found = false;
+  bool component3_found = false;
+  for (std::unordered_set<int> &component : result) {
+    if (component.size() == component1.size()) {
+      component1_found = true;
+      EXPECT_EQ(component, component1);
+    } else if (component.size() == component2.size()) {
+      component2_found = true;
+      EXPECT_EQ(component, component2);
+    } else if (component.size() == component3.size()) {
+      component3_found = true;
+      EXPECT_EQ(component, component3);
+    }
+  }
+
+  EXPECT_TRUE(component1_found);
+  EXPECT_TRUE(component2_found);
+  EXPECT_TRUE(component3_found);
 }

--- a/tests/unit/test_dot.cc
+++ b/tests/unit/test_dot.cc
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "dot_file.h"
+#include "flexflow/utils/dot_file.h"
 
 TEST(record_formatters, basic) {
   RecordFormatter rf, rf2, rf3;

--- a/tests/unit/test_machine_view.cc
+++ b/tests/unit/test_machine_view.cc
@@ -1,8 +1,9 @@
 #include "gtest/gtest.h"
-#include "config.h"
-#include "machine_view.h"
+#include "flexflow/config.h"
+#include "flexflow/machine_view.h"
 
 using namespace Legion;
+using namespace FlexFlow;
 
 TEST(machine_view_get_domain, basic) {
   MachineView mv;  

--- a/tests/unit/test_parallel_config.cc
+++ b/tests/unit/test_parallel_config.cc
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
-#include "config.h"
-#include "model.h"
+#include "flexflow/config.h"
+#include "flexflow/model.h"
+
+using namespace FlexFlow;
 
 TEST(change_data_parallel_dimensionality, basic_reduce) {
   ParallelConfig pc = get_basic_data_parallel_config(8, 4);

--- a/tests/unit/test_random_utils.cc
+++ b/tests/unit/test_random_utils.cc
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "random_utils.h"
+#include "flexflow/utils/random_utils.h"
 
 TEST(select_random, basic) {
   std::vector<int> values { 1, 2, 3, 4 };


### PR DESCRIPTION
Fix a bug in `Graph::split_horizontal` where the resulting subgraphs could have multiple parents. 

Example: 
```
digraph taskgraph {
  node1 [label="1"];
  node2 [label="2"];
  node3 [label="3"];
  node4 [label="4"];
  node5 [label="5"];
  node6 [label="6"];
  node7 [label="7"];

  node1 -> node2;
  node1 -> node6;
  node2 -> node3;
  node2 -> node4;
  node3 -> node5;
  node4 -> node5;
  node6 -> node7;
  node7 -> node5;
}
```
when split horizontally could result in `first_graph` being
```
digraph taskgraph {
  node1 [label="1"];
  node2 [label="2"];
  node4 [label="4"];
  node5 [label="5"];

  node1 -> node2;
  node2 -> node4;
  node4 -> node5;
}
```
and `second_graph` being
```
digraph taskgraph {
  node1 [label="1"];
  node3 [label="3"];
  node5 [label="5"];
  node6 [label="6"];
  node7 [label="7"];

  node1 -> node6;
  node3 -> node5;
  node6 -> node7;
  node7 -> node5;
}
```

This PR fixes the algorithm by performing `split_horizontal` as follows: 
1. Remove the source and sink nodes
2. Calculate the weakly connected components
3. Select one to use for `first_graph`, and union the rest. Add source and sink nodes back in to each
4. Create `first_graph` and `second_graph` as subgraphs formed from these two sets