### PR TITLE
[NoOp] Refactor NoOp to have better cache hash function

### DIFF
--- a/include/flexflow/model.h
+++ b/include/flexflow/model.h
@@ -854,7 +854,7 @@ public:
   Legion::Future current_metrics;
   // Cached operators: key: operator hash, value: operator pointer
   std::unordered_map<size_t, NoOp*> cached_noop_ops;
-  std::unordered_map<size_t, NoOp*> cached_input_ops;
+  std::unordered_map<ParallelTensorShape, NoOp*> cached_input_ops;
   std::unordered_map<size_t, Cast*> cached_cast_ops;
   std::unordered_map<size_t, Concat*> cached_concat_ops;
   std::unordered_map<std::pair<ParallelTensorShape, Conv2DParams>, Conv2D*> cached_conv2d_ops;

--- a/include/flexflow/operator_params.h
+++ b/include/flexflow/operator_params.h
@@ -1,19 +1,38 @@
+/**
+ * @file operator_params.h
+ * @brief Common Header for Operator Parameters
+ *
+ * @copyright Copyright 2022 Stanford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef _OPERATOR_PARAMS_H
 #define _OPERATOR_PARAMS_H
 
 #include "mpark/variant.hpp"
+
 #include "flexflow/ops/conv_2d.h"
 #include "flexflow/ops/linear.h"
+#include "flexflow/ops/noop.h"
 
 namespace mp = mpark;
 
 namespace FlexFlow {
 
-using OperatorParameters = mp::variant<
-Conv2DParams,
-LinearParams
->;
 
-}; // namespace FlexFlow
+using OperatorParameters = mp::variant<Conv2DParams, LinearParams, NoOpParams>;
 
-#endif // _OPERATOR_PARAMS_H
+};  // namespace FlexFlow
+
+#endif  // _OPERATOR_PARAMS_H

--- a/include/flexflow/ops/noop.h
+++ b/include/flexflow/ops/noop.h
@@ -1,3 +1,22 @@
+/**
+ * @file noop.h
+ * @brief NoOp Operator
+ *
+ * @copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef _FLEXFLOW_NOOP_H
 #define _FLEXFLOW_NOOP_H
 
@@ -5,34 +24,74 @@
 
 namespace FlexFlow {
 
+/**
+ * @brief The characteristic of NoOp, combined by a vector of inputs and the
+ * op_type.
+ *
+ * This is actually not a "parameter", but some kind of characteristic to
+ * distinguish different NoOp objects. To maintain the naming consistency, name
+ * this class as "Params".
+ */
+class NoOpParams {
+ public:
+  std::vector<ParallelTensor> inputs;
+  OperatorType op_type;
+
+  NoOpParams(const std::vector<ParallelTensor> _inputs,
+             const OperatorType _op_type)
+      : inputs(_inputs), op_type{_op_type} {}
+
+  friend bool operator==(NoOpParams const& lhs, NoOpParams const& rhs) {
+    if (lhs.inputs == rhs.inputs && lhs.op_type == rhs.op_type) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
 class NoOp : public Op {
-public:
-  NoOp(FFModel& model,
-       OperatorType type,
-       const ParallelTensor output,
-       const char* name = NULL);
-  NoOp(FFModel& model,
-       OperatorType type,
-       size_t input_tensor_guid,
-       const ParallelTensor output,
-       const char* name = NULL);
+ public:
+  // This is necessary to support get_or_create_node in model.h
+  using Params = NoOpParams;
+
+  NoOp(FFModel& model, OperatorType type, const ParallelTensor output,
+       const char* name = nullptr);
+  NoOp(FFModel& model, OperatorType type, size_t input_tensor_guid,
+       const ParallelTensor output, const char* name = nullptr);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;
-  void print_layer(const FFModel& model) override {assert(0);}
-  bool measure_operator_cost(Simulator* sim,
-                             const MachineView& pc,
+  void print_layer(const FFModel& model) override { assert(0); }
+  bool measure_operator_cost(Simulator* sim, const MachineView& pc,
                              CostMetrics& cost_metrics) const override;
-  static OpMeta* init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
-                           Legion::Context ctx, Legion::Runtime *runtime);
-  
-  size_t get_params_hash() const override;
+  static OpMeta* init_task(const Legion::Task* task,
+                           const std::vector<Legion::PhysicalRegion>& regions,
+                           Legion::Context ctx, Legion::Runtime* runtime);
+
+  NoOpParams get_params() const;
   tl::optional<RecordFormatter> as_dot() const override;
-public:
+
+ public:
   size_t input_tensor_guid;
 };
 
-}; // namespace FlexFlow
+};  // namespace FlexFlow
 
