### PR TITLE
Implement input node duplication

### DIFF
--- a/include/flexflow/dominators.h
+++ b/include/flexflow/dominators.h
@@ -35,6 +35,12 @@ namespace FlexFlow::PCG::Utils {
   }
 
   template <typename G, typename Structure = GraphStructure<G>>
+  std::unordered_set<typename Structure::edge_type> outgoing_edges(G const &g, typename Structure::vertex_type const &n) {
+    Structure s;
+    return s.get_outgoing_edges(g, n);
+  }
+
+  template <typename G, typename Structure = GraphStructure<G>>
   std::pair<typename Structure::vertex_type, typename Structure::vertex_type> get_basic_edge(G const &g, typename Structure::edge_type const &e) {
     Structure s;
 

--- a/include/flexflow/graph.h
+++ b/include/flexflow/graph.h
@@ -255,6 +255,14 @@ public:
   void contract_out_node(const Node&);
   float optimal_cost() const;
   std::unordered_map<Node, MachineView> optimal_views() const;
+  void remove_input_nodes();
+  void duplicate_input_node(Node const &);
+  void duplicate_input_nodes();
+  Node clone_node(Node const &);
+  std::pair<Node, std::unordered_set<Node>> deduplicate_input_node(Node const &);
+  std::unordered_map<Node, Node> deduplicate_input_nodes();
+  Node declone_node(Node const &);
+
 
 
   size_t hash(void) const;

--- a/include/flexflow/graph_structures.h
+++ b/include/flexflow/graph_structures.h
@@ -188,6 +188,10 @@ namespace FlexFlow::PCG::Utils {
     std::unordered_set<edge_type> get_incoming_edges(G const &g, vertex_type const &n) const {
       Invalid invalid;
 
+      if (n == invalid()) {
+        return {};
+      }
+
       std::unordered_set<edge_type> edges = this->base.get_incoming_edges(g, n);
       if (edges.empty()) {
         edge_type e;

--- a/include/flexflow/model.h
+++ b/include/flexflow/model.h
@@ -463,22 +463,26 @@ struct Node {
   inline bool operator==(const Node& b) const {
     if (guid != b.guid) return false;
     if (ptr != b.ptr) return false;
+    if (original_guid != b.original_guid) return false;
     return true;
   }
   inline bool operator!=(const Node& b) const {
     if (guid != b.guid) return true;
     if (ptr != b.ptr) return true;
+    if (original_guid != b.original_guid) return false;
     return false;
   }
   inline bool operator<(const Node& b) const {
     if (guid != b.guid) return guid < b.guid;
     if (ptr != b.ptr) return ptr < b.ptr;
+    if (original_guid != b.original_guid) return false;
     return false;
   }
   Node& operator=(const Node& n)
   {
     guid = n.guid;
     ptr = n.ptr;
+    original_guid = n.original_guid;
     return *this;
   }
   std::string op_to_string(const Op* ptr) const;
@@ -494,6 +498,8 @@ struct Node {
   static const Node INVALID_NODE;
   size_t guid;
   const Op* ptr;
+
+  tl::optional<size_t> original_guid = tl::nullopt;
 };
 
 }; // namespace PCG


### PR DESCRIPTION
(graphs specified via mermaid)

```mermaid
graph TD;
    Input1 --> A;
    Input1 --> B;
    Input2 --> A;
    Input2 --> B;
    A --> C;
    B --> C;
```

How to split the above graph, considering that `Input` nodes can be arbitrarily replicated since they have no cost. We can either 
1. Duplicate `Input1` and `Input2`, allowing a parallel split to be applied but losing the similarity between the inputs of `A` and `B`, which could be used for e.g. operator fusion 
    ```mermaid
    graph TD;
        Input1 --> A;
        Input2 --> A;
        Input1' --> B;
        Input2' --> B;
        A --> C;
        B --> C;
    ```
    Operator fusion example:
    ```mermaid
    graph TD; 
        Input1 --> Conv1;
        Weight1 --> Conv1;
        Input1 --> Conv2;
        Weight2 --> Conv2;
    ```
    could be converted to 
    ```mermaid
    graph TD;
        Conv["Conv (1 & 2)"];
        Input1 --> Conv;
        Weight1 --> Concat;
        Weight2 --> Concat;
        Concat --> Conv;
    ```
2. Not duplicate `Input1` and `Input2`, in which case we can't split the graph but could potentially apply operator fusion

We choose to do the former and expand input nodes because the operator fusion cases that are problematic are only an issue for the very first layer and generally do not appear in most models, and doing it this way closely mirrors how the runtime eventually implements things