### PR TITLE
[Torch] String IR fixes; better AttributeNode erroring

### DIFF
--- a/examples/python/pytorch/mt5/mt5_ff.py
+++ b/examples/python/pytorch/mt5/mt5_ff.py
@@ -93,11 +93,12 @@ def top_level_task():
     encoder_seq_length = ids.shape[1]
     decoder_seq_length = y_ids.shape[1]
     seq_length = (encoder_seq_length, decoder_seq_length)
+    input_names = ["input_ids", "attention_mask", "decoder_input_ids"]
 
     print("Tracing the model...")
     hf_model = PyTorchModel(
-        model, is_hf_model=True, batch_size=ffconfig.batch_size,
-        seq_length=seq_length,
+        model, is_hf_model=True, input_names=input_names,
+        batch_size=batch_size, seq_length=seq_length,
     )
     output_tensors = hf_model.torch_to_ff(ffmodel, input_tensors, verbose=True)
     ffoptimizer = SGDOptimizer(ffmodel, lr=0.01)


### PR DESCRIPTION
6c4065d3ebe18f26282b337846a7c09c82c02fb8
- Running HuggingFace mT5 using FlexFlow must use the `torch_to_ff()` code path (and not the `torch_to_file()` + `file_to_ff()` code path that uses an intermediate string representation). This is because mT5 has attribute tensors, which we must fetch from the model itself. Writing those tensor values to a string is unwieldy.
- As a result, I previously did not test the `torch_to_file()` + `file_to_ff()` code path. This commit resolves some extraneous errors on that code path and ends with a useful `RuntimeError()` indicating that attributes are not supported for that code path.
- It also factors out the delimiters used in the string representation as global variables to avoid discrepancies in functions that `split()` on the delimiter.
- It also makes `input_names` argument to `PyTorchModel()` to accommodate different HuggingFace models (e.g. BERT).