-#endif // _FLEXFLOW_NOOP_H
+namespace std {
+
+template <>
+struct hash<FlexFlow::NoOpParams> {
+  size_t operator()(FlexFlow::NoOpParams const& params) const {
+    size_t hash = 0;
+    for (const auto& tensor : params.inputs) {
+      hash_combine(hash, tensor);
+    }
+    hash_combine(hash, params.op_type);
+    return hash;
+  }
+};
+
+};  // namespace std
+
+#endif  // _FLEXFLOW_NOOP_H

--- a/src/ops/noop.cc
+++ b/src/ops/noop.cc
@@ -169,9 +169,10 @@ Node FFModel::get_or_create_noop_node(const ParallelTensor input) {
 
 Node FFModel::get_or_create_input_node(
     const ParallelTensorShape& output_shape) {
-  size_t hash = std::hash<ParallelTensorShape>{}(output_shape);
-  NoOp* input = NULL;
-  const auto& it = cached_input_ops.find(hash);
+  NoOp* input = nullptr;
+
+  // For OP_INPUT, output_shape is what distinguishes them.
+  const auto& it = cached_input_ops.find(output_shape);
   if (it != cached_input_ops.end()) {
     input = it->second;
   } else {
@@ -179,6 +180,7 @@ Node FFModel::get_or_create_input_node(
     tensor->parallel_tensor_guid = parallel_tensor_global_guid++;
     tensor->data_type = DT_FLOAT;  // TODO FIXME @lockshaw
     tensor->num_dims = output_shape.num_dims;
+
     int parallel_idx = 0;
     for (int i = 0; i < output_shape.num_dims; i++) {
       tensor->dims[i].size = output_shape.dims[i].size;
@@ -190,6 +192,7 @@ Node FFModel::get_or_create_input_node(
         tensor->dims[i].parallel_idx = -1;
       }
     }
+
     assert(tensor->check_valid());
     input = new NoOp(*this, OP_INPUT, tensor, NULL);
   }

--- a/src/runtime/simulator.cc
+++ b/src/runtime/simulator.cc
@@ -1,4 +1,8 @@
-/* Copyright 2020 Stanford
+/**
+ * @file simulator.cc
+ * @brief 
+ * 
+ * @copyright Copyright 2020 Stanford
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -482,12 +486,32 @@ ParallelConfig Op::view_to_pc(MachineView const &view) const {
   return config;
 }
 
+/**
+ * @brief Try to get the operator's parameters.
+ *
+ * @note This function can be improved to avoid forcibly casting the const Op*
+ * to a specific operator pointer type. Ideally, this should be implemented as a
+ * dynamic dispatch on the Op base class (i.e. define a get_params() virtual
+ * function on Op class).
+ *
+ * To avoid the forcibly casting from a const Op pointer to a specific operator
+ * pointer. Developers may use
+ * `dynamic_cast<SpecificOp*>((const_cast<Op*>(op)))->get_params()` as the
+ * return value. For example:
+ * `dynamic_cast<NoOp*>((const_cast<Op*>(op)))->get_params()`. However, it is
+ * too long and not obvious.
+ *
+ * @param op A const pointer to Op
+ * @return tl::optional<OperatorParameters> An option to hold the parameters.
+ */
 tl::optional<OperatorParameters> get_op_parameters(const Op* op) {
   switch (op->op_type) {
     case OP_LINEAR:
       return ((Linear*)op)->get_params();
     case OP_CONV2D:
       return ((Conv2D*)op)->get_params();
+    case OP_NOOP:
+      return ((NoOp*)op)->get_params();
     default:
       return tl::nullopt;
   }


### PR DESCRIPTION
This pull request is to change the unordered_map key of cached_input_op and cached_noop_op in model.h. This is to avoid the hash collision possibly caused by the original hash key "size_t".

The current changes have modified the key type of cached_input_op. There is some trouble to update cached_noop_op due to template specialization of the std::hash of NoOpParams. But it might be good to start to review the change.

@lockshaw does the new hash key look good? In other words, do we only distinguish input_op by its ParallelTensorShape? It basically means that if we have two inputs that have the same shape, they will use the same input_op from the cache. From my understanding, this is incorrect? Not sure if this caused any trouble in the past? I can see that this may actually cause hash collision.

Thanks