### PR TITLE
Refactor cache keys

### DIFF
--- a/include/flexflow/model.h
+++ b/include/flexflow/model.h
@@ -897,13 +897,13 @@ public:
     std::unordered_map<std::pair<std::vector<ParallelTensorShape>, ConcatParams>, Concat*>,
     std::unordered_map<std::pair<ParallelTensorShape, Conv2DParams>, Conv2D*>,
     std::unordered_map<std::pair<std::pair<ParallelTensorShape, ParallelTensorShape>, ElementBinaryParams>, ElementBinary*>,
-    std::unordered_map<std::pair<ParallelTensorShape, LinearParams>, Linear*>
+    std::unordered_map<std::pair<ParallelTensorShape, LinearParams>, Linear*>,
+    std::unordered_map<std::pair<ParallelTensorShape, ElementUnaryParams>, ElementUnary*>
   > cached_ops;
   std::unordered_map<size_t, NoOp*> cached_noop_ops;
   std::unordered_map<size_t, NoOp*> cached_input_ops;
   std::unordered_map<size_t, Cast*> cached_cast_ops;
   std::unordered_map<size_t, Dropout*> cached_dropout_ops;
-  std::unordered_map<size_t, ElementUnary*> cached_element_unary_ops;
   std::unordered_map<size_t, Embedding*> cached_embedding_ops;
   std::unordered_map<size_t, Pool2D*> cached_pool2d_ops;
   std::unordered_map<size_t, Flat*> cached_flat_ops;

--- a/include/flexflow/model.h
+++ b/include/flexflow/model.h
@@ -898,14 +898,14 @@ public:
     std::unordered_map<std::pair<ParallelTensorShape, Conv2DParams>, Conv2D*>,
     std::unordered_map<std::pair<std::pair<ParallelTensorShape, ParallelTensorShape>, ElementBinaryParams>, ElementBinary*>,
     std::unordered_map<std::pair<ParallelTensorShape, LinearParams>, Linear*>,
-    std::unordered_map<std::pair<ParallelTensorShape, ElementUnaryParams>, ElementUnary*>
+    std::unordered_map<std::pair<ParallelTensorShape, ElementUnaryParams>, ElementUnary*>,
+    std::unordered_map<std::pair<ParallelTensorShape, Pool2DParams>, Pool2D*>
   > cached_ops;
   std::unordered_map<size_t, NoOp*> cached_noop_ops;
   std::unordered_map<size_t, NoOp*> cached_input_ops;
   std::unordered_map<size_t, Cast*> cached_cast_ops;
   std::unordered_map<size_t, Dropout*> cached_dropout_ops;
   std::unordered_map<size_t, Embedding*> cached_embedding_ops;
-  std::unordered_map<size_t, Pool2D*> cached_pool2d_ops;
   std::unordered_map<size_t, Flat*> cached_flat_ops;
   std::unordered_map<size_t, MultiHeadAttention*> cached_multihead_attn_ops;
   std::unordered_map<size_t, Reshape*> cached_reshape_ops;

--- a/include/flexflow/operator_params.h
+++ b/include/flexflow/operator_params.h
@@ -6,6 +6,7 @@
 #include "flexflow/ops/linear.h"
 #include "flexflow/ops/concat.h"
 #include "flexflow/ops/element_binary.h"
+#include "flexflow/ops/element_unary.h"
 
 namespace mp = mpark;
 
@@ -15,7 +16,8 @@ using OperatorParameters = mp::variant<
 Conv2DParams,
 LinearParams,
 ConcatParams,
-ElementBinaryParams
+ElementBinaryParams,
+ElementUnaryParams
 >;
 
 }; // namespace FlexFlow

--- a/include/flexflow/operator_params.h
+++ b/include/flexflow/operator_params.h
@@ -7,6 +7,7 @@
 #include "flexflow/ops/concat.h"
 #include "flexflow/ops/element_binary.h"
 #include "flexflow/ops/element_unary.h"
+#include "flexflow/ops/pool_2d.h"
 
 namespace mp = mpark;
 
@@ -17,7 +18,8 @@ Conv2DParams,
 LinearParams,
 ConcatParams,
 ElementBinaryParams,
-ElementUnaryParams
+ElementUnaryParams,
+Pool2DParams
 >;
 
 }; // namespace FlexFlow

