### PR TITLE
Refactor cache key for Concat, ElementBinary

### DIFF
--- a/include/flexflow/model.h
+++ b/include/flexflow/model.h
@@ -887,7 +887,7 @@ public:
   std::unordered_map<std::pair<ParallelTensorShapes, ConcatParams>, Concat*> cached_concat_ops;
   std::unordered_map<std::pair<ParallelTensorShape, Conv2DParams>, Conv2D*> cached_conv2d_ops;
   std::unordered_map<size_t, Dropout*> cached_dropout_ops;
-  std::unordered_map<size_t, ElementBinary*> cached_element_binary_ops;
+  std::unordered_map<std::pair<ParallelTensorShapes, ElementBinaryParams>, ElementBinary*> cached_element_binary_ops;
   std::unordered_map<size_t, ElementUnary*> cached_element_unary_ops;
   std::unordered_map<size_t, Embedding*> cached_embedding_ops;
   std::unordered_map<std::pair<ParallelTensorShape, LinearParams>, Linear*> cached_linear_ops;

--- a/include/flexflow/model.h
+++ b/include/flexflow/model.h
@@ -672,7 +672,7 @@ public:
     >(this->cached_ops);
     const auto &it = cache.find(key);
     if (it != cache.end()) {
-      op = (T*)it->second;
+      op = it->second;
     } else {
       op = new T(*this, params, input);
       cache[key] = op;

--- a/include/flexflow/operator_params.h
+++ b/include/flexflow/operator_params.h
@@ -5,6 +5,7 @@
 #include "flexflow/ops/conv_2d.h"
 #include "flexflow/ops/linear.h"
 #include "flexflow/ops/concat.h"
+#include "flexflow/ops/element_binary.h"
 
 namespace mp = mpark;
 
@@ -13,7 +14,8 @@ namespace FlexFlow {
 using OperatorParameters = mp::variant<
 Conv2DParams,
 LinearParams,
-ConcatParams
+ConcatParams,
+ElementBinaryParams
 >;
 
 }; // namespace FlexFlow

--- a/include/flexflow/operator_params.h
+++ b/include/flexflow/operator_params.h
@@ -4,6 +4,7 @@
 #include "mpark/variant.hpp"
 #include "flexflow/ops/conv_2d.h"
 #include "flexflow/ops/linear.h"
+#include "flexflow/ops/concat.h"
 
 namespace mp = mpark;
 
@@ -11,7 +12,8 @@ namespace FlexFlow {
 
 using OperatorParameters = mp::variant<
 Conv2DParams,
-LinearParams
+LinearParams,
+ConcatParams
 >;
 
 }; // namespace FlexFlow

--- a/include/flexflow/ops/concat.h
+++ b/include/flexflow/ops/concat.h
@@ -10,16 +10,10 @@
 
 namespace FlexFlow {
 
-struct ConcatInputShape {
-  std::vector<ParallelTensorShape> shapes;
-};
-
-bool operator==(const ConcatInputShape&, const ConcatInputShape&);
-
 struct ConcatParams {
   int axis;
   
-  bool is_valid(const ConcatInputShape &) const;
+  bool is_valid(const std::vector<ParallelTensorShape> &) const;
 };
 
 bool operator==(const ConcatParams&, const ConcatParams&);
@@ -34,8 +28,7 @@ public:
 class Concat : public Op {
 public:
   using Params = ConcatParams;
-  using InputType = std::vector<ParallelTensor>;
-  using InputShapeType = ConcatInputShape;
+  using Input = std::vector<ParallelTensor>;
 
   Concat(FFModel& model,
          int n,
@@ -45,6 +38,7 @@ public:
   Concat(FFModel& model,
          const ConcatParams& params,
          const std::vector<ParallelTensor>& inputs,
+         bool allocate_weights,
          const char* name);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
@@ -110,11 +104,6 @@ namespace std {
   template <>
   struct hash<FlexFlow::ConcatParams> {
     size_t operator()(const FlexFlow::ConcatParams&) const;
-  };
-  
-  template <>
-  struct hash<FlexFlow::ConcatInputShape> {
-    size_t operator()(const FlexFlow::ConcatInputShape&) const;
   };
 }; // namespace std
 

--- a/include/flexflow/ops/concat.h
+++ b/include/flexflow/ops/concat.h
@@ -38,8 +38,8 @@ public:
   Concat(FFModel& model,
          const ConcatParams& params,
          const std::vector<ParallelTensor>& inputs,
-         bool allocate_weights,
-         const char* name);
+         const char* name=NULL,
+         bool allocate_weights=false);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;

--- a/include/flexflow/ops/concat.h
+++ b/include/flexflow/ops/concat.h
@@ -38,8 +38,7 @@ public:
   Concat(FFModel& model,
          const ConcatParams& params,
          const std::vector<ParallelTensor>& inputs,
-         const char* name=NULL,
-         bool allocate_weights=false);
+         const char* name = nullptr);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;

--- a/include/flexflow/ops/concat.h
+++ b/include/flexflow/ops/concat.h
@@ -10,11 +10,19 @@
 
 namespace FlexFlow {
 
+struct ConcatInputShape {
+  std::vector<ParallelTensorShape> shapes;
+};
+
+bool operator==(const ConcatInputShape&, const ConcatInputShape&);
+
 struct ConcatParams {
   int axis;
-
-  friend bool operator==(const ConcatParams&, const ConcatParams&);
+  
+  bool is_valid(const ConcatInputShape &) const;
 };
+
+bool operator==(const ConcatParams&, const ConcatParams&);
 
 class ConcatMeta : public OpMeta {
 public:
@@ -26,6 +34,8 @@ public:
 class Concat : public Op {
 public:
   using Params = ConcatParams;
+  using InputType = std::vector<ParallelTensor>;
+  using InputShapeType = ConcatInputShape;
 
   Concat(FFModel& model,
          int n,
@@ -100,6 +110,11 @@ namespace std {
   template <>
   struct hash<FlexFlow::ConcatParams> {
     size_t operator()(const FlexFlow::ConcatParams&) const;
+  };
+  
+  template <>
+  struct hash<FlexFlow::ConcatInputShape> {
+    size_t operator()(const FlexFlow::ConcatInputShape&) const;
   };
 }; // namespace std
 

--- a/include/flexflow/ops/concat.h
+++ b/include/flexflow/ops/concat.h
@@ -1,9 +1,20 @@
 #ifndef _FLEXFLOW_CONCAT_H
 #define _FLEXFLOW_CONCAT_H
 
-#include "flexflow/model.h"
+#include "flexflow/fftype.h"
+#include "flexflow/op_meta.h"
+#include "flexflow/operator.h"
+#include "flexflow/node.h"
+#include "flexflow/device.h"
+#include "flexflow/layer.h"
 
 namespace FlexFlow {
+
+struct ConcatParams {
+  int axis;
+
+  friend bool operator==(const ConcatParams&, const ConcatParams&);
+};
 
 class ConcatMeta : public OpMeta {
 public:
@@ -14,10 +25,16 @@ public:
 
 class Concat : public Op {
 public:
+  using Params = ConcatParams;
+
   Concat(FFModel& model,
          int n,
          const ParallelTensor* inputs,
          int axis,
+         const char* name);
+  Concat(FFModel& model,
+         const ConcatParams& params,
+         const std::vector<ParallelTensor>& inputs,
          const char* name);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
@@ -70,11 +87,20 @@ public:
                              const MachineView& pc,
                              CostMetrics& cost_metrics) const override;
 
-  size_t get_params_hash() const override;
+  // size_t get_params_hash() const override;
+
+  Params get_params() const;
 public:
   int legion_axis;
 };
 
 }; // namespace FlexFlow
+
+namespace std {
+  template <>
+  struct hash<FlexFlow::ConcatParams> {
+    size_t operator()(const FlexFlow::ConcatParams&) const;
+  };
+}; // namespace std
 
 #endif // _FLEXFLOW_CONCAT_H

--- a/include/flexflow/ops/concat.h
+++ b/include/flexflow/ops/concat.h
@@ -91,8 +91,6 @@ public:
                              const MachineView& pc,
                              CostMetrics& cost_metrics) const override;
 
-  // size_t get_params_hash() const override;
-
   Params get_params() const;
 public:
   int legion_axis;

--- a/include/flexflow/ops/conv_2d.h
+++ b/include/flexflow/ops/conv_2d.h
@@ -116,8 +116,7 @@ public:
 class Conv2D : public Op {
 public:
   using Params = Conv2DParams;
-  using InputType = ParallelTensor;
-  using InputShapeType = ParallelTensorShape;
+  using Input = ParallelTensor;
 
   Conv2D(FFModel& model,
          const LayerID& layer_guid,
@@ -138,6 +137,7 @@ public:
   Conv2D(FFModel& model,
          Conv2DParams const &params,
          ParallelTensor input,
+         bool allocate_weights,
          const char* name);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;

--- a/include/flexflow/ops/conv_2d.h
+++ b/include/flexflow/ops/conv_2d.h
@@ -116,6 +116,8 @@ public:
 class Conv2D : public Op {
 public:
   using Params = Conv2DParams;
+  using InputType = ParallelTensor;
+  using InputShapeType = ParallelTensorShape;
 
   Conv2D(FFModel& model,
          const LayerID& layer_guid,
@@ -136,7 +138,6 @@ public:
   Conv2D(FFModel& model,
          Conv2DParams const &params,
          ParallelTensor input,
-         bool allocate_weights,
          const char* name);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;

--- a/include/flexflow/ops/conv_2d.h
+++ b/include/flexflow/ops/conv_2d.h
@@ -208,10 +208,6 @@ public:
   static void construct_mappings(std::vector<ParallelDimMappingRecord> &, bool use_bias);
   static void construct_weight_mappings(std::vector<ParallelDimMappingRecord> &, bool use_bias);
 
-  std::unordered_map<std::pair<ParallelTensorShape, Conv2DParams>, Conv2D*> &get_cache(FFModel &ff) const;
-
-  // size_t get_params_hash() const override;
-
   Conv2DParams get_params() const;
 
   tl::optional<RecordFormatter> as_dot() const override;

--- a/include/flexflow/ops/conv_2d.h
+++ b/include/flexflow/ops/conv_2d.h
@@ -137,8 +137,8 @@ public:
   Conv2D(FFModel& model,
          Conv2DParams const &params,
          ParallelTensor input,
-         bool allocate_weights,
-         const char* name);
+         const char* name=NULL,
+         bool allocate_weights=false);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;

--- a/include/flexflow/ops/conv_2d.h
+++ b/include/flexflow/ops/conv_2d.h
@@ -137,8 +137,8 @@ public:
   Conv2D(FFModel& model,
          Conv2DParams const &params,
          ParallelTensor input,
-         const char* name=NULL,
-         bool allocate_weights=false);
+         const char* name = nullptr,
+         bool allocate_weights = false);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;

--- a/include/flexflow/ops/element_binary.h
+++ b/include/flexflow/ops/element_binary.h
@@ -96,7 +96,6 @@ public:
                                       const float* in2_ptr,
                                       float* in1_grad_ptr,
                                       float* in2_grad_ptr);
-  // size_t get_params_hash() const override;
   bool measure_operator_cost(Simulator* sim,
                             const MachineView& pc,
                             CostMetrics& cost_metrics) const override;

--- a/include/flexflow/ops/element_binary.h
+++ b/include/flexflow/ops/element_binary.h
@@ -49,8 +49,8 @@ public:
   ElementBinary(FFModel& model,
                 const Params& params,
                 const Input& inputs,
-                bool inplace_a,
-                const char* name);
+                const char* name=NULL,
+                bool inplace_a=false);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;

--- a/include/flexflow/ops/element_binary.h
+++ b/include/flexflow/ops/element_binary.h
@@ -49,8 +49,8 @@ public:
   ElementBinary(FFModel& model,
                 const Params& params,
                 const Input& inputs,
-                const char* name=NULL,
-                bool inplace_a=false);
+                const char* name = nullptr,
+                bool inplace_a = false);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;

--- a/include/flexflow/ops/element_binary.h
+++ b/include/flexflow/ops/element_binary.h
@@ -38,8 +38,7 @@ public:
 class ElementBinary : public Op {
 public:
   using Params = ElementBinaryParams;
-  using InputType = std::pair<ParallelTensor, ParallelTensor>;
-  using InputShapeType = std::pair<ParallelTensorShape, ParallelTensorShape>;
+  using Input = std::pair<ParallelTensor, ParallelTensor>;
 
   ElementBinary(FFModel& model,
                 OperatorType type,
@@ -49,7 +48,8 @@ public:
                 const char* name);
   ElementBinary(FFModel& model,
                 const Params& params,
-                const InputType& inputs,
+                const Input& inputs,
+                bool inplace_a,
                 const char* name);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;

--- a/include/flexflow/ops/element_binary.h
+++ b/include/flexflow/ops/element_binary.h
@@ -13,8 +13,10 @@ namespace FlexFlow {
 struct ElementBinaryParams {
   OperatorType type;
 
-  friend bool operator==(const ElementBinaryParams &, const ElementBinaryParams &);
+  bool is_valid(const std::pair<ParallelTensorShape, ParallelTensorShape>&) const;
 };
+
+bool operator==(const ElementBinaryParams &, const ElementBinaryParams &);
 
 class ElementBinaryMeta : public OpMeta {
 public:
@@ -36,6 +38,8 @@ public:
 class ElementBinary : public Op {
 public:
   using Params = ElementBinaryParams;
+  using InputType = std::pair<ParallelTensor, ParallelTensor>;
+  using InputShapeType = std::pair<ParallelTensorShape, ParallelTensorShape>;
 
   ElementBinary(FFModel& model,
                 OperatorType type,
@@ -45,7 +49,7 @@ public:
                 const char* name);
   ElementBinary(FFModel& model,
                 const Params& params,
-                const std::vector<ParallelTensor>& inputs,
+                const InputType& inputs,
                 const char* name);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;

--- a/include/flexflow/ops/element_binary.h
+++ b/include/flexflow/ops/element_binary.h
@@ -1,9 +1,20 @@
 #ifndef _FLEXFLOW_ELEMENT_BINARY_H
 #define _FLEXFLOW_ELEMENT_BINARY_H
 
-#include "flexflow/model.h"
+#include "flexflow/fftype.h"
+#include "flexflow/op_meta.h"
+#include "flexflow/operator.h"
+#include "flexflow/node.h"
+#include "flexflow/device.h"
+#include "flexflow/layer.h"
 
 namespace FlexFlow {
+
+struct ElementBinaryParams {
+  OperatorType type;
+
+  friend bool operator==(const ElementBinaryParams &, const ElementBinaryParams &);
+};
 
 class ElementBinaryMeta : public OpMeta {
 public:
@@ -24,11 +35,17 @@ public:
 
 class ElementBinary : public Op {
 public:
+  using Params = ElementBinaryParams;
+
   ElementBinary(FFModel& model,
                 OperatorType type,
                 const ParallelTensor x,
                 const ParallelTensor y,
                 bool inplace_a,
+                const char* name);
+  ElementBinary(FFModel& model,
+                const Params& params,
+                const std::vector<ParallelTensor>& inputs,
                 const char* name);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
@@ -75,15 +92,23 @@ public:
                                       const float* in2_ptr,
                                       float* in1_grad_ptr,
                                       float* in2_grad_ptr);
-  size_t get_params_hash() const override;
+  // size_t get_params_hash() const override;
   bool measure_operator_cost(Simulator* sim,
                             const MachineView& pc,
                             CostMetrics& cost_metrics) const override;
+  Params get_params() const;
 public:
   bool inplace_a, has_same_operands;
   bool broadcast_input1, broadcast_input2;
 };
 
 }; // namespace FlexFlow
+
+namespace std {
+  template<>
+  struct hash<FlexFlow::ElementBinaryParams> {
+    size_t operator()(const FlexFlow::ElementBinaryParams&) const;
+  };
+}; // namespace std
 
 #endif // _FLEXFFLOW_ELEMENT_BINARY_H

--- a/include/flexflow/ops/linear.h
+++ b/include/flexflow/ops/linear.h
@@ -99,8 +99,8 @@ public:
   Linear(FFModel& model, 
          LinearParams const &params,
          ParallelTensor input,
-         bool allocate_weights,
-         const char *name);
+         const char *name=NULL,
+         bool allocate_weights=false);
 
 
 

--- a/include/flexflow/ops/linear.h
+++ b/include/flexflow/ops/linear.h
@@ -99,8 +99,8 @@ public:
   Linear(FFModel& model, 
          LinearParams const &params,
          ParallelTensor input,
-         const char *name=NULL,
-         bool allocate_weights=false);
+         const char *name = nullptr,
+         bool allocate_weights = false);
 
 
 

--- a/include/flexflow/ops/linear.h
+++ b/include/flexflow/ops/linear.h
@@ -81,8 +81,7 @@ private:
 class Linear : public Op {
 public:
   using Params = LinearParams;
-  using InputType = ParallelTensor;
-  using InputShapeType = ParallelTensorShape;
+  using Input = ParallelTensor;
 
   Linear(FFModel& model,
          const LayerID& layer_guid,
@@ -100,6 +99,7 @@ public:
   Linear(FFModel& model, 
          LinearParams const &params,
          ParallelTensor input,
+         bool allocate_weights,
          const char *name);
 
 

--- a/include/flexflow/ops/linear.h
+++ b/include/flexflow/ops/linear.h
@@ -81,6 +81,8 @@ private:
 class Linear : public Op {
 public:
   using Params = LinearParams;
+  using InputType = ParallelTensor;
+  using InputShapeType = ParallelTensorShape;
 
   Linear(FFModel& model,
          const LayerID& layer_guid,
@@ -98,7 +100,6 @@ public:
   Linear(FFModel& model, 
          LinearParams const &params,
          ParallelTensor input,
-         bool allocate_weights,
          const char *name);
 
 

--- a/include/flexflow/parallel_tensor.h
+++ b/include/flexflow/parallel_tensor.h
@@ -99,12 +99,18 @@ struct ParallelTensorShape {
 
 std::ostream& operator<<(std::ostream&, ParallelTensorShape const &);
 
+typedef std::vector<ParallelTensorShape> ParallelTensorShapes;
+
 }; // namespace FlexFlow
 
 namespace std {
   template <>
   struct hash<FlexFlow::ParallelTensorShape> {
     size_t operator()(FlexFlow::ParallelTensorShape const &) const;
+  };
+  template <>
+  struct hash<FlexFlow::ParallelTensorShapes> {
+    size_t operator()(FlexFlow::ParallelTensorShapes const &) const;
   };
 }
 

--- a/include/flexflow/parallel_tensor.h
+++ b/include/flexflow/parallel_tensor.h
@@ -99,18 +99,12 @@ struct ParallelTensorShape {
 
 std::ostream& operator<<(std::ostream&, ParallelTensorShape const &);
 
-typedef std::vector<ParallelTensorShape> ParallelTensorShapes;
-
 }; // namespace FlexFlow
 
 namespace std {
   template <>
   struct hash<FlexFlow::ParallelTensorShape> {
     size_t operator()(FlexFlow::ParallelTensorShape const &) const;
-  };
-  template <>
-  struct hash<FlexFlow::ParallelTensorShapes> {
-    size_t operator()(FlexFlow::ParallelTensorShapes const &) const;
   };
 }
 

--- a/include/flexflow/utils/hash_utils.h
+++ b/include/flexflow/utils/hash_utils.h
@@ -61,6 +61,18 @@ namespace std {
       return seed;
     }
   };
+
+  template <typename T>
+  struct hash<std::vector<T>> {
+    size_t operator()(const std::vector<T> &vec) const {
+      size_t seed = 0;
+      hash_combine(seed, vec.size());
+      for (const auto& ele : vec) {
+        hash_combine(seed, ele);
+      }
+      return seed;
+    }
+  };
 }
 
 #endif // _FLEXFLOW_HASH_UTILS_H

--- a/include/flexflow/utils/tuple.h
+++ b/include/flexflow/utils/tuple.h
@@ -1,0 +1,60 @@
+#ifndef _FLEXFLOW_UTILS_TUPLE_H
+#define _FLEXFLOW_UTILS_TUPLE_H
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+// Adapted from https://github.com/bitwizeshift/BackportCpp/blob/4f33a7f9b219f169e60d8ed2fd5731a3a23288e4/include/bpstd/tuple.hpp
+
+namespace FlexFlow {
+
+namespace TupleUtils {
+
+template <typename T, std::size_t Index, typename...Types>
+struct index_of_impl;
+
+template <typename T, std::size_t Index, typename Type0, typename...Types>
+struct index_of_impl<T, Index, Type0, Types...>
+: index_of_impl<T, Index + 1, Types...>{};
+
+template <typename T, std::size_t Index, typename...Types>
+struct index_of_impl<T, Index, T, Types...>
+: std::integral_constant<std::size_t, Index>{};
+
+template <typename T, typename...Types>
+struct index_of : index_of_impl<T,0,Types...>{};
+
+}; // namespace TupleUtils
+
+template <typename T, typename... Types>
+T& get(std::tuple<Types...>& t)
+  noexcept
+{
+  return std::get<TupleUtils::index_of<T,Types...>::value>(t);
+}
+
+template <typename T, typename... Types>
+T&& get(std::tuple<Types...>&& t)
+  noexcept
+{
+  return move(std::get<TupleUtils::index_of<T,Types...>::value>(t));
+}
+
+template <typename T, typename... Types>
+const T& get(const std::tuple<Types...>& t)
+  noexcept
+{
+  return std::get<TupleUtils::index_of<T,Types...>::value>(t);
+}
+
+template <typename T, typename... Types>
+const T&& get(const std::tuple<Types...>&& t)
+  noexcept
+{
+  return move(std::get<TupleUtils::index_of<T,Types...>::value>(t));
+}
+
+}; // namespace FlexFlow
+
+#endif // _FLEXFLOW_UTILS_TUPLE_H

--- a/src/ops/concat.cc
+++ b/src/ops/concat.cc
@@ -43,6 +43,7 @@ bool operator==(const ConcatParams &lhs, const ConcatParams &rhs) {
 }
 
 bool ConcatParams::is_valid(const std::vector<ParallelTensorShape> &) const {
+  // TODO: more check on the input shape
   return true;
 }
 
@@ -133,8 +134,7 @@ Concat::Concat(FFModel& model,
 Concat::Concat(FFModel& model,
                const ConcatParams& params,
                const std::vector<ParallelTensor>& inputs,
-               const char* name,
-               bool allocate_weights)
+               const char* name)
   : Concat(model, inputs.size(), inputs.data(), params.axis, name) {}
 
 void Concat::init_meta(ConcatMeta *m) const

--- a/src/ops/concat.cc
+++ b/src/ops/concat.cc
@@ -38,11 +38,6 @@ using Legion::Predicate;
 using PCG::Node;
 
 
-template <>
-std::unordered_map<std::pair<std::vector<ParallelTensorShape>, ConcatParams>, Concat*> &FFModel::get_cache() {
-  return this->cached_concat_ops;
-}
-
 bool operator==(const ConcatParams &lhs, const ConcatParams &rhs) {
   return lhs.axis == rhs.axis;
 }

--- a/src/ops/concat.cc
+++ b/src/ops/concat.cc
@@ -138,8 +138,8 @@ Concat::Concat(FFModel& model,
 Concat::Concat(FFModel& model,
                const ConcatParams& params,
                const std::vector<ParallelTensor>& inputs,
-               bool allocate_weights,
-               const char* name)
+               const char* name,
+               bool allocate_weights)
   : Concat(model, inputs.size(), inputs.data(), params.axis, name) {}
 
 void Concat::init_meta(ConcatMeta *m) const

--- a/src/ops/conv_2d.cc
+++ b/src/ops/conv_2d.cc
@@ -162,11 +162,6 @@ Conv2DParams Conv2D::get_params() const {
 using PCG::Node;
 
 
-template <>
-std::unordered_map<std::pair<ParallelTensorShape, Conv2DParams>, Conv2D*> &FFModel::get_cache() {
-  return this->cached_conv2d_ops;
-}
-
 bool operator==(Conv2DParams const &lhs, Conv2DParams const &rhs) {
   return lhs.layer_guid == rhs.layer_guid && 
       lhs.kernel_h == rhs.kernel_h &&

--- a/src/ops/conv_2d.cc
+++ b/src/ops/conv_2d.cc
@@ -373,8 +373,8 @@ Conv2D::Conv2D(FFModel& model,
 Conv2D::Conv2D(FFModel& model,
                Conv2DParams const &params,
                ParallelTensor const input,
-               bool allocate_weights,
-               const char* name) 
+               const char* name,
+               bool allocate_weights)
   : Conv2D(model,
            params.layer_guid,
            input,

--- a/src/ops/conv_2d.cc
+++ b/src/ops/conv_2d.cc
@@ -373,7 +373,6 @@ Conv2D::Conv2D(FFModel& model,
 Conv2D::Conv2D(FFModel& model,
                Conv2DParams const &params,
                ParallelTensor const input,
-               bool allocate_weights,
                const char* name) 
   : Conv2D(model,
            params.layer_guid,
@@ -388,7 +387,7 @@ Conv2D::Conv2D(FFModel& model,
            params.activation,
            params.groups,
            params.use_bias,
-           allocate_weights,
+           false,
            name)
 { }
 

--- a/src/ops/conv_2d.cc
+++ b/src/ops/conv_2d.cc
@@ -373,6 +373,7 @@ Conv2D::Conv2D(FFModel& model,
 Conv2D::Conv2D(FFModel& model,
                Conv2DParams const &params,
                ParallelTensor const input,
+               bool allocate_weights,
                const char* name) 
   : Conv2D(model,
            params.layer_guid,
@@ -387,7 +388,7 @@ Conv2D::Conv2D(FFModel& model,
            params.activation,
            params.groups,
            params.use_bias,
-           false,
+           allocate_weights,
            name)
 { }
 

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -649,11 +649,6 @@ Node FFModel::get_or_create_element_binary_node(const ParallelTensor input1,
   return get_or_create_node<ElementBinary>(inputs, params);
 }
 
-template <>
-std::unordered_map<std::pair<std::pair<ParallelTensorShape, ParallelTensorShape>, ElementBinaryParams>, ElementBinary*> &FFModel::get_cache() {
-  return this->cached_element_binary_ops;
-}
-
 }; // namespace FlexFlow
 
 namespace std {

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -98,6 +98,7 @@ Tensor FFModel::divide(const Tensor in1,
 }
 
 bool ElementBinaryParams::is_valid(const std::pair<ParallelTensorShape, ParallelTensorShape>&) const {
+  // TODO: more check on the input shape
   return true;
 }
 

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -153,8 +153,8 @@ ElementBinary::ElementBinary(FFModel& model,
 ElementBinary::ElementBinary(FFModel& model,
                              const ElementBinaryParams& params,
                              const std::pair<ParallelTensor, ParallelTensor>& inputs,
-                             bool inplace_a,
-                             const char* name)
+                             const char* name,
+                             bool inplace_a)
   : ElementBinary(model, params.type, inputs.first, inputs.second, inplace_a, name) {}
 
 bool ElementBinary::can_inplace_output(void)

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -97,6 +97,10 @@ Tensor FFModel::divide(const Tensor in1,
   return this->binary(OP_EW_DIV, in1, in2, inplace_a, name);
 }
 
+bool ElementBinaryParams::is_valid(const std::pair<ParallelTensorShape, ParallelTensorShape>&) const {
+  return true;
+}
+
 bool operator==(const ElementBinaryParams& lhs, const ElementBinaryParams& rhs) {
   return lhs.type == rhs.type;
 }
@@ -148,9 +152,9 @@ ElementBinary::ElementBinary(FFModel& model,
 
 ElementBinary::ElementBinary(FFModel& model,
                              const ElementBinaryParams& params,
-                             const std::vector<ParallelTensor>& inputs,
+                             const std::pair<ParallelTensor, ParallelTensor>& inputs,
                              const char* name)
-  : ElementBinary(model, params.type, inputs[0], inputs[1], false, name) {}
+  : ElementBinary(model, params.type, inputs.first, inputs.second, false, name) {}
 
 bool ElementBinary::can_inplace_output(void)
 {
@@ -637,7 +641,7 @@ Node FFModel::get_or_create_element_binary_node(const ParallelTensor input1,
                                                 const ParallelTensor input2,
                                                 OperatorType op_type)
 {
-  std::vector<ParallelTensor> inputs{input1, input2};
+  auto inputs = std::make_pair(input1, input2);
   ElementBinaryParams params;
   params.type = op_type;
 
@@ -645,7 +649,7 @@ Node FFModel::get_or_create_element_binary_node(const ParallelTensor input1,
 }
 
 template <>
-std::unordered_map<std::pair<ParallelTensorShapes, ElementBinaryParams>, ElementBinary*> &FFModel::get_cache_multi_inputs() {
+std::unordered_map<std::pair<std::pair<ParallelTensorShape, ParallelTensorShape>, ElementBinaryParams>, ElementBinary*> &FFModel::get_cache() {
   return this->cached_element_binary_ops;
 }
 

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -153,8 +153,9 @@ ElementBinary::ElementBinary(FFModel& model,
 ElementBinary::ElementBinary(FFModel& model,
                              const ElementBinaryParams& params,
                              const std::pair<ParallelTensor, ParallelTensor>& inputs,
+                             bool inplace_a,
                              const char* name)
-  : ElementBinary(model, params.type, inputs.first, inputs.second, false, name) {}
+  : ElementBinary(model, params.type, inputs.first, inputs.second, inplace_a, name) {}
 
 bool ElementBinary::can_inplace_output(void)
 {

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -740,11 +740,6 @@ bool Linear::measure_operator_cost(
 
 using PCG::Node;
 
-template <>
-std::unordered_map<std::pair<ParallelTensorShape, LinearParams>, Linear*> &FFModel::get_cache() {
-  return this->cached_linear_ops;
-}
-
 Node FFModel::get_or_create_linear_node(const LayerID& layer_guid,
                                         const ParallelTensor input,
                                         int out_dim,

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -96,6 +96,7 @@ Linear::Linear(FFModel& model,
 Linear::Linear(FFModel &model,
                LinearParams const &params,
                ParallelTensor const input,
+               bool allocate_weights,
                const char* name) 
   : Linear(model,
            params.layer_guid,
@@ -104,7 +105,7 @@ Linear::Linear(FFModel &model,
            params.activation,
            params.use_bias,
            params.data_type,
-           false,
+           allocate_weights,
            name)
 { } 
 

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -96,7 +96,6 @@ Linear::Linear(FFModel& model,
 Linear::Linear(FFModel &model,
                LinearParams const &params,
                ParallelTensor const input,
-               bool allocate_weights,
                const char* name) 
   : Linear(model,
            params.layer_guid,
@@ -105,7 +104,7 @@ Linear::Linear(FFModel &model,
            params.activation,
            params.use_bias,
            params.data_type,
-           allocate_weights,
+           false,
            name)
 { } 
 

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -96,8 +96,8 @@ Linear::Linear(FFModel& model,
 Linear::Linear(FFModel &model,
                LinearParams const &params,
                ParallelTensor const input,
-               bool allocate_weights,
-               const char* name) 
+               const char* name,
+               bool allocate_weights) 
   : Linear(model,
            params.layer_guid,
            input,

--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -3192,6 +3192,21 @@ PerfMetrics FFModel::update_metrics_task(const Task *task,
   return all_metrics;
 }
 
+template <>
+std::tuple<> FFModel::get_input_shape(const std::tuple<> &) {
+  return std::tuple<>();
+}
+
+template <>
+ParallelTensorShape FFModel::get_input_shape(const ParallelTensor &input) {
+  return input->get_shape();
+}
+
+template <>
+std::pair<ParallelTensorShape, ParallelTensorShape> FFModel::get_input_shape(const std::pair<ParallelTensor, ParallelTensor> &inputs) {
+  return std::make_pair(inputs.first->get_shape(), inputs.second->get_shape());
+}
+
 void Op::prefetch(const FFModel& ff)
 {
   // TODO: perform prefetch for performance imporvement

--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -3192,20 +3192,31 @@ PerfMetrics FFModel::update_metrics_task(const Task *task,
   return all_metrics;
 }
 
+// TODO: Move to an appropriate place
 template <>
-std::tuple<> FFModel::get_input_shape(const std::tuple<> &) {
+std::tuple<> get_input_shape(const std::tuple<> &) {
   return std::tuple<>();
 }
 
 template <>
-ParallelTensorShape FFModel::get_input_shape(const ParallelTensor &input) {
+ParallelTensorShape get_input_shape(const ParallelTensor &input) {
   return input->get_shape();
 }
 
 template <>
-std::pair<ParallelTensorShape, ParallelTensorShape> FFModel::get_input_shape(const std::pair<ParallelTensor, ParallelTensor> &inputs) {
+std::pair<ParallelTensorShape, ParallelTensorShape> get_input_shape(const std::pair<ParallelTensor, ParallelTensor> &inputs) {
   return std::make_pair(inputs.first->get_shape(), inputs.second->get_shape());
 }
+
+template<>
+std::vector<ParallelTensorShape> get_input_shape(const std::vector<ParallelTensor>& inputs) {
+  std::vector<ParallelTensorShape> shapes;
+  for (const auto& input : inputs) {
+    shapes.push_back(input->get_shape());
+  }
+  return shapes;
+}
+
 
 void Op::prefetch(const FFModel& ff)
 {

--- a/src/runtime/parallel_tensor.cc
+++ b/src/runtime/parallel_tensor.cc
@@ -581,14 +581,6 @@ namespace std {
     }
     return key;
   }
-  size_t hash<FlexFlow::ParallelTensorShapes>::operator()(FlexFlow::ParallelTensorShapes const &shapes) const {
-    size_t key = 0;
-    hash_combine(key, shapes.size());
-    for (const auto& shape : shapes) {
-      hash_combine(key, shape);
-    }
-    return key;
-  }
 };
 
 namespace FlexFlow {

--- a/src/runtime/parallel_tensor.cc
+++ b/src/runtime/parallel_tensor.cc
@@ -581,6 +581,14 @@ namespace std {
     }
     return key;
   }
+  size_t hash<FlexFlow::ParallelTensorShapes>::operator()(FlexFlow::ParallelTensorShapes const &shapes) const {
+    size_t key = 0;
+    hash_combine(key, shapes.size());
+    for (const auto& shape : shapes) {
+      hash_combine(key, shape);
+    }
+    return key;
+  }
 };
 
 namespace FlexFlow {


### PR DESCRIPTION
This changes the cache key for Concat and ElementBinary operators to avoid hash collision.

Change the key type of `cached_concat_ops` and `cached_element_binary_ops` to `std::pair<ParallelTensorShapes, Params>` where `ParallelTensorShapes` is `std::vector<ParallelTensorShape>` to encode information of multiple inputs. Add some functions for operators with multiple inputs. @lockshaw do you think it is proper?
