### PR TITLE
[PyTorch] Enable `file_to_ff()` without `torch`

### DIFF
--- a/examples/python/pytorch/cifar10_cnn.py
+++ b/examples/python/pytorch/cifar10_cnn.py
@@ -1,6 +1,6 @@
 from flexflow.core import *
 from flexflow.keras.datasets import cifar10
-from flexflow.torch.model import PyTorchModel
+from flexflow.torch.model import file_to_ff
 
 #from accuracy import ModelAccuracy
 
@@ -11,7 +11,7 @@ def top_level_task():
 
   dims_input = [ffconfig.batch_size, 3, 32, 32]
   input_tensor = ffmodel.create_tensor(dims_input, DataType.DT_FLOAT)
-  output_tensors = PyTorchModel.file_to_ff("cnn.ff", ffmodel, [input_tensor, input_tensor])
+  output_tensors = file_to_ff("cnn.ff", ffmodel, [input_tensor, input_tensor])
 
   t = ffmodel.softmax(output_tensors[0])
 

--- a/python/flexflow/torch/model.py
+++ b/python/flexflow/torch/model.py
@@ -2551,3 +2551,7 @@ class PyTorchModel():
         with open(filename, "w") as f:
             for line in s:
                 f.write(line + "\n")
+
+
+# Make the static method `file_to_ff()` available without importing `torch`
+file_to_ff = PyTorchModel.file_to_ff


### PR DESCRIPTION
This is a (hacky) workaround that enables loading from a `.ff` file without calling `import torch`. It makes the static method `PyTorchModel.file_to_ff()` available in `model.py`'s namespace and hence able to be imported from other files directly.

I tested that I can run
```
./python/flexflow_python examples/python/pytorch/cifar10_cnn.py -ll:py 1 -ll:gpu 1 -ll:fsize 4096 -ll:zsize 12192
```
when `cnn.ff` is available appropriately and when using CFFI instead of pybind (i.e. `export FF_USE_CFFI=1`).