--- a/include/flexflow/ops/element_unary.h
+++ b/include/flexflow/ops/element_unary.h
@@ -12,7 +12,7 @@ namespace FlexFlow {
 
 struct ElementUnaryParams {
   OperatorType op_type;
-  // TODO: bool inplace;
+  bool inplace;
   float scalar;
 
   bool is_valid(const ParallelTensorShape &) const;
@@ -50,8 +50,7 @@ public:
   ElementUnary(FFModel& model,
                const Params& params,
                const Input x,
-               const char* name = nullptr,
-               bool inplace = false); // TODO: should this be in params?
+               const char* name = nullptr);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;

--- a/include/flexflow/ops/element_unary.h
+++ b/include/flexflow/ops/element_unary.h
@@ -12,7 +12,6 @@ namespace FlexFlow {
 
 struct ElementUnaryParams {
   OperatorType op_type;
-  DataType data_type;
   // TODO: bool inplace;
   float scalar;
 

--- a/include/flexflow/ops/pool_2d.h
+++ b/include/flexflow/ops/pool_2d.h
@@ -1,7 +1,12 @@
 #ifndef _FLEXFLOW_POOL_2D_H
 #define _FLEXFLOW_POOL_2D_H
 
-#include "flexflow/model.h"
+#include "flexflow/fftype.h"
+#include "flexflow/op_meta.h"
+#include "flexflow/operator.h"
+#include "flexflow/node.h"
+#include "flexflow/device.h"
+#include "flexflow/layer.h"
 
 namespace FlexFlow {
 
@@ -31,11 +36,12 @@ struct Pool2DParams {
   bool is_valid(const ParallelTensor input) const;
   void solve_dims(const ParallelTensor input, 
                   ParallelDim output_dims[MAX_TENSOR_DIM], int* output_ndims) const;
-  size_t get_hash(const ParallelTensor input) const;
 private:
   int output_size(const ParallelTensor input,
                   ParallelDim output_dims[MAX_TENSOR_DIM]) const; 
 };
+
+bool operator==(const Pool2DParams&, const Pool2DParams&);
 
 class Pool2DMeta : public OpMeta {
 public:
@@ -55,6 +61,9 @@ public:
 
 class Pool2D : public Op {
 public:
+  using Params = Pool2DParams;
+  using Input = ParallelTensor;
+
   Pool2D(FFModel& model,
          const ParallelTensor input,
          int kernelH, int kernelW,
@@ -66,6 +75,10 @@ public:
   Pool2D(FFModel& model,
          Pool2D const &other,
          ParallelTensor const input);
+  Pool2D(FFModel& model, 
+         const Params& params,
+         const Input input,
+         const char* name = nullptr);
   void init(const FFModel&) override;
   void forward(const FFModel&) override;
   void backward(const FFModel&) override;
@@ -117,8 +130,7 @@ public:
 
   static void construct_output_mappings(std::vector<ParallelDimMappingRecord> &);
 
-  Pool2DParams get_params() const;
-  size_t get_params_hash() const override;
+  Params get_params() const;
 private:
   int output_size(ParallelDim output_dims[MAX_TENSOR_DIM]); 
 
@@ -131,5 +143,12 @@ public:
 };
 
 }; // namespace FlexFlow
+
+namespace std {
+  template <>
+  struct hash<FlexFlow::Pool2DParams> {
+    size_t operator()(const FlexFlow::Pool2DParams&) const;
+  };
+}; // namespace std
 
 #endif //_FLEXFLOW_POOL_2D_H

--- a/src/ops/element_unary.cc
+++ b/src/ops/element_unary.cc
@@ -143,9 +143,9 @@ Tensor FFModel::pow(const Tensor x, const float exponent, bool inplace, const ch
   return this->unary(OP_POW, x, inplace, name, exponent);
 }
 
-bool ElementUnaryParams::is_valid(const ParallelTensorShape &) const {
+bool ElementUnaryParams::is_valid(const ParallelTensorShape & input) const {
   // TODO: more check on the input shape
-  return true
+  return input.is_valid();
 }
 
 bool operator==(const ElementUnaryParams& lhs, const ElementUnaryParams& rhs) {

--- a/src/ops/element_unary.cc
+++ b/src/ops/element_unary.cc
@@ -55,7 +55,8 @@ Op* ElementUnary::create_operator_from_layer(
 
 ElementUnaryParams ElementUnary::get_params() const {
   ElementUnaryParams params;
-  params.op_type = op_type;
+  params.op_type = this->op_type;
+  params.scalar = this->scalar;
   return params;
 }
 
@@ -146,7 +147,8 @@ bool ElementUnaryParams::is_valid(const ParallelTensorShape &) const {
 }
 
 bool operator==(const ElementUnaryParams& lhs, const ElementUnaryParams& rhs) {
-  return lhs.type == rhs.type;
+  return lhs.op_type == rhs.op_type && 
+          lhs.scalar == rhs.scalar;
 }
 
 ElementUnary::ElementUnary(FFModel& model,
@@ -171,7 +173,7 @@ ElementUnary::ElementUnary(FFModel& model,
                            const ParallelTensor input,
                            const char* name,
                            bool inplace)
-  : ElementUnary(model, params.type, input, inplace, name, params.scalar) {}
+  : ElementUnary(model, params.op_type, input, inplace, name, params.scalar) {}
 
 bool ElementUnary::can_inplace_output(void)
 {
@@ -573,7 +575,6 @@ namespace std {
   size_t hash<FlexFlow::ElementUnaryParams>::operator()(const FlexFlow::ElementUnaryParams& params) const {
     size_t key = 0;
     hash_combine(key, params.op_type);
-    hash_combine(key, params.data_type);
     hash_combine(key, params.scalar);
     // TODO: hash_combine(key, params.inplace);
     return key;

--- a/src/ops/element_unary.cc
+++ b/src/ops/element_unary.cc
@@ -56,6 +56,7 @@ Op* ElementUnary::create_operator_from_layer(
 ElementUnaryParams ElementUnary::get_params() const {
   ElementUnaryParams params;
   params.op_type = this->op_type;
+  params.inplace = this->inplace;
   params.scalar = this->scalar;
   return params;
 }
@@ -68,6 +69,7 @@ Node FFModel::get_or_create_element_unary_node(const ParallelTensor input,
 {
   ElementUnaryParams params;
   params.op_type = op;
+  params.inplace = inplace;
   params.scalar = scalar;
 
   return get_or_create_node<ElementUnary>(input, params);
@@ -148,7 +150,8 @@ bool ElementUnaryParams::is_valid(const ParallelTensorShape &) const {
 
 bool operator==(const ElementUnaryParams& lhs, const ElementUnaryParams& rhs) {
   return lhs.op_type == rhs.op_type && 
-          lhs.scalar == rhs.scalar;
+         lhs.scalar == rhs.scalar &&
+         lhs.inplace = rhs.inplace;
 }
 
 ElementUnary::ElementUnary(FFModel& model,
@@ -167,13 +170,12 @@ ElementUnary::ElementUnary(FFModel& model,
   }
   outputs[0] = model.create_parallel_tensor_legion_ordering(numdim, dims, x->data_type, this);
 }
-// TODO: should inplace be in params?
+
 ElementUnary::ElementUnary(FFModel& model,
                            const ElementUnaryParams& params,
                            const ParallelTensor input,
-                           const char* name,
-                           bool inplace)
-  : ElementUnary(model, params.op_type, input, inplace, name, params.scalar) {}
+                           const char* name)
+  : ElementUnary(model, params.op_type, input, params.inplace, name, params.scalar) {}
 
 bool ElementUnary::can_inplace_output(void)
 {
@@ -576,7 +578,7 @@ namespace std {
     size_t key = 0;
     hash_combine(key, params.op_type);
     hash_combine(key, params.scalar);
-    // TODO: hash_combine(key, params.inplace);
+    hash_combine(key, params.inplace);
     return key;
   }
 }; // namespace std

--- a/src/ops/pool_2d.cc
+++ b/src/ops/pool_2d.cc
@@ -117,14 +117,14 @@ bool Pool2DParams::is_valid(const ParallelTensor input) const {
 
 using PCG::Node;
 bool operator==(const Pool2DParams& lhs, const Pool2DParams& rhs) {
-  return lhs.kernel_h = rhs.kernelH &&
-        lhs.kernel_w = rhs.kernelW &&
-        lhs.stride_h = rhs.strideH &&
-        lhs.stride_w = rhs.strideW &&
-        lhs.padding_h = rhs.paddingH &&
-        lhs.padding_w = rhs.paddingW &&
-        lhs.pool_type = rhs.type &&
-        lhs.activation = rhs.activation;
+  return lhs.kernel_h == rhs.kernel_h &&
+        lhs.kernel_w == rhs.kernel_w &&
+        lhs.stride_h == rhs.stride_h &&
+        lhs.stride_w == rhs.stride_w &&
+        lhs.padding_h == rhs.padding_h &&
+        lhs.padding_w == rhs.padding_w &&
+        lhs.pool_type == rhs.pool_type &&
+        lhs.activation == rhs.activation;
 }
 
 Node FFModel::get_or_create_pool2d_node(const ParallelTensor input,

--- a/src/runtime/simulator.cc
+++ b/src/runtime/simulator.cc
@@ -493,8 +493,22 @@ tl::optional<OperatorParameters> get_op_parameters(const Op* op) {
     case OP_EW_MUL:
     case OP_EW_DIV:
       return ((ElementBinary*)op)->get_params();
+    case OP_EXP:
+    case OP_SCALAR_MULTIPLY:
+    case OP_SCALAR_ADD:
+    case OP_SCALAR_SUB:
+    case OP_SCALAR_TRUE_DIV:
+    case OP_RELU:
+    case OP_SIGMOID:
+    case OP_TANH:
+    case OP_IDENTITY:
+    case OP_GELU:
+    case OP_ELU:
+      return ((ElementUnary*)op)->get_params();
     case OP_CONCAT:
       return ((Concat*)op)->get_params();
+    case OP_POOL2D:
+      return ((Pool2D*)op)->get_params();
     default:
       return tl::nullopt;
   }


### PR DESCRIPTION
- Refactor cache keys for `ElementUnary` and `Pool2D`
- Open question about whether `inplace` belongs in `ElementUnaryParams` and `ElementBinaryParams`. Currently, I've added it to unary because it is already being serialized and deserialized there but left it out of binary.
@lockshaw let me know if this looks good