### PR TITLE
Add const positioning to autoformatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -128,6 +128,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
 PointerAlignment: Right
 PPIndentWidth:   -1
+QualifierAlignment: Right
 ReferenceAlignment: Pointer
 ReflowComments:  true
 ShortNamespaceLines: 1

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -20,6 +20,6 @@ jobs:
     - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.8.0
       with:
-        clang-format-version: '13'
+        clang-format-version: '14'
         check-path: ${{ matrix.path['check'] }}
         exclude-regex: ${{ matrix.path['exclude'] }}

--- a/examples/cpp/AlexNet/alexnet.cc
+++ b/examples/cpp/AlexNet/alexnet.cc
@@ -35,14 +35,14 @@ void parse_input_args(char **argv, int argc, AlexNetConfig &config) {
   }
 }
 
-void FlexFlow::top_level_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void FlexFlow::top_level_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   FFConfig ffConfig;
   AlexNetConfig alexnetConfig;
   {
-    const InputArgs &command_args = HighLevelRuntime::get_input_args();
+    InputArgs const &command_args = HighLevelRuntime::get_input_args();
     char **argv = command_args.argv;
     int argc = command_args.argc;
     parse_input_args(argv, argc, alexnetConfig);
@@ -55,7 +55,7 @@ void FlexFlow::top_level_task(const Task *task,
 
   Tensor input;
   {
-    const int dims[] = {ffConfig.batchSize, 3, 229, 229};
+    int const dims[] = {ffConfig.batchSize, 3, 229, 229};
     input = ff.create_tensor<4>(dims, DT_FLOAT);
   }
   // Tensor label;
@@ -131,7 +131,7 @@ void FlexFlow::top_level_task(const Task *task,
          data_loader.num_samples * ffConfig.epochs / run_time);
 }
 
-size_t get_file_size(const std::string &filename) {
+size_t get_file_size(std::string const &filename) {
   streampos begin, end;
   ifstream file(filename.c_str(), ios::binary);
   begin = file.tellg();
@@ -143,7 +143,7 @@ size_t get_file_size(const std::string &filename) {
 }
 
 DataLoader::DataLoader(FFModel &ff,
-                       const AlexNetConfig *alexnet,
+                       AlexNetConfig const *alexnet,
                        Tensor input,
                        Tensor label) {
   Context ctx = ff.config.lg_ctx;
@@ -162,7 +162,7 @@ DataLoader::DataLoader(FFModel &ff,
   // Create full input
   {
     batch_input = input;
-    const int dims[] = {
+    int const dims[] = {
         num_samples, input->dims[2], input->dims[1], input->dims[0]};
     full_input = ff.create_tensor<4>(dims, DT_FLOAT);
     // ff.map_tensor(full_input, NULL);
@@ -170,7 +170,7 @@ DataLoader::DataLoader(FFModel &ff,
   // Create full label
   {
     batch_label = label;
-    const int dims[] = {num_samples, label->dims[0]};
+    int const dims[] = {num_samples, label->dims[0]};
     full_label = ff.create_tensor<2>(dims, DT_INT32);
     // ff.map_tensor(full_label, NULL);
   }
@@ -226,11 +226,11 @@ void nearest_neigh(unsigned char *image,
   }
 }
 
-void DataLoader::load_entire_dataset(const Task *task,
-                                     const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_entire_dataset(Task const *task,
+                                     std::vector<PhysicalRegion> const &regions,
                                      Context ctx,
                                      Runtime *runtime) {
-  const AlexNetConfig *alexnet = (AlexNetConfig *)task->args;
+  AlexNetConfig const *alexnet = (AlexNetConfig *)task->args;
   assert(regions.size() == 2);
   assert(task->regions.size() == regions.size());
   const FlexFlow::AccessorWO<float, 4> acc_input(regions[0], FID_DATA);

--- a/examples/cpp/AlexNet/alexnet.cu
+++ b/examples/cpp/AlexNet/alexnet.cu
@@ -16,8 +16,8 @@
 #include "alexnet.h"
 #include "flexflow/utils/cuda_helper.h"
 
-void DataLoader::load_input(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_input(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
@@ -42,15 +42,15 @@ void DataLoader::load_input(const Task *task,
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
   coord_t start_idx = meta->idxs[0];
-  const float *input_zc =
+  float const *input_zc =
       acc_full_input.ptr + start_idx * channels * height * width;
   copy_kernel<<<GET_BLOCKS(acc_batch_input.rect.volume()), CUDA_NUM_THREADS>>>(
       acc_batch_input.ptr, input_zc, acc_batch_input.rect.volume());
   checkCUDA(cudaDeviceSynchronize());
 }
 
-void DataLoader::load_label(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_label(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
@@ -69,7 +69,7 @@ void DataLoader::load_label(const Task *task,
   assert(batch_size == meta->num_samples);
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
-  const int *input_zc = acc_full_label.ptr + meta->idxs[0];
+  int const *input_zc = acc_full_label.ptr + meta->idxs[0];
   copy_kernel<<<GET_BLOCKS(acc_batch_label.rect.volume()), CUDA_NUM_THREADS>>>(
       acc_batch_label.ptr, input_zc, acc_batch_label.rect.volume());
   checkCUDA(cudaDeviceSynchronize());

--- a/examples/cpp/AlexNet/alexnet.h
+++ b/examples/cpp/AlexNet/alexnet.h
@@ -33,19 +33,19 @@ struct AlexNetConfig {
 class DataLoader {
 public:
   DataLoader(FlexFlow::FFModel &ff,
-             const AlexNetConfig *alexnet,
+             AlexNetConfig const *alexnet,
              FlexFlow::Tensor _input,
              FlexFlow::Tensor _label);
-  static void load_input(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_input(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
-  static void load_label(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_label(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
-  static void load_entire_dataset(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+  static void load_entire_dataset(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
   void next_batch(FlexFlow::FFModel &);

--- a/examples/cpp/DLRM/dlrm.cu
+++ b/examples/cpp/DLRM/dlrm.cu
@@ -16,8 +16,8 @@
 #include "dlrm.h"
 #include "flexflow/utils/cuda_helper.h"
 
-void DataLoader::load_sparse_input(const Task *task,
-                                   const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_sparse_input(Task const *task,
+                                   std::vector<PhysicalRegion> const &regions,
                                    Context ctx,
                                    Runtime *runtime) {
   assert(regions.size() == 2);
@@ -62,8 +62,8 @@ void DataLoader::load_sparse_input(const Task *task,
   // "[DataLoader:load_sparse]");
 }
 
-void DataLoader::load_dense_input(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_dense_input(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime) {
   assert(regions.size() == 2);
@@ -98,8 +98,8 @@ void DataLoader::load_dense_input(const Task *task,
   checkCUDA(cudaFreeHost(input_zc));
 }
 
-void DataLoader::load_label(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_label(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);

--- a/examples/cpp/DLRM/dlrm.h
+++ b/examples/cpp/DLRM/dlrm.h
@@ -40,32 +40,32 @@ struct ArgsConfig {
 class DataLoader {
 public:
   DataLoader(FFModel &ff,
-             const DLRMConfig &dlrm,
-             const std::vector<Tensor> &_sparse_inputs,
+             DLRMConfig const &dlrm,
+             std::vector<Tensor> const &_sparse_inputs,
              Tensor _dense_input,
              Tensor _label);
 
   void next_batch(FFModel &ff);
   void shuffle();
   void reset();
-  static void load_entire_dataset(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+  static void load_entire_dataset(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
-  static void load_sparse_input(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+  static void load_sparse_input(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime);
-  static void load_sparse_input_cpu(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+  static void load_sparse_input_cpu(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime);
-  static void load_dense_input(const Task *task,
-                               const std::vector<PhysicalRegion> &regions,
+  static void load_dense_input(Task const *task,
+                               std::vector<PhysicalRegion> const &regions,
                                Context ctx,
                                Runtime *runtime);
-  static void load_label(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_label(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
 

--- a/examples/cpp/DLRM/strategies/dlrm_strategy.cc
+++ b/examples/cpp/DLRM/strategies/dlrm_strategy.cc
@@ -11,13 +11,13 @@
 class FFStrategy {
 public:
   FFStrategy(int _gpus_per_node, int _embs_per_node, int _num_nodes);
-  bool add_conv_config(const std::string &name,
-                       const std::string &device_type,
+  bool add_conv_config(std::string const &name,
+                       std::string const &device_type,
                        int num_par_n,
                        int num_par_c,
-                       const std::string &input_memory,
-                       const std::string &output_memory);
-  FFProtoBuf::Op_DeviceType to_device_type(const std::string &name) {
+                       std::string const &input_memory,
+                       std::string const &output_memory);
+  FFProtoBuf::Op_DeviceType to_device_type(std::string const &name) {
     if (name == "gpu" || name == "GPU") {
       return FFProtoBuf::Op_DeviceType_GPU;
     } else if (name == "cpu" || name == "CPU") {
@@ -28,7 +28,7 @@ public:
     return FFProtoBuf::Op_DeviceType_GPU;
   }
 
-  FFProtoBuf::Op_MemoryType to_memory_type(const std::string &name) {
+  FFProtoBuf::Op_MemoryType to_memory_type(std::string const &name) {
     if (name == "gpu_memory" || name == "FBM") {
       return FFProtoBuf::Op_MemoryType_FBM;
     } else if (name == "cpu_memory" || name == "ZCM") {
@@ -38,46 +38,46 @@ public:
     }
     return FFProtoBuf::Op_MemoryType_FBM;
   }
-  bool add_embed_config(const std::string &name,
-                        const std::string &device_type,
-                        const std::string &input_memory_type,
-                        const std::string &weight_memory_type,
-                        const std::string &output_memory_type,
+  bool add_embed_config(std::string const &name,
+                        std::string const &device_type,
+                        std::string const &input_memory_type,
+                        std::string const &weight_memory_type,
+                        std::string const &output_memory_type,
                         int gpu_id);
-  bool add_concat_config(const std::string &name,
-                         const std::string &device_type,
-                         const std::string &input_memory_type,
-                         const std::string &output_memory_type,
+  bool add_concat_config(std::string const &name,
+                         std::string const &device_type,
+                         std::string const &input_memory_type,
+                         std::string const &output_memory_type,
                          int num_parts_sample,
-                         const std::vector<int> &device_ids);
-  bool add_batch_matmul_config(const std::string &name,
-                               const std::string &device_type,
-                               const std::string &input1_memory_type,
-                               const std::string &input2_memory_type,
-                               const std::string &output_memory_type,
+                         std::vector<int> const &device_ids);
+  bool add_batch_matmul_config(std::string const &name,
+                               std::string const &device_type,
+                               std::string const &input1_memory_type,
+                               std::string const &input2_memory_type,
+                               std::string const &output_memory_type,
                                int num_parts_sample,
-                               const std::vector<int> &device_ids);
-  bool add_linear_config(const std::string &name,
-                         const std::string &device_type,
-                         const std::string &input_memory_type,
-                         const std::string &weight_memory_type,
-                         const std::string &output_memory_type,
+                               std::vector<int> const &device_ids);
+  bool add_linear_config(std::string const &name,
+                         std::string const &device_type,
+                         std::string const &input_memory_type,
+                         std::string const &weight_memory_type,
+                         std::string const &output_memory_type,
                          int num_parts_channel,
                          int num_parts_sample,
-                         const std::vector<int> &device_ids);
-  bool add_mse_config(const std::string &name,
-                      const std::string &device_type,
-                      const std::string &input_memory_type,
+                         std::vector<int> const &device_ids);
+  bool add_mse_config(std::string const &name,
+                      std::string const &device_type,
+                      std::string const &input_memory_type,
                       int num_parts_batch,
-                      const std::vector<int> &device_ids);
-  bool add_transpose_config(const std::string &name,
-                            const std::string &device_type,
-                            const std::string &input_memory_type,
-                            const std::string &output_memory_type,
+                      std::vector<int> const &device_ids);
+  bool add_transpose_config(std::string const &name,
+                            std::string const &device_type,
+                            std::string const &input_memory_type,
+                            std::string const &output_memory_type,
                             int num_parts_sample,
-                            const std::vector<int> &device_ids);
+                            std::vector<int> const &device_ids);
 
-  void export_file(const std::string &file);
+  void export_file(std::string const &file);
 
 private:
   int gpus_per_node, embs_per_node, num_nodes;
@@ -93,11 +93,11 @@ FFStrategy::FFStrategy(int _gpus_per_node, int _num_nodes, int _embs_per_node)
   }
 }
 
-bool FFStrategy::add_embed_config(const std::string &name,
-                                  const std::string &device_type,
-                                  const std::string &input_memory_type,
-                                  const std::string &weight_memory_type,
-                                  const std::string &output_memory_type,
+bool FFStrategy::add_embed_config(std::string const &name,
+                                  std::string const &device_type,
+                                  std::string const &input_memory_type,
+                                  std::string const &weight_memory_type,
+                                  std::string const &output_memory_type,
                                   int gpu_id) {
   FFProtoBuf::Op *op = strategy.add_ops();
   op->set_name(name);
@@ -113,12 +113,12 @@ bool FFStrategy::add_embed_config(const std::string &name,
   return true;
 }
 
-bool FFStrategy::add_concat_config(const std::string &name,
-                                   const std::string &device_type,
-                                   const std::string &input_memory_type,
-                                   const std::string &output_memory_type,
+bool FFStrategy::add_concat_config(std::string const &name,
+                                   std::string const &device_type,
+                                   std::string const &input_memory_type,
+                                   std::string const &output_memory_type,
                                    int num_parts_sample,
-                                   const std::vector<int> &device_ids) {
+                                   std::vector<int> const &device_ids) {
   FFProtoBuf::Op *op = strategy.add_ops();
   op->set_name(name);
   op->set_device_type(to_device_type(device_type));
@@ -131,13 +131,13 @@ bool FFStrategy::add_concat_config(const std::string &name,
     op->add_device_ids(device_ids[i]);
 }
 
-bool FFStrategy::add_batch_matmul_config(const std::string &name,
-                                         const std::string &device_type,
-                                         const std::string &input1_memory_type,
-                                         const std::string &input2_memory_type,
-                                         const std::string &output_memory_type,
+bool FFStrategy::add_batch_matmul_config(std::string const &name,
+                                         std::string const &device_type,
+                                         std::string const &input1_memory_type,
+                                         std::string const &input2_memory_type,
+                                         std::string const &output_memory_type,
                                          int num_parts_sample,
-                                         const std::vector<int> &device_ids) {
+                                         std::vector<int> const &device_ids) {
   FFProtoBuf::Op *op = strategy.add_ops();
   op->set_name(name);
   op->set_device_type(to_device_type(device_type));
@@ -152,12 +152,12 @@ bool FFStrategy::add_batch_matmul_config(const std::string &name,
     op->add_device_ids(device_ids[i]);
 }
 
-bool FFStrategy::add_transpose_config(const std::string &name,
-                                      const std::string &device_type,
-                                      const std::string &input_memory_type,
-                                      const std::string &output_memory_type,
+bool FFStrategy::add_transpose_config(std::string const &name,
+                                      std::string const &device_type,
+                                      std::string const &input_memory_type,
+                                      std::string const &output_memory_type,
                                       int num_parts_sample,
-                                      const std::vector<int> &device_ids) {
+                                      std::vector<int> const &device_ids) {
   FFProtoBuf::Op *op = strategy.add_ops();
   op->set_name(name);
   op->set_device_type(to_device_type(device_type));
@@ -171,14 +171,14 @@ bool FFStrategy::add_transpose_config(const std::string &name,
     op->add_device_ids(device_ids[i]);
 }
 
-bool FFStrategy::add_linear_config(const std::string &name,
-                                   const std::string &device_type,
-                                   const std::string &input_memory_type,
-                                   const std::string &weight_memory_type,
-                                   const std::string &output_memory_type,
+bool FFStrategy::add_linear_config(std::string const &name,
+                                   std::string const &device_type,
+                                   std::string const &input_memory_type,
+                                   std::string const &weight_memory_type,
+                                   std::string const &output_memory_type,
                                    int num_parts_channel,
                                    int num_parts_sample,
-                                   const std::vector<int> &device_ids) {
+                                   std::vector<int> const &device_ids) {
   FFProtoBuf::Op *op = strategy.add_ops();
   op->set_name(name);
   op->set_device_type(to_device_type(device_type));
@@ -192,11 +192,11 @@ bool FFStrategy::add_linear_config(const std::string &name,
     op->add_device_ids(device_ids[i]);
 }
 
-bool FFStrategy::add_mse_config(const std::string &name,
-                                const std::string &device_type,
-                                const std::string &input_memory_type,
+bool FFStrategy::add_mse_config(std::string const &name,
+                                std::string const &device_type,
+                                std::string const &input_memory_type,
                                 int num_parts_sample,
-                                const std::vector<int> &device_ids) {
+                                std::vector<int> const &device_ids) {
   FFProtoBuf::Op *op = strategy.add_ops();
   op->set_name(name);
   op->set_device_type(to_device_type(device_type));
@@ -208,7 +208,7 @@ bool FFStrategy::add_mse_config(const std::string &name,
     op->add_device_ids(device_ids[i]);
 }
 
-void FFStrategy::export_file(const std::string &output) {
+void FFStrategy::export_file(std::string const &output) {
   std::fstream outputFile(output.c_str(), std::ios::out | std::ios::trunc);
   strategy.SerializeToOstream(&outputFile);
 }

--- a/examples/cpp/InceptionV3/inception.cc
+++ b/examples/cpp/InceptionV3/inception.cc
@@ -120,8 +120,8 @@ Tensor InceptionE(FFModel &ff, Tensor input) {
   return output;
 }
 
-void FlexFlow::top_level_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void FlexFlow::top_level_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   FFConfig ffConfig;
@@ -139,7 +139,7 @@ void FlexFlow::top_level_task(const Task *task,
 
   Tensor input;
   {
-    const int dims[] = {ffConfig.batchSize, 3, 299, 299};
+    int const dims[] = {ffConfig.batchSize, 3, 299, 299};
     input = ff.create_tensor<4>(dims, DT_FLOAT);
   }
   // Tensor label;

--- a/examples/cpp/MLP_Unify/mlp.cc
+++ b/examples/cpp/MLP_Unify/mlp.cc
@@ -20,8 +20,8 @@
 using namespace Legion;
 using namespace FlexFlow;
 
-void FlexFlow::top_level_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void FlexFlow::top_level_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   FFConfig ffConfig;
@@ -36,13 +36,13 @@ void FlexFlow::top_level_task(const Task *task,
       8192, 8192, 8192, 8192, 8192, 8192, 8192, 8192};
   Tensor input1, input2;
   {
-    const int dims[] = {ffConfig.batchSize, 1024};
+    int const dims[] = {ffConfig.batchSize, 1024};
     input1 = ff.create_tensor<2>(dims, DT_FLOAT);
     input2 = ff.create_tensor<2>(dims, DT_FLOAT);
   }
   Tensor t1 = input1, t2 = input2;
   for (size_t i = 0; i < hidden_dims.size(); i++) {
-    const int dims[] = {hidden_dims[i], t1->dims[0]};
+    int const dims[] = {hidden_dims[i], t1->dims[0]};
     ActiMode acti_mode =
         (i + 1 == hidden_dims.size()) ? AC_MODE_NONE : AC_MODE_RELU;
     t1 = ff.dense(t1, hidden_dims[i], acti_mode, false);

--- a/examples/cpp/ResNet/resnet.cc
+++ b/examples/cpp/ResNet/resnet.cc
@@ -58,14 +58,14 @@ BottleneckBlock(FFModel &ff, Tensor input, int out_channels, int stride) {
   return ff.relu(t, false);
 }
 
-void FlexFlow::top_level_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void FlexFlow::top_level_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   FFConfig ffConfig;
   ResNetConfig resnetConfig;
   {
-    const InputArgs &command_args = HighLevelRuntime::get_input_args();
+    InputArgs const &command_args = HighLevelRuntime::get_input_args();
     char **argv = command_args.argv;
     int argc = command_args.argc;
     parse_input_args(argv, argc, resnetConfig);
@@ -78,7 +78,7 @@ void FlexFlow::top_level_task(const Task *task,
 
   Tensor input;
   {
-    const int dims[] = {ffConfig.batchSize, 3, 229, 229};
+    int const dims[] = {ffConfig.batchSize, 3, 229, 229};
     input = ff.create_tensor<4>(dims, DT_FLOAT);
   }
   // Tensor label;
@@ -161,7 +161,7 @@ void FlexFlow::top_level_task(const Task *task,
          128 * ffConfig.batchSize * ffConfig.epochs / run_time);
 }
 
-size_t get_file_size(const std::string &filename) {
+size_t get_file_size(std::string const &filename) {
   streampos begin, end;
   ifstream file(filename.c_str(), ios::binary);
   begin = file.tellg();

--- a/examples/cpp/ResNet/resnet.cu
+++ b/examples/cpp/ResNet/resnet.cu
@@ -21,8 +21,8 @@ using FlexFlow::Tensor;
 using FlexFlow::TensorAccessorR;
 using FlexFlow::TensorAccessorW;
 
-void DataLoader::load_input(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_input(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
@@ -47,15 +47,15 @@ void DataLoader::load_input(const Task *task,
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
   coord_t start_idx = meta->idxs[0];
-  const float *input_zc =
+  float const *input_zc =
       acc_full_input.ptr + start_idx * channels * height * width;
   copy_kernel<<<GET_BLOCKS(acc_batch_input.rect.volume()), CUDA_NUM_THREADS>>>(
       acc_batch_input.ptr, input_zc, acc_batch_input.rect.volume());
   checkCUDA(cudaDeviceSynchronize());
 }
 
-void DataLoader::load_label(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_label(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
@@ -74,7 +74,7 @@ void DataLoader::load_label(const Task *task,
   assert(batch_size == meta->num_samples);
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
-  const int *input_zc = acc_full_label.ptr + meta->idxs[0];
+  int const *input_zc = acc_full_label.ptr + meta->idxs[0];
   copy_kernel<<<GET_BLOCKS(acc_batch_label.rect.volume()), CUDA_NUM_THREADS>>>(
       acc_batch_label.ptr, input_zc, acc_batch_label.rect.volume());
   checkCUDA(cudaDeviceSynchronize());

--- a/examples/cpp/ResNet/resnet.h
+++ b/examples/cpp/ResNet/resnet.h
@@ -29,19 +29,19 @@ struct ResNetConfig {
 class DataLoader {
 public:
   DataLoader(FlexFlow::FFModel &ff,
-             const ResNetConfig &resnet,
+             ResNetConfig const &resnet,
              FlexFlow::Tensor _input,
              FlexFlow::Tensor _label);
-  static void load_input(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_input(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
-  static void load_label(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_label(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
-  static void load_entire_dataset(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+  static void load_entire_dataset(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
   void next_batch(FlexFlow::FFModel &);

--- a/examples/cpp/Transformer/transformer.cc
+++ b/examples/cpp/Transformer/transformer.cc
@@ -20,7 +20,7 @@ using namespace Legion;
 LegionRuntime::Logger::Category log_app("Transformer");
 
 Tensor create_emb(FFModel *model,
-                  const Tensor &input,
+                  Tensor const &input,
                   int input_dim,
                   int output_dim,
                   int idx) {
@@ -31,7 +31,7 @@ Tensor create_emb(FFModel *model,
 }
 
 Tensor create_attention_encoder(FFModel *model,
-                                const Tensor &input,
+                                Tensor const &input,
                                 int hidden_dim,
                                 int num_heads,
                                 int kdim,
@@ -45,8 +45,8 @@ Tensor create_attention_encoder(FFModel *model,
 }
 
 void create_attention_encoder_decoder(FFModel *model,
-                                      const Tensor &input1,
-                                      const Tensor &input2,
+                                      Tensor const &input1,
+                                      Tensor const &input2,
                                       Tensor &output1,
                                       Tensor &output2,
                                       int hidden_dim,
@@ -109,14 +109,14 @@ void parse_input_args(char **argv, int argc, TransformerConfig &config) {
   }
 }
 
-void FlexFlow::top_level_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void FlexFlow::top_level_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   FFConfig ffConfig;
   TransformerConfig tfConfig;
   {
-    const InputArgs &command_args = HighLevelRuntime::get_input_args();
+    InputArgs const &command_args = HighLevelRuntime::get_input_args();
     char **argv = command_args.argv;
     int argc = command_args.argc;
     parse_input_args(argv, argc, tfConfig);
@@ -133,7 +133,7 @@ void FlexFlow::top_level_task(const Task *task,
   FFModel ff(ffConfig);
   Tensor input;
   {
-    const int dims[] = {
+    int const dims[] = {
         ffConfig.batchSize, tfConfig.sequence_length, tfConfig.hidden_size};
     input = ff.create_tensor<3>(dims, DT_FLOAT);
   }
@@ -211,9 +211,9 @@ void FlexFlow::top_level_task(const Task *task,
 }
 
 DataLoader::DataLoader(FFModel &ff,
-                       const TransformerConfig &tf,
-                       const Tensor &_input,
-                       const Tensor &_label) {
+                       TransformerConfig const &tf,
+                       Tensor const &_input,
+                       Tensor const &_label) {
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   num_samples = 0;
@@ -224,12 +224,12 @@ DataLoader::DataLoader(FFModel &ff,
   return;
   {
     batch_input = _input;
-    const int dims[] = {num_samples, tf.sequence_length, tf.hidden_size};
+    int const dims[] = {num_samples, tf.sequence_length, tf.hidden_size};
     full_input = ff.create_tensor<3>(dims, DT_FLOAT);
   }
   {
     batch_label = _label;
-    const int dims[] = {num_samples, tf.sequence_length, 1};
+    int const dims[] = {num_samples, tf.sequence_length, 1};
     full_label = ff.create_tensor<3>(dims, DT_FLOAT);
   }
   // Load entire dataset
@@ -254,16 +254,16 @@ DataLoader::DataLoader(FFModel &ff,
   runtime->execute_task(ctx, launcher);
 }
 
-void DataLoader::load_entire_dataset(const Task *task,
-                                     const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_entire_dataset(Task const *task,
+                                     std::vector<PhysicalRegion> const &regions,
                                      Context ctx,
                                      Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
   // Note that these instances are in ZCM, can only use
   // TensorAccessorW with readOutput flag
-  const AccessorWO<float, 3> acc_input(regions[0], FID_DATA);
-  const AccessorWO<float, 3> acc_label(regions[1], FID_DATA);
+  AccessorWO<float, 3> const acc_input(regions[0], FID_DATA);
+  AccessorWO<float, 3> const acc_label(regions[1], FID_DATA);
   Rect<3> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   Rect<3> rect_label = runtime->get_index_space_domain(

--- a/examples/cpp/Transformer/transformer.cu
+++ b/examples/cpp/Transformer/transformer.cu
@@ -16,8 +16,8 @@
 #include "flexflow/utils/cuda_helper.h"
 #include "transformer.h"
 
-void DataLoader::load_input(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_input(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);

--- a/examples/cpp/Transformer/transformer.h
+++ b/examples/cpp/Transformer/transformer.h
@@ -27,17 +27,17 @@ struct TransformerConfig {
 class DataLoader {
 public:
   DataLoader(FFModel &ff,
-             const TransformerConfig &tf,
-             const Tensor &_input,
-             const Tensor &_label);
+             TransformerConfig const &tf,
+             Tensor const &_input,
+             Tensor const &_label);
   void next_batch(FFModel &ff);
   void reset();
-  static void load_entire_dataset(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+  static void load_entire_dataset(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
-  static void load_input(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_input(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
 

--- a/examples/cpp/XDL/xdl.cu
+++ b/examples/cpp/XDL/xdl.cu
@@ -16,8 +16,8 @@
 #include "flexflow/utils/cuda_helper.h"
 #include "xdl.h"
 
-void DataLoader::load_sparse_input(const Task *task,
-                                   const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_sparse_input(Task const *task,
+                                   std::vector<PhysicalRegion> const &regions,
                                    Context ctx,
                                    Runtime *runtime) {
   assert(regions.size() == 2);
@@ -62,8 +62,8 @@ void DataLoader::load_sparse_input(const Task *task,
   // "[DataLoader:load_sparse]");
 }
 
-void DataLoader::load_label(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_label(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);

--- a/examples/cpp/XDL/xdl.h
+++ b/examples/cpp/XDL/xdl.h
@@ -40,27 +40,27 @@ struct ArgsConfig {
 class DataLoader {
 public:
   DataLoader(FFModel &ff,
-             const XDLConfig &xdl,
-             const std::vector<Tensor> &_sparse_inputs,
+             XDLConfig const &xdl,
+             std::vector<Tensor> const &_sparse_inputs,
              Tensor _label);
 
   void next_batch(FFModel &ff);
   void shuffle();
   void reset();
-  static void load_entire_dataset(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+  static void load_entire_dataset(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
-  static void load_sparse_input(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+  static void load_sparse_input(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime);
-  static void load_sparse_input_cpu(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+  static void load_sparse_input_cpu(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime);
-  static void load_label(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_label(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
 

--- a/examples/cpp/candle_uno/candle_uno.cu
+++ b/examples/cpp/candle_uno/candle_uno.cu
@@ -16,8 +16,8 @@
 #include "candle_uno.h"
 #include "flexflow/utils/cuda_helper.h"
 
-void DataLoader::load_input(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_input(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
@@ -39,7 +39,7 @@ void DataLoader::load_input(const Task *task,
   assert(batch_size == meta->num_samples);
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
-  const float *input_zc = acc_full_input.ptr + meta->idxs[0] * num_feats;
+  float const *input_zc = acc_full_input.ptr + meta->idxs[0] * num_feats;
   copy_kernel<<<GET_BLOCKS(acc_batch_input.rect.volume()), CUDA_NUM_THREADS>>>(
       acc_batch_input.ptr, input_zc, acc_batch_input.rect.volume());
   checkCUDA(cudaDeviceSynchronize());

--- a/examples/cpp/candle_uno/candle_uno.h
+++ b/examples/cpp/candle_uno/candle_uno.h
@@ -31,15 +31,15 @@ struct CandleConfig {
 class DataLoader {
 public:
   DataLoader(FFModel &ff,
-             const CandleConfig &candle,
-             const std::vector<Tensor> &_all_inputs,
+             CandleConfig const &candle,
+             std::vector<Tensor> const &_all_inputs,
              Tensor _label);
-  static void load_input(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_input(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
-  static void load_entire_dataset(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+  static void load_entire_dataset(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
   void next_batch(FFModel &);

--- a/examples/cpp/mixture_of_experts/moe.cc
+++ b/examples/cpp/mixture_of_experts/moe.cc
@@ -48,8 +48,8 @@ void parse_input_args(char **argv, int argc, MoeConfig &config) {
 
 // Score: Running average over sample ratio of which experts are corr. cached
 float moe_score(float *cached_score,
-                const void *input,
-                const void *cached,
+                void const *input,
+                void const *cached,
                 int vol) {
   float gamma = 0.99f;
   *cached_score *= gamma;
@@ -104,14 +104,14 @@ void moe_alter(FFModel *ff) {
   ff->layers[17]->input_grad_lps[1] = ff->layers[3]->outputs[0].part_grad;
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   FFConfig ffConfig;
   MoeConfig moeConfig;
   {
-    const InputArgs &command_args = HighLevelRuntime::get_input_args();
+    InputArgs const &command_args = HighLevelRuntime::get_input_args();
     char **argv = command_args.argv;
     int argc = command_args.argc;
     parse_input_args(argv, argc, moeConfig);
@@ -124,7 +124,7 @@ void top_level_task(const Task *task,
 
   Tensor input;
   {
-    const int dims[] = {ffConfig.batchSize, DATA_DIMS};
+    int const dims[] = {ffConfig.batchSize, DATA_DIMS};
     input = ff.create_tensor<2>(dims, DT_FLOAT);
   }
 
@@ -219,7 +219,7 @@ void top_level_task(const Task *task,
 }
 
 DataLoader::DataLoader(FFModel &ff,
-                       const MoeConfig &moe,
+                       MoeConfig const &moe,
                        Tensor input,
                        Tensor label) {
   num_samples = NUM_SAMPLES;
@@ -230,19 +230,19 @@ DataLoader::DataLoader(FFModel &ff,
   // Create full input
   {
     batch_input = input;
-    const int dims[] = {NUM_SAMPLES, input.adim[0]};
+    int const dims[] = {NUM_SAMPLES, input.adim[0]};
     full_input = ff.create_tensor<2>(dims, DT_FLOAT);
   }
   // Create full label
   {
     batch_label = label;
-    const int dims[] = {NUM_SAMPLES, label.adim[0]};
+    int const dims[] = {NUM_SAMPLES, label.adim[0]};
     full_label = ff.create_tensor<2>(dims, DT_INT32);
   }
 
   // Load entire dataset
   // TODO: Use index launcher instead of task launcher
-  const MoeConfig *ptr = &moe;
+  MoeConfig const *ptr = &moe;
   TaskLauncher launcher(CUSTOM_CPU_TASK_ID_1,
                         TaskArgument(&ptr, sizeof(MoeConfig *)));
   // regions[0]: full_input
@@ -365,8 +365,8 @@ void read_mnist(float *input_ptr, int *label_ptr) {
   }
 }
 
-void DataLoader::load_entire_dataset(const Task *task,
-                                     const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_entire_dataset(Task const *task,
+                                     std::vector<PhysicalRegion> const &regions,
                                      Context ctx,
                                      Runtime *runtime) {
   // const MoeConfig* conf = *((MoeConfig**)task->args);
@@ -374,8 +374,8 @@ void DataLoader::load_entire_dataset(const Task *task,
   assert(task->regions.size() == regions.size());
 
   // get input and label pointer
-  const AccessorWO<float, 2> acc_input(regions[0], FID_DATA);
-  const AccessorWO<int, 2> acc_label(regions[1], FID_DATA);
+  AccessorWO<float, 2> const acc_input(regions[0], FID_DATA);
+  AccessorWO<int, 2> const acc_label(regions[1], FID_DATA);
   Rect<2> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_input.accessor.is_dense_arbitrary(rect_input));

--- a/examples/cpp/mixture_of_experts/moe.cu
+++ b/examples/cpp/mixture_of_experts/moe.cu
@@ -16,8 +16,8 @@
 #include "cuda_helper.h"
 #include "moe.h"
 
-void DataLoader::load_input(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_input(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
@@ -42,14 +42,14 @@ void DataLoader::load_input(const Task *task,
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
   coord_t start_idx = meta->idxs[0];
-  const float *input_zc = acc_full_input.ptr + start_idx * sample_dim;
+  float const *input_zc = acc_full_input.ptr + start_idx * sample_dim;
   copy_kernel<<<GET_BLOCKS(acc_batch_input.rect.volume()), CUDA_NUM_THREADS>>>(
       acc_batch_input.ptr, input_zc, acc_batch_input.rect.volume());
   checkCUDA(cudaDeviceSynchronize());
 }
 
-void DataLoader::load_label(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_label(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
@@ -68,7 +68,7 @@ void DataLoader::load_label(const Task *task,
   assert(batch_size == meta->num_samples);
   for (int i = 1; i < meta->num_samples; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
-  const int *input_zc = acc_full_label.ptr + meta->idxs[0];
+  int const *input_zc = acc_full_label.ptr + meta->idxs[0];
   copy_kernel<<<GET_BLOCKS(acc_batch_label.rect.volume()), CUDA_NUM_THREADS>>>(
       acc_batch_label.ptr, input_zc, acc_batch_label.rect.volume());
   checkCUDA(cudaDeviceSynchronize());

--- a/examples/cpp/mixture_of_experts/moe.h
+++ b/examples/cpp/mixture_of_experts/moe.h
@@ -29,19 +29,19 @@ struct MoeConfig {
 class DataLoader {
 public:
   DataLoader(FFModel &ff,
-             const MoeConfig &alexnet,
+             MoeConfig const &alexnet,
              Tensor _input,
              Tensor _label);
-  static void load_input(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_input(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
-  static void load_label(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_label(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
-  static void load_entire_dataset(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+  static void load_entire_dataset(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
   void next_batch(FFModel &);

--- a/examples/cpp/resnext50/resnext.cc
+++ b/examples/cpp/resnext50/resnext.cc
@@ -31,8 +31,8 @@ Tensor resnext_block(FFModel &ff,
   return t;
 }
 
-void FlexFlow::top_level_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void FlexFlow::top_level_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   FFConfig ffConfig;
@@ -50,7 +50,7 @@ void FlexFlow::top_level_task(const Task *task,
 
   Tensor input;
   {
-    const int dims[] = {ffConfig.batchSize, 3, 224, 224};
+    int const dims[] = {ffConfig.batchSize, 3, 224, 224};
     input = ff.create_tensor<4>(dims, DT_FLOAT);
   }
 

--- a/examples/cpp/split_test/split_test.cc
+++ b/examples/cpp/split_test/split_test.cc
@@ -5,8 +5,8 @@ using namespace FlexFlow;
 
 LegionRuntime::Logger::Category log_app("split_test");
 
-void FlexFlow::top_level_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void FlexFlow::top_level_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   int layer_dims[4] = {256, 128, 64, 32};
@@ -20,7 +20,7 @@ void FlexFlow::top_level_task(const Task *task,
 
   Tensor input;
   {
-    const int dims[] = {1, ffConfig.batchSize, layer_dims[0]};
+    int const dims[] = {1, ffConfig.batchSize, layer_dims[0]};
     input = ff.create_tensor<3>(dims, DT_FLOAT);
     log_app.print("input size: %d %d %d", dims[0], dims[1], dims[2]);
   }

--- a/examples/cpp/split_test_2/split_test_2.cc
+++ b/examples/cpp/split_test_2/split_test_2.cc
@@ -11,8 +11,8 @@ using FlexFlow::PCG::Node;
 
 LegionRuntime::Logger::Category log_app("split_test_2");
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   FFConfig ffConfig;
@@ -24,7 +24,7 @@ void top_level_task(const Task *task,
 
   Tensor input;
   {
-    const int dims[] = {ffConfig.batchSize, 4, 32, 32};
+    int const dims[] = {ffConfig.batchSize, 4, 32, 32};
     input = ff.create_tensor<4>(dims, DT_FLOAT);
     log_app.print(
         "input size: %d %d %d %d", dims[0], dims[1], dims[2], dims[3]);

--- a/include/flexflow/accessor.h
+++ b/include/flexflow/accessor.h
@@ -53,7 +53,7 @@ struct GenericTensorAccessorR {
   DataType data_type;
   Legion::Domain domain;
   Legion::Memory memory;
-  const void *ptr;
+  void const *ptr;
 };
 
 struct GenericTensorAccessorW {

--- a/include/flexflow/config.h
+++ b/include/flexflow/config.h
@@ -109,7 +109,7 @@ public:
   // bool load_strategy_file(std::string filename);
   // bool save_strategy_file(std::string filename);
   void parse_args(char **argv, int argc);
-  static Legion::MappingTagID get_hash_id(const std::string &pcname);
+  static Legion::MappingTagID get_hash_id(std::string const &pcname);
   // bool find_parallel_config(int ndims,
   //                           const std::string& pcname,
   //                           ParallelConfig& config) const;

--- a/include/flexflow/graph.h
+++ b/include/flexflow/graph.h
@@ -29,16 +29,16 @@ namespace FlexFlow::PCG {
 
 struct Edge {
   Edge(void);
-  Edge(const Node &_srcOp, const Node &_dstOp, int _srcIdx, int _dstIdx);
-  bool operator==(const Edge &rhs) const;
+  Edge(Node const &_srcOp, Node const &_dstOp, int _srcIdx, int _dstIdx);
+  bool operator==(Edge const &rhs) const;
   Node srcOp, dstOp;
   int srcIdx, dstIdx;
 
-  void replace_node(const Node &currentOp, const Node &replaceWith);
+  void replace_node(Node const &currentOp, Node const &replaceWith);
 };
 
 struct EdgeCompare {
-  bool operator()(const Edge &a, const Edge &b) const {
+  bool operator()(Edge const &a, Edge const &b) const {
     if (!(a.srcOp == b.srcOp))
       return a.srcOp < b.srcOp;
     if (!(a.dstOp == b.dstOp))
@@ -54,7 +54,7 @@ struct EdgeCompare {
 
 namespace std {
 template <> struct hash<FlexFlow::PCG::Edge> {
-  size_t operator()(const FlexFlow::PCG::Edge &e) const {
+  size_t operator()(FlexFlow::PCG::Edge const &e) const {
     size_t res = 17;
     res = res * 31 + hash<size_t>()((size_t)e.srcOp.guid);
     res = res * 31 + hash<size_t>()((size_t)e.dstOp.guid);
@@ -65,14 +65,14 @@ template <> struct hash<FlexFlow::PCG::Edge> {
 };
 
 template <> struct hash<FlexFlow::PCG::Node> {
-  size_t operator()(const FlexFlow::PCG::Node &n) const { return n.guid; }
+  size_t operator()(FlexFlow::PCG::Node const &n) const { return n.guid; }
 };
 }; // namespace std
 
 namespace FlexFlow::PCG {
 
 struct NodeCompare {
-  bool operator()(const Node &a, const Node &b) const {
+  bool operator()(Node const &a, Node const &b) const {
     if (a.guid != b.guid)
       return a.guid < b.guid;
     return a.ptr < b.ptr;
@@ -109,12 +109,12 @@ template <typename T> T sequence_cost(T const &first, T const &second);
 
 template <typename T> T parallel_cost(T const &first, T const &second);
 
-size_t dp_state_hash(const Graph *graph,
-                     const Node &sink_node,
-                     const MachineView &sink_view,
-                     const Node &source_node,
-                     const MachineView &source_view,
-                     const MachineResource &resource);
+size_t dp_state_hash(Graph const *graph,
+                     Node const &sink_node,
+                     MachineView const &sink_view,
+                     Node const &source_node,
+                     MachineView const &source_view,
+                     MachineResource const &resource);
 
 enum class SplitType { SEQUENTIAL, VERTICAL, HORIZONTAL };
 
@@ -135,10 +135,10 @@ public:
   SearchHelper(FFModel *model);
 
   template <typename T>
-  T graph_cost(const Graph *graph,
-               const NodeAssignment &source,
-               const NodeAssignment &sink,
-               const MachineResource &resources,
+  T graph_cost(Graph const *graph,
+               NodeAssignment const &source,
+               NodeAssignment const &sink,
+               MachineResource const &resources,
                bool include_sink_compute_time) const;
   template <typename T>
   T find_optimal_sequence_graph_time(Graph const *g,
@@ -161,10 +161,10 @@ public:
    * MachineView>& optimal_views) const; */
   std::vector<MachineView>
   get_valid_machine_views(Node const &node,
-                          const MachineResource &resource,
+                          MachineResource const &resource,
                           bool log = false) const;
   std::vector<MachineView> get_valid_machine_views(
-      const Op *op, const MachineResource &resource, bool log = false) const;
+      Op const *op, MachineResource const &resource, bool log = false) const;
 
   template <typename T>
   std::pair<bool, T> try_get_cost_from_cache(size_t hash) const;
@@ -230,18 +230,18 @@ struct SimplificationSettings {
 class Graph {
 public:
   Graph(FFModel *model);
-  void add_edge(const Node &srcOp, const Node &dstOp, int srcIdx, int dstIdx);
-  void add_node(const Node &);
-  void add_edge(const Edge &e);
-  void remove_node(const Node &, bool purge_edges = false);
-  void remove_edge(const Edge &e, bool remove_node_if_unused = true);
+  void add_edge(Node const &srcOp, Node const &dstOp, int srcIdx, int dstIdx);
+  void add_node(Node const &);
+  void add_edge(Edge const &e);
+  void remove_node(Node const &, bool purge_edges = false);
+  void remove_edge(Edge const &e, bool remove_node_if_unused = true);
   bool
-  has_edge(const Node &srcOp, const Node &dstOp, int srcIdx, int dstIdx) const;
-  bool has_edge(const Edge &e) const;
+  has_edge(Node const &srcOp, Node const &dstOp, int srcIdx, int dstIdx) const;
+  bool has_edge(Edge const &e) const;
   void replace_subgraph(std::unordered_set<Node> const &currentNodes,
-                        const Graph &replaceWith);
+                        Graph const &replaceWith);
   Graph subgraph(std::unordered_set<Node> const &nodes) const;
-  void contract_out_node(const Node &);
+  void contract_out_node(Node const &);
   float optimal_cost() const;
   std::unordered_map<Node, MachineView> optimal_views() const;
   void remove_input_nodes();
@@ -262,12 +262,12 @@ public:
   bool has_loop(void);
   bool map_operators_to_layers(std::vector<Op *> &layers) const;
   static GraphOptimalViewSerialized
-  graph_optimize_task(const Legion::Task *task,
-                      const std::vector<Legion::PhysicalRegion> &regions,
+  graph_optimize_task(Legion::Task const *task,
+                      std::vector<Legion::PhysicalRegion> const &regions,
                       Legion::Context ctx,
                       Legion::Runtime *runtime);
-  Node find_bottleneck_node(const Node &sink_node,
-                            const Node &source_node) const;
+  Node find_bottleneck_node(Node const &sink_node,
+                            Node const &source_node) const;
   void print_strategy_computation_graph(
       std::unordered_map<Node, MachineView> const &strategy) const;
   void export_strategy_computation_graph(
@@ -307,7 +307,7 @@ private:
   void remove_inverse_parallel_ops();
   void
   replace_subgraph_with_nonempty(std::unordered_set<Node> const &currentNodes,
-                                 const Graph &replaceWith);
+                                 Graph const &replaceWith);
 };
 
 struct GraphOptimizeResult {

--- a/include/flexflow/initializer.h
+++ b/include/flexflow/initializer.h
@@ -27,16 +27,16 @@ class Initializer {
 public:
   Initializer(void);
   virtual ~Initializer(void);
-  virtual void init(const FFModel *ff, const ParallelTensor p) = 0;
+  virtual void init(FFModel const *ff, const ParallelTensor p) = 0;
 };
 
 class GlorotUniform : public Initializer {
 public:
   GlorotUniform(int _seed);
   ~GlorotUniform(void);
-  void init(const FFModel *ff, const ParallelTensor p);
-  static void init_task(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  void init(FFModel const *ff, const ParallelTensor p);
+  static void init_task(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
   int seed;
@@ -44,7 +44,7 @@ public:
 };
 
 struct ZeroInitMeta {
-  static const int MAX_NUM_REGIONS = 64;
+  static int const MAX_NUM_REGIONS = 64;
   int num_regions;
   DataType data_types[MAX_NUM_REGIONS];
 };
@@ -53,13 +53,13 @@ class ZeroInitializer : public Initializer {
 public:
   ZeroInitializer(void);
   ~ZeroInitializer(void);
-  void init(const FFModel *ff, const ParallelTensor p);
-  static void init_task(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  void init(FFModel const *ff, const ParallelTensor p);
+  static void init_task(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
-  static void init_task_cpu(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void init_task_cpu(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
 };
@@ -68,9 +68,9 @@ class UniformInitializer : public Initializer {
 public:
   UniformInitializer(int _seed, float _min, float _max);
   ~UniformInitializer(void);
-  void init(const FFModel *ff, const ParallelTensor p);
-  static void init_task(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  void init(FFModel const *ff, const ParallelTensor p);
+  static void init_task(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
   int seed;
@@ -81,9 +81,9 @@ class NormInitializer : public Initializer {
 public:
   NormInitializer(int _seed, float _mean, float _stddev);
   ~NormInitializer(void);
-  void init(const FFModel *ff, const ParallelTensor p);
-  static void init_task(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  void init(FFModel const *ff, const ParallelTensor p);
+  static void init_task(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
   int seed;
@@ -96,13 +96,13 @@ public:
   ConstantInitializer(int64_t _value);
   ConstantInitializer(int _value);
   ~ConstantInitializer(void);
-  void init(const FFModel *ff, const ParallelTensor p);
-  static void init_task(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  void init(FFModel const *ff, const ParallelTensor p);
+  static void init_task(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
-  static void init_task_cpu(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void init_task_cpu(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
 

--- a/include/flexflow/layer.h
+++ b/include/flexflow/layer.h
@@ -11,7 +11,7 @@ class Layer {
 public:
   Layer(FFModel *model,
         OperatorType type,
-        const char *name,
+        char const *name,
         int numInputs,
         int numWeights,
         int numOutputs,
@@ -21,21 +21,21 @@ public:
         const Tensor input4 = NULL);
   Layer(FFModel *model,
         OperatorType type,
-        const char *name,
+        char const *name,
         int numInputs,
         int numWeights,
         int numOutputs,
-        const Tensor *tensors = NULL);
-  void add_int_property(const std::string &key, long long value);
-  void add_float_property(const std::string &key, float value);
-  void add_int_vector_property(const std::string &key,
-                               const std::vector<int> &value);
-  void add_initializer(const std::string &key, Initializer *initializer);
-  bool get_int_property(const std::string &key, long long &value) const;
-  bool get_float_property(const std::string &key, float &value) const;
-  bool get_int_vector_property(const std::string &key,
+        Tensor const *tensors = NULL);
+  void add_int_property(std::string const &key, long long value);
+  void add_float_property(std::string const &key, float value);
+  void add_int_vector_property(std::string const &key,
+                               std::vector<int> const &value);
+  void add_initializer(std::string const &key, Initializer *initializer);
+  bool get_int_property(std::string const &key, long long &value) const;
+  bool get_float_property(std::string const &key, float &value) const;
+  bool get_int_vector_property(std::string const &key,
                                std::vector<int> &value) const;
-  bool get_initializer(const std::string &key, Initializer *&initializer) const;
+  bool get_initializer(std::string const &key, Initializer *&initializer) const;
   Tensor get_parameter(int index);
   void print();
 

--- a/include/flexflow/loss_functions.h
+++ b/include/flexflow/loss_functions.h
@@ -26,17 +26,17 @@ class FFModel;
 
 class Loss {
 public:
-  Loss(const std::string &loss, bool _repl_labels = false);
+  Loss(std::string const &loss, bool _repl_labels = false);
   Loss(LossType _loss_type, bool _repl_labels = false);
 
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <int NDIM>
   static void
-  backward_task_with_dim(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_dim(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   void backward(FFModel *model,
@@ -48,8 +48,8 @@ public:
                          const ParallelTensor label);
   static void sparse_categorical_crossentropy_loss_backward_kernel_wrapper(
       float *logit_grad_ptr,
-      const float *logit_ptr,
-      const int *label_ptr,
+      float const *logit_ptr,
+      int const *label_ptr,
       size_t logit_volume,
       size_t logit_grad_volume,
       int num_samples,
@@ -58,15 +58,15 @@ public:
       float scale_factor);
   static void categorical_crossentropy_loss_backward_kernel_wrapper(
       float *logit_grad_ptr,
-      const float *logit_ptr,
-      const float *label_ptr,
+      float const *logit_ptr,
+      float const *label_ptr,
       size_t logit_volume,
       size_t logit_grad_volume,
       float scale_factor);
   static void
   mean_squared_error_avg_loss_backward_kernel_wrapper(float *logit_grad_ptr,
-                                                      const float *logit_ptr,
-                                                      const float *label_ptr,
+                                                      float const *logit_ptr,
+                                                      float const *label_ptr,
                                                       size_t logit_volume,
                                                       size_t logit_grad_volume,
                                                       float scale_factor);

--- a/include/flexflow/machine_view.h
+++ b/include/flexflow/machine_view.h
@@ -15,9 +15,9 @@ struct MachineView {
   static const MachineView NO_VIEW;
   MachineView();
 
-  int get_device_id(const Legion::DomainPoint &p) const;
-  bool operator==(const MachineView &rhs) const;
-  bool operator!=(const MachineView &rhs) const;
+  int get_device_id(Legion::DomainPoint const &p) const;
+  bool operator==(MachineView const &rhs) const;
+  bool operator!=(MachineView const &rhs) const;
 
   Legion::Domain get_domain() const;
 
@@ -35,7 +35,7 @@ struct MachineView {
 };
 
 struct MachineViewDimCompare {
-  bool operator()(const MachineView &a, const MachineView &b) const {
+  bool operator()(MachineView const &a, MachineView const &b) const {
     if (a.ndims != b.ndims)
       return a.ndims < b.ndims;
     for (int i = 0; i < a.ndims; i++)
@@ -48,7 +48,7 @@ struct MachineViewDimCompare {
 struct MachineResource {
   MachineResource(FFConfig const &);
 
-  bool is_valid_machine_view(const MachineView &view) const;
+  bool is_valid_machine_view(MachineView const &view) const;
   size_t hash() const;
   int num_nodes;
   int all_cpus_per_node, available_cpus_per_node;
@@ -61,7 +61,7 @@ struct ParallelConfig {
     GPU = 0,
     CPU = 1,
   };
-  bool operator==(const ParallelConfig &rhs) const {
+  bool operator==(ParallelConfig const &rhs) const {
     if (nDims != rhs.nDims)
       return false;
     if (device_type != rhs.device_type)

--- a/include/flexflow/mapper.h
+++ b/include/flexflow/mapper.h
@@ -31,12 +31,12 @@ public:
   FFShardingFunctor(int gpus_per_node,
                     int cpus_per_node,
                     int num_nodes,
-                    const MachineView &_mv);
+                    MachineView const &_mv);
   ~FFShardingFunctor(void);
 
 public:
-  ShardID shard(const DomainPoint &point,
-                const Domain &full_space,
+  ShardID shard(DomainPoint const &point,
+                Domain const &full_space,
                 const size_t total_shards);
 
 private:
@@ -56,291 +56,291 @@ public:
   FFMapper(MapperRuntime *rt,
            Machine machine,
            Processor local,
-           const char *mapper_name, // const std::string& strategyFile,
+           char const *mapper_name, // const std::string& strategyFile,
            bool _enable_control_replication,
            bool _log_instance_creation);
   ~FFMapper();
-  virtual const char *get_mapper_name(void) const;
+  virtual char const *get_mapper_name(void) const;
   virtual MapperSyncModel get_mapper_sync_model(void) const;
 
 public:
   static void update_mappers(Machine machine,
                              Runtime *rt,
-                             const std::set<Processor> &local_procs);
+                             std::set<Processor> const &local_procs);
   static void register_sharding_functor(int argv, char **argc);
   virtual void select_task_options(const MapperContext ctx,
-                                   const Task &task,
+                                   Task const &task,
                                    TaskOptions &output);
   virtual void premap_task(const MapperContext ctx,
-                           const Task &task,
-                           const PremapTaskInput &input,
+                           Task const &task,
+                           PremapTaskInput const &input,
                            PremapTaskOutput &output);
   virtual void slice_task(const MapperContext ctx,
-                          const Task &task,
-                          const SliceTaskInput &input,
+                          Task const &task,
+                          SliceTaskInput const &input,
                           SliceTaskOutput &output);
   virtual void map_task(const MapperContext ctx,
-                        const Task &task,
-                        const MapTaskInput &input,
+                        Task const &task,
+                        MapTaskInput const &input,
                         MapTaskOutput &output);
   virtual void map_replicate_task(const MapperContext ctx,
-                                  const Task &task,
-                                  const MapTaskInput &input,
-                                  const MapTaskOutput &default_output,
+                                  Task const &task,
+                                  MapTaskInput const &input,
+                                  MapTaskOutput const &default_output,
                                   MapReplicateTaskOutput &output);
   virtual void select_task_variant(const MapperContext ctx,
-                                   const Task &task,
-                                   const SelectVariantInput &input,
+                                   Task const &task,
+                                   SelectVariantInput const &input,
                                    SelectVariantOutput &output);
   virtual void postmap_task(const MapperContext ctx,
-                            const Task &task,
-                            const PostMapInput &input,
+                            Task const &task,
+                            PostMapInput const &input,
                             PostMapOutput &output);
   virtual void select_task_sources(const MapperContext ctx,
-                                   const Task &task,
-                                   const SelectTaskSrcInput &input,
+                                   Task const &task,
+                                   SelectTaskSrcInput const &input,
                                    SelectTaskSrcOutput &output);
   virtual void
   create_task_temporary_instance(const MapperContext ctx,
-                                 const Task &task,
-                                 const CreateTaskTemporaryInput &input,
+                                 Task const &task,
+                                 CreateTaskTemporaryInput const &input,
                                  CreateTaskTemporaryOutput &output);
   virtual void speculate(const MapperContext ctx,
-                         const Task &task,
+                         Task const &task,
                          SpeculativeOutput &output);
   virtual void report_profiling(const MapperContext ctx,
-                                const Task &task,
-                                const TaskProfilingInfo &input);
+                                Task const &task,
+                                TaskProfilingInfo const &input);
   virtual void select_sharding_functor(const MapperContext ctx,
-                                       const Task &task,
-                                       const SelectShardingFunctorInput &input,
+                                       Task const &task,
+                                       SelectShardingFunctorInput const &input,
                                        SelectShardingFunctorOutput &output);
 
 public: // Inline mapping calls
   virtual void map_inline(const MapperContext ctx,
-                          const InlineMapping &inline_op,
-                          const MapInlineInput &input,
+                          InlineMapping const &inline_op,
+                          MapInlineInput const &input,
                           MapInlineOutput &output);
   virtual void select_inline_sources(const MapperContext ctx,
-                                     const InlineMapping &inline_op,
-                                     const SelectInlineSrcInput &input,
+                                     InlineMapping const &inline_op,
+                                     SelectInlineSrcInput const &input,
                                      SelectInlineSrcOutput &output);
   virtual void
   create_inline_temporary_instance(const MapperContext ctx,
-                                   const InlineMapping &inline_op,
-                                   const CreateInlineTemporaryInput &input,
+                                   InlineMapping const &inline_op,
+                                   CreateInlineTemporaryInput const &input,
                                    CreateInlineTemporaryOutput &output);
   virtual void report_profiling(const MapperContext ctx,
-                                const InlineMapping &inline_op,
-                                const InlineProfilingInfo &input);
+                                InlineMapping const &inline_op,
+                                InlineProfilingInfo const &input);
 
 public: // Copy mapping calls
   virtual void map_copy(const MapperContext ctx,
-                        const Copy &copy,
-                        const MapCopyInput &input,
+                        Copy const &copy,
+                        MapCopyInput const &input,
                         MapCopyOutput &output);
   virtual void select_copy_sources(const MapperContext ctx,
-                                   const Copy &copy,
-                                   const SelectCopySrcInput &input,
+                                   Copy const &copy,
+                                   SelectCopySrcInput const &input,
                                    SelectCopySrcOutput &output);
   virtual void
   create_copy_temporary_instance(const MapperContext ctx,
-                                 const Copy &copy,
-                                 const CreateCopyTemporaryInput &input,
+                                 Copy const &copy,
+                                 CreateCopyTemporaryInput const &input,
                                  CreateCopyTemporaryOutput &output);
   virtual void speculate(const MapperContext ctx,
-                         const Copy &copy,
+                         Copy const &copy,
                          SpeculativeOutput &output);
   virtual void report_profiling(const MapperContext ctx,
-                                const Copy &copy,
-                                const CopyProfilingInfo &input);
+                                Copy const &copy,
+                                CopyProfilingInfo const &input);
   virtual void select_sharding_functor(const MapperContext ctx,
-                                       const Copy &copy,
-                                       const SelectShardingFunctorInput &input,
+                                       Copy const &copy,
+                                       SelectShardingFunctorInput const &input,
                                        SelectShardingFunctorOutput &output);
 
 public: // Close mapping calls
   virtual void map_close(const MapperContext ctx,
-                         const Close &close,
-                         const MapCloseInput &input,
+                         Close const &close,
+                         MapCloseInput const &input,
                          MapCloseOutput &output);
   virtual void select_close_sources(const MapperContext ctx,
-                                    const Close &close,
-                                    const SelectCloseSrcInput &input,
+                                    Close const &close,
+                                    SelectCloseSrcInput const &input,
                                     SelectCloseSrcOutput &output);
   virtual void
   create_close_temporary_instance(const MapperContext ctx,
-                                  const Close &close,
-                                  const CreateCloseTemporaryInput &input,
+                                  Close const &close,
+                                  CreateCloseTemporaryInput const &input,
                                   CreateCloseTemporaryOutput &output);
   virtual void report_profiling(const MapperContext ctx,
-                                const Close &close,
-                                const CloseProfilingInfo &input);
+                                Close const &close,
+                                CloseProfilingInfo const &input);
   virtual void select_sharding_functor(const MapperContext ctx,
-                                       const Close &close,
-                                       const SelectShardingFunctorInput &input,
+                                       Close const &close,
+                                       SelectShardingFunctorInput const &input,
                                        SelectShardingFunctorOutput &output);
 
 public: // Acquire mapping calls
   virtual void map_acquire(const MapperContext ctx,
-                           const Acquire &acquire,
-                           const MapAcquireInput &input,
+                           Acquire const &acquire,
+                           MapAcquireInput const &input,
                            MapAcquireOutput &output);
   virtual void speculate(const MapperContext ctx,
-                         const Acquire &acquire,
+                         Acquire const &acquire,
                          SpeculativeOutput &output);
   virtual void report_profiling(const MapperContext ctx,
-                                const Acquire &acquire,
-                                const AcquireProfilingInfo &input);
+                                Acquire const &acquire,
+                                AcquireProfilingInfo const &input);
   virtual void select_sharding_functor(const MapperContext ctx,
-                                       const Acquire &acquire,
-                                       const SelectShardingFunctorInput &input,
+                                       Acquire const &acquire,
+                                       SelectShardingFunctorInput const &input,
                                        SelectShardingFunctorOutput &output);
 
 public: // Release mapping calls
   virtual void map_release(const MapperContext ctx,
-                           const Release &release,
-                           const MapReleaseInput &input,
+                           Release const &release,
+                           MapReleaseInput const &input,
                            MapReleaseOutput &output);
   virtual void select_release_sources(const MapperContext ctx,
-                                      const Release &release,
-                                      const SelectReleaseSrcInput &input,
+                                      Release const &release,
+                                      SelectReleaseSrcInput const &input,
                                       SelectReleaseSrcOutput &output);
   virtual void
   create_release_temporary_instance(const MapperContext ctx,
-                                    const Release &release,
-                                    const CreateReleaseTemporaryInput &input,
+                                    Release const &release,
+                                    CreateReleaseTemporaryInput const &input,
                                     CreateReleaseTemporaryOutput &output);
   virtual void speculate(const MapperContext ctx,
-                         const Release &release,
+                         Release const &release,
                          SpeculativeOutput &output);
   virtual void report_profiling(const MapperContext ctx,
-                                const Release &release,
-                                const ReleaseProfilingInfo &input);
+                                Release const &release,
+                                ReleaseProfilingInfo const &input);
   virtual void select_sharding_functor(const MapperContext ctx,
-                                       const Release &release,
-                                       const SelectShardingFunctorInput &input,
+                                       Release const &release,
+                                       SelectShardingFunctorInput const &input,
                                        SelectShardingFunctorOutput &output);
 
 public: // Partition mapping calls
   virtual void
   select_partition_projection(const MapperContext ctx,
-                              const Partition &partition,
-                              const SelectPartitionProjectionInput &input,
+                              Partition const &partition,
+                              SelectPartitionProjectionInput const &input,
                               SelectPartitionProjectionOutput &output);
   virtual void map_partition(const MapperContext ctx,
-                             const Partition &partition,
-                             const MapPartitionInput &input,
+                             Partition const &partition,
+                             MapPartitionInput const &input,
                              MapPartitionOutput &output);
   virtual void select_partition_sources(const MapperContext ctx,
-                                        const Partition &partition,
-                                        const SelectPartitionSrcInput &input,
+                                        Partition const &partition,
+                                        SelectPartitionSrcInput const &input,
                                         SelectPartitionSrcOutput &output);
   virtual void create_partition_temporary_instance(
       const MapperContext ctx,
-      const Partition &partition,
-      const CreatePartitionTemporaryInput &input,
+      Partition const &partition,
+      CreatePartitionTemporaryInput const &input,
       CreatePartitionTemporaryOutput &output);
   virtual void report_profiling(const MapperContext ctx,
-                                const Partition &partition,
-                                const PartitionProfilingInfo &input);
+                                Partition const &partition,
+                                PartitionProfilingInfo const &input);
   virtual void select_sharding_functor(const MapperContext ctx,
-                                       const Partition &partition,
-                                       const SelectShardingFunctorInput &input,
+                                       Partition const &partition,
+                                       SelectShardingFunctorInput const &input,
                                        SelectShardingFunctorOutput &output);
 
 public: // Fill mapper calls
   virtual void select_sharding_functor(const MapperContext ctx,
-                                       const Fill &fill,
-                                       const SelectShardingFunctorInput &input,
+                                       Fill const &fill,
+                                       SelectShardingFunctorInput const &input,
                                        SelectShardingFunctorOutput &output);
 
 public: // Task execution mapping calls
   virtual void configure_context(const MapperContext ctx,
-                                 const Task &task,
+                                 Task const &task,
                                  ContextConfigOutput &output);
   virtual void select_tunable_value(const MapperContext ctx,
-                                    const Task &task,
-                                    const SelectTunableInput &input,
+                                    Task const &task,
+                                    SelectTunableInput const &input,
                                     SelectTunableOutput &output);
 
 public: // Must epoch mapping
   virtual void select_sharding_functor(const MapperContext ctx,
-                                       const MustEpoch &epoch,
-                                       const SelectShardingFunctorInput &input,
+                                       MustEpoch const &epoch,
+                                       SelectShardingFunctorInput const &input,
                                        MustEpochShardingFunctorOutput &output);
   virtual void map_must_epoch(const MapperContext ctx,
-                              const MapMustEpochInput &input,
+                              MapMustEpochInput const &input,
                               MapMustEpochOutput &output);
 
 public: // Dataflow graph mapping
   virtual void map_dataflow_graph(const MapperContext ctx,
-                                  const MapDataflowGraphInput &input,
+                                  MapDataflowGraphInput const &input,
                                   MapDataflowGraphOutput &output);
 
 public: // Memoization control
   virtual void memoize_operation(const MapperContext ctx,
-                                 const Mappable &mappable,
-                                 const MemoizeInput &input,
+                                 Mappable const &mappable,
+                                 MemoizeInput const &input,
                                  MemoizeOutput &output);
 
 public: // Mapping control and stealing
   virtual void select_tasks_to_map(const MapperContext ctx,
-                                   const SelectMappingInput &input,
+                                   SelectMappingInput const &input,
                                    SelectMappingOutput &output);
   virtual void select_steal_targets(const MapperContext ctx,
-                                    const SelectStealingInput &input,
+                                    SelectStealingInput const &input,
                                     SelectStealingOutput &output);
   virtual void permit_steal_request(const MapperContext ctx,
-                                    const StealRequestInput &intput,
+                                    StealRequestInput const &intput,
                                     StealRequestOutput &output);
 
 private: // static inline methods
   static inline bool
-  physical_sort_func(const std::pair<PhysicalInstance, unsigned> &left,
-                     const std::pair<PhysicalInstance, unsigned> &right) {
+  physical_sort_func(std::pair<PhysicalInstance, unsigned> const &left,
+                     std::pair<PhysicalInstance, unsigned> const &right) {
     return (left.second < right.second);
   }
 
 private: // Default helper functions
   Memory default_select_target_memory(MapperContext ctx,
                                       Processor target_proc,
-                                      const RegionRequirement &req);
+                                      RegionRequirement const &req);
   bool default_make_instance(MapperContext ctx,
                              Memory target_mem,
-                             const LayoutConstraintSet &constraints,
+                             LayoutConstraintSet const &constraints,
                              PhysicalInstance &result,
                              bool meets_constraints,
-                             const RegionRequirement &req,
+                             RegionRequirement const &req,
                              bool &created,
                              size_t *footprint);
   LayoutConstraintID
   default_select_layout_constraints(MapperContext ctx,
                                     Memory target_memory,
-                                    const RegionRequirement &req,
+                                    RegionRequirement const &req,
                                     bool needs_field_constraint_check);
   void default_select_constraints(MapperContext ctx,
                                   LayoutConstraintSet &constraints,
                                   Memory target_memory,
-                                  const RegionRequirement &req);
+                                  RegionRequirement const &req);
   void
   default_policy_select_sources(MapperContext ctx,
-                                const PhysicalInstance &target,
-                                const std::vector<PhysicalInstance> &sources,
+                                PhysicalInstance const &target,
+                                std::vector<PhysicalInstance> const &sources,
                                 std::deque<PhysicalInstance> &ranking,
                                 Memory preferred_memory = Memory::NO_MEMORY);
 
 private:
-  unsigned long long compute_task_hash(const Task &task);
+  unsigned long long compute_task_hash(Task const &task);
   bool is_parameter_server_update_task(TaskID tid);
   bool is_initializer_task(TaskID tid);
-  const std::vector<Processor> &all_procs_by_kind(Processor::Kind kind);
+  std::vector<Processor> const &all_procs_by_kind(Processor::Kind kind);
 
 protected:
   const Processor local_processor;
   const AddressSpace node_id;
   int total_nodes;
-  const char *mapper_name;
+  char const *mapper_name;
   bool enable_control_replication;
   bool log_instance_creation;
   std::vector<Processor> all_gpus, all_cpus, all_pys, local_gpus, local_cpus,

--- a/include/flexflow/metrics_functions.h
+++ b/include/flexflow/metrics_functions.h
@@ -27,9 +27,9 @@ class Metrics;
 class PerfMetrics {
 public:
   PerfMetrics(void);
-  void update(const PerfMetrics &one);
+  void update(PerfMetrics const &one);
   void apply_scale(float scale_factor);
-  void print(const Metrics *m);
+  void print(Metrics const *m);
 
 public:
   int train_all, train_correct; // measure_accuracy
@@ -43,27 +43,27 @@ public:
 
 class Metrics {
 public:
-  Metrics(LossType _loss_type, const std::vector<MetricsType> &metrics);
+  Metrics(LossType _loss_type, std::vector<MetricsType> const &metrics);
   static PerfMetrics
-  compute_task(const Legion::Task *task,
-               const std::vector<Legion::PhysicalRegion> &regions,
+  compute_task(Legion::Task const *task,
+               std::vector<Legion::PhysicalRegion> const &regions,
                Legion::Context ctx,
                Legion::Runtime *runtime);
   template <int NDIM>
   static PerfMetrics
-  compute_task_with_dim(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  compute_task_with_dim(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
-  static void update_metrics_sparse_label_kernel_wrapper(const float *logit_ptr,
-                                                         const int *label_ptr,
-                                                         const Metrics *me,
+  static void update_metrics_sparse_label_kernel_wrapper(float const *logit_ptr,
+                                                         int const *label_ptr,
+                                                         Metrics const *me,
                                                          int num_samples,
                                                          int num_classes,
                                                          PerfMetrics &perf_zc);
-  static void update_metrics_label_kernel_wrapper(const float *logit_ptr,
-                                                  const float *label_ptr,
-                                                  const Metrics *me,
+  static void update_metrics_label_kernel_wrapper(float const *logit_ptr,
+                                                  float const *label_ptr,
+                                                  Metrics const *me,
                                                   int num_samples,
                                                   int num_classes,
                                                   PerfMetrics &perf_zc);

--- a/include/flexflow/model.h
+++ b/include/flexflow/model.h
@@ -232,14 +232,14 @@ class ParallelOp;
 std::string optype_to_string(OperatorType);
 
 void solve_parallel_dim_mappings(
-    const std::vector<ParallelDimMappingRecord> &mapping,
-    const std::vector<ParallelDim const *> &inputs,
-    const std::vector<ParallelDim *> &weights,
-    const std::vector<ParallelDim *> &outputs);
+    std::vector<ParallelDimMappingRecord> const &mapping,
+    std::vector<ParallelDim const *> const &inputs,
+    std::vector<ParallelDim *> const &weights,
+    std::vector<ParallelDim *> const &outputs);
 std::unordered_map<int, int>
-output_to_input_mapping(const std::vector<ParallelDimMappingRecord> &mapping);
+output_to_input_mapping(std::vector<ParallelDimMappingRecord> const &mapping);
 std::unordered_map<int, int>
-input_to_output_mapping(const std::vector<ParallelDimMappingRecord> &mapping);
+input_to_output_mapping(std::vector<ParallelDimMappingRecord> const &mapping);
 
 class NoOp;
 
@@ -290,19 +290,19 @@ struct ToShape<Container<Args...>> {
 
 // TODO: Move to an appropriate place
 template <typename Input>
-typename ToShape<Input>::type get_input_shape(const Input &input) = delete;
+typename ToShape<Input>::type get_input_shape(Input const &input) = delete;
 
-template <> std::tuple<> get_input_shape(const std::tuple<> &);
+template <> std::tuple<> get_input_shape(std::tuple<> const &);
 
-template <> ParallelTensorShape get_input_shape(const ParallelTensor &input);
+template <> ParallelTensorShape get_input_shape(ParallelTensor const &input);
 
 template <>
 std::pair<ParallelTensorShape, ParallelTensorShape>
-get_input_shape(const std::pair<ParallelTensor, ParallelTensor> &inputs);
+get_input_shape(std::pair<ParallelTensor, ParallelTensor> const &inputs);
 
 template <>
 std::vector<ParallelTensorShape>
-get_input_shape(const std::vector<ParallelTensor> &inputs);
+get_input_shape(std::vector<ParallelTensor> const &inputs);
 
 class FFModel {
 public:
@@ -314,7 +314,7 @@ public:
 
   // C++ APIs for constructing models
   // Add an exp layer
-  Tensor exp(const Tensor x, const char *name = NULL);
+  Tensor exp(const Tensor x, char const *name = NULL);
   // Add an add layer
   Tensor add(const Tensor x,
              const Tensor y,
@@ -339,33 +339,33 @@ public:
   Tensor rsqrt(const Tensor x, bool inplace = true, char const *name = NULL);
   // Add a pow layer
   Tensor pow(const Tensor x,
-             const float exponent,
+             float const exponent,
              bool inplace = true,
              char const *name = NULL);
   // Add a scalar multiply layer
   Tensor scalar_multiply(const Tensor x,
-                         const float scalar,
+                         float const scalar,
                          bool inplace = true,
-                         const char *name = NULL);
+                         char const *name = NULL);
   Tensor scalar_add(const Tensor x,
-                    const float scalar,
+                    float const scalar,
                     bool inplace = true,
-                    const char *name = NULL);
+                    char const *name = NULL);
   Tensor scalar_sub(const Tensor x,
-                    const float scalar,
+                    float const scalar,
                     bool inplace = true,
-                    const char *name = NULL);
+                    char const *name = NULL);
   Tensor scalar_truediv(const Tensor x,
-                        const float scalar,
+                        float const scalar,
                         bool inplace = true,
-                        const char *name = NULL);
+                        char const *name = NULL);
   // Add an activation layer
-  Tensor relu(const Tensor x, bool inplace = true, const char *name = NULL);
-  Tensor identity(const Tensor x, const char *name = NULL);
-  Tensor gelu(const Tensor x, const char *name = NULL);
-  Tensor sigmoid(const Tensor x, const char *name = NULL);
-  Tensor tanh(const Tensor x, const char *name = NULL);
-  Tensor elu(const Tensor x, bool inplace = true, const char *name = NULL);
+  Tensor relu(const Tensor x, bool inplace = true, char const *name = NULL);
+  Tensor identity(const Tensor x, char const *name = NULL);
+  Tensor gelu(const Tensor x, char const *name = NULL);
+  Tensor sigmoid(const Tensor x, char const *name = NULL);
+  Tensor tanh(const Tensor x, char const *name = NULL);
+  Tensor elu(const Tensor x, bool inplace = true, char const *name = NULL);
   // Add a 2D convolutional layer
   Tensor conv2d(const Tensor input,
                 int outChannels,
@@ -378,46 +378,46 @@ public:
                 ActiMode activation = AC_MODE_NONE,
                 int groups = 1,
                 bool use_bias = true,
-                const Layer *shared_op = NULL,
+                Layer const *shared_op = NULL,
                 Initializer *krenel_initializer = NULL,
                 Initializer *bias_initializer = NULL,
-                const char *name = NULL);
+                char const *name = NULL);
   // Add a dropout layer
   Tensor dropout(const Tensor input,
                  float rate,
                  unsigned long long seed = 0,
-                 const char *name = NULL);
+                 char const *name = NULL);
   // Add an embedding layer
   Tensor embedding(const Tensor input,
                    int num_entires,
                    int outDim,
                    AggrMode aggr,
-                   const Layer *shared_op = NULL,
+                   Layer const *shared_op = NULL,
                    Initializer *kernel_initializer = NULL,
-                   const char *name = NULL);
+                   char const *name = NULL);
   // Add a group_by layer
   void group_by(const Tensor data,
                 const Tensor assign,
                 Tensor *outputs,
                 int n,
                 float alpha,
-                const char *name = NULL);
+                char const *name = NULL);
   // Add a cache layer
-  Tensor cache(const Tensor &input,
+  Tensor cache(Tensor const &input,
                int num_batches,
-               std::function<float(float *, const void *, const void *, int)>
+               std::function<float(float *, void const *, void const *, int)>
                    score_f = {},
-               const char *name = NULL);
+               char const *name = NULL);
   // Add aggregate layer
-  Tensor aggregate(const Tensor *inputs,
+  Tensor aggregate(Tensor const *inputs,
                    int n,
                    float lambda_bal,
-                   const char *name = NULL);
+                   char const *name = NULL);
   // Add aggregate_spec layer
-  Tensor aggregate_spec(const Tensor *inputs,
+  Tensor aggregate_spec(Tensor const *inputs,
                         int n,
                         float lambda_bal,
-                        const char *name = NULL);
+                        char const *name = NULL);
   // Add a 2D pooling layer
   Tensor pool2d(const Tensor input,
                 int kernelH,
@@ -428,16 +428,16 @@ public:
                 int paddingW,
                 PoolType type = POOL_MAX,
                 ActiMode activation = AC_MODE_NONE,
-                const char *name = NULL);
+                char const *name = NULL);
   // Add a batch_norm layer
   Tensor layer_norm(const Tensor input,
-                    const std::vector<int> &axes,
+                    std::vector<int> const &axes,
                     bool elementwise_affine,
                     float eps,
-                    const char *name = NULL);
+                    char const *name = NULL);
   // Add a batch_norm layer
   Tensor
-  batch_norm(const Tensor input, bool relu = true, const char *name = NULL);
+  batch_norm(const Tensor input, bool relu = true, char const *name = NULL);
   // Add a batch_matmul layer
   Tensor batch_matmul(const Tensor A,
                       const Tensor B,
@@ -449,43 +449,43 @@ public:
                ActiMode activation = AC_MODE_NONE,
                bool use_bias = true,
                DataType data_type = DT_FLOAT,
-               const Layer *shared_op = NULL,
+               Layer const *shared_op = NULL,
                Initializer *kernel_initializer = NULL,
                Initializer *bias_initializer = NULL,
-               const char *name = NULL);
+               char const *name = NULL);
   // Add a cast layer
-  Tensor cast(const Tensor input, DataType dtype, const char *name);
+  Tensor cast(const Tensor input, DataType dtype, char const *name);
   // Add a concat layer
   Tensor
-  concat(int n, const Tensor *tensors, int axis, const char *name = NULL);
+  concat(int n, Tensor const *tensors, int axis, char const *name = NULL);
   // Add a mean layer
   Tensor mean(const Tensor input,
-              const std::vector<int> &dims,
+              std::vector<int> const &dims,
               bool keepdims,
-              const char *name);
+              char const *name);
   // Add a split layer
   void split(const Tensor input,
              Tensor *outputs,
-             const std::vector<int> &split,
+             std::vector<int> const &split,
              int axis,
-             const char *name = NULL);
+             char const *name = NULL);
   // Add a flat layer
-  Tensor flat(const Tensor input, const char *name = NULL);
+  Tensor flat(const Tensor input, char const *name = NULL);
   // Add a softmax layer
-  Tensor softmax(const Tensor input, int dim = -1, const char *name = NULL);
+  Tensor softmax(const Tensor input, int dim = -1, char const *name = NULL);
   // Create input tensors and constants
   Tensor transpose(const Tensor input,
-                   const std::vector<int> &perm,
-                   const char *name = NULL);
+                   std::vector<int> const &perm,
+                   char const *name = NULL);
   Tensor reshape(const Tensor input,
-                 const std::vector<int> &shape,
-                 const char *name = NULL);
-  Tensor reverse(const Tensor input, int axis, const char *name = NULL);
+                 std::vector<int> const &shape,
+                 char const *name = NULL);
+  Tensor reverse(const Tensor input, int axis, char const *name = NULL);
   void top_k(const Tensor input,
              Tensor *outputs,
              int k,
              bool sorted,
-             const char *name = NULL);
+             char const *name = NULL);
   Tensor multihead_attention(const Tensor query,
                              const Tensor key,
                              const Tensor value,
@@ -498,60 +498,60 @@ public:
                              bool add_bias_kv = false,
                              bool add_zero_attn = false,
                              Initializer *kernel_initializer = NULL,
-                             const char *name = NULL);
+                             char const *name = NULL);
   Tensor create_tensor_legion_ordering(int num_dim,
-                                       const int dims[],
+                                       int const dims[],
                                        DataType data_type,
-                                       const Layer *owner_op = NULL,
+                                       Layer const *owner_op = NULL,
                                        int owner_idx = 0,
                                        bool create_grad = true);
   ParallelTensor
   create_parallel_tensor_legion_ordering(int num_dim,
                                          const ParallelDim dims[],
                                          DataType data_type,
-                                         const Op *owner_op = NULL,
+                                         Op const *owner_op = NULL,
                                          int owner_idx = 0,
                                          bool create_grad = true,
                                          size_t input_tensor_guid = 0);
   Tensor create_tensor(int num_dim,
-                       const int dims[],
+                       int const dims[],
                        DataType data_type,
-                       const Layer *owner_op = NULL,
+                       Layer const *owner_op = NULL,
                        int owner_idx = 0,
                        bool create_grad = true);
   ParallelTensor create_parallel_tensor(int num_dim,
                                         const ParallelDim dims[],
                                         DataType data_type,
-                                        const Op *owner_op = NULL,
+                                        Op const *owner_op = NULL,
                                         int owner_idx = 0,
                                         bool create_grad = true,
                                         size_t input_tensor_guid = 0);
   template <int NDIM>
-  Tensor create_tensor(const int dims[],
+  Tensor create_tensor(int const dims[],
                        DataType data_type,
-                       const Layer *owner_op = NULL,
+                       Layer const *owner_op = NULL,
                        int owner_idx = 0,
                        bool create_grad = true);
   template <int NDIM>
   ParallelTensor create_parallel_tensor(const ParallelDim dims[],
                                         DataType data_type,
-                                        const Op *owner_op = NULL,
+                                        Op const *owner_op = NULL,
                                         int owner_idx = 0,
                                         bool create_grad = true,
                                         size_t input_tensor_guid = 0);
   Parameter
   create_weight(int numdim,
-                const int dims[],
+                int const dims[],
                 DataType data_type,
-                const Layer *owner_op = NULL,
+                Layer const *owner_op = NULL,
                 bool create_grad = true,
                 Initializer *initializer = NULL,
                 ParameterSyncType sync_type = ParameterSyncType::NONE);
   Parameter create_weight_legion_ordering(
       int numdim,
-      const int dims[],
+      int const dims[],
       DataType data_type,
-      const Layer *owner_op = NULL,
+      Layer const *owner_op = NULL,
       bool create_grad = true,
       Initializer *initializer = NULL,
       ParameterSyncType sync_type = ParameterSyncType::NONE);
@@ -559,7 +559,7 @@ public:
   ParallelParameter
   create_parallel_weight(const ParallelDim dims[],
                          DataType data_type,
-                         const Op *owner_op = NULL,
+                         Op const *owner_op = NULL,
                          bool create_grad = true,
                          Initializer *initializer = NULL,
                          ParameterSyncType sync_type = ParameterSyncType::NONE);
@@ -567,7 +567,7 @@ public:
   create_parallel_weight(int numdim,
                          const ParallelDim dims[],
                          DataType data_type,
-                         const Op *owner_op = NULL,
+                         Op const *owner_op = NULL,
                          bool create_grad = true,
                          Initializer *initializer = NULL,
                          ParameterSyncType sync_type = ParameterSyncType::NONE);
@@ -575,55 +575,55 @@ public:
       int numdim,
       const ParallelDim dims[],
       DataType data_type,
-      const Op *owner_op = NULL,
+      Op const *owner_op = NULL,
       bool create_grad = true,
       Initializer *initializer = NULL,
       ParameterSyncType sync_type = ParameterSyncType::NONE);
 
-  void map_tensor(ParallelTensor tensor, const Op *parallel_op);
-  void map_weight(ParallelTensor tensor, const Op *parallel_op);
+  void map_tensor(ParallelTensor tensor, Op const *parallel_op);
+  void map_weight(ParallelTensor tensor, Op const *parallel_op);
   bool get_parallel_tensor_from_tensor(const Tensor tensor,
                                        ParallelTensor &parallel_tensor) const;
 
   template <int NDIM>
-  Tensor create_constant(const int dims[], float value, DataType date_type);
+  Tensor create_constant(int const dims[], float value, DataType date_type);
   // ========================================
   // Parallel APIs
   // ========================================
   ParallelTensor repartition(const ParallelTensor input,
                              int partition_legion_dim,
                              int partition_degree,
-                             const char *name = NULL);
+                             char const *name = NULL);
   ParallelTensor combine(const ParallelTensor input,
                          int combine_legion_dim,
                          int combine_degree,
-                         const char *name = NULL);
+                         char const *name = NULL);
   ParallelTensor replicate(const ParallelTensor input,
                            int replicate_legion_dim,
                            int replicate_degree,
-                           const char *name = NULL);
+                           char const *name = NULL);
   ParallelTensor reduction(const ParallelTensor input,
                            int reduction_legion_dim,
                            int reduction_degree,
-                           const char *name = NULL);
+                           char const *name = NULL);
   // ========================================
   // Graph APIs
   // ========================================
   float graph_cost(const PCG::Graph *graph,
                    const PCG::Node &sink_node,
-                   const MachineView &sink_view,
+                   MachineView const &sink_view,
                    const PCG::Node &source_node,
-                   const MachineView &source_view,
-                   const MachineResource &resources,
+                   MachineView const &source_view,
+                   MachineResource const &resources,
                    bool include_sink_compute_time,
                    bool constructing_optimal_view = false);
   void construct_optimal_view(
       const PCG::Graph *graph,
       const PCG::Node &sink_node,
-      const MachineView &sink_view,
+      MachineView const &sink_view,
       const PCG::Node &source_node,
-      const MachineView &source_view,
-      const MachineResource &resources,
+      MachineView const &source_view,
+      MachineResource const &resources,
       bool include_sink_compute_time,
       float optimal_cost,
       std::unordered_map<PCG::Node, MachineView> &optimal_views);
@@ -633,7 +633,7 @@ public:
       std::unordered_map<PCG::Node, MachineView> &optimal_views);
   bool convert_graph_to_operators(
       const PCG::Graph *graph,
-      const std::unordered_map<PCG::Node, MachineView> &optimal_views);
+      std::unordered_map<PCG::Node, MachineView> const &optimal_views);
   static void register_all_machine_views(int num_nodes,
                                          int gpus_per_node,
                                          int cpus_per_node,
@@ -659,7 +659,7 @@ public:
     auto &cache = get<std::unordered_map<
         std::pair<typename ToShape<typename T::Input>::type, Params>,
         T *>>(this->cached_ops);
-    const auto &it = cache.find(key);
+    auto const &it = cache.find(key);
     if (it != cache.end()) {
       op = it->second;
     } else {
@@ -672,25 +672,25 @@ public:
   }
 
   PCG::Node get_or_create_noop_node(const ParallelTensor input);
-  PCG::Node get_or_create_input_node(const ParallelTensorShape &);
+  PCG::Node get_or_create_input_node(ParallelTensorShape const &);
   PCG::Node get_or_create_cast_node(const ParallelTensor input, DataType dtype);
   PCG::Node get_or_create_concat_node(int num_inputs,
-                                      const ParallelTensor *inputs,
+                                      ParallelTensor const *inputs,
                                       int legion_axis);
   PCG::Node get_or_create_element_binary_node(const ParallelTensor input1,
                                               const ParallelTensor input2,
                                               OperatorType type);
-  PCG::Node get_or_create_embedding_node(const LayerID &layer_guid,
+  PCG::Node get_or_create_embedding_node(LayerID const &layer_guid,
                                          const ParallelTensor input,
                                          int num_entries,
                                          int out_channels,
                                          AggrMode aggr);
-  PCG::Node get_or_create_linear_node(const LayerID &layer_guid,
+  PCG::Node get_or_create_linear_node(LayerID const &layer_guid,
                                       const ParallelTensor input,
                                       int out_dim,
                                       ActiMode activation,
                                       bool use_bias);
-  PCG::Node get_or_create_multihead_attn_node(const LayerID &layer_guid,
+  PCG::Node get_or_create_multihead_attn_node(LayerID const &layer_guid,
                                               const ParallelTensor query,
                                               const ParallelTensor key,
                                               const ParallelTensor value,
@@ -703,13 +703,13 @@ public:
                                               bool add_bias_kv,
                                               bool add_zero_attn);
   PCG::Node get_or_create_reshape_node(const ParallelTensor input,
-                                       const ReshapeParams &shape);
+                                       ReshapeParams const &shape);
   PCG::Node get_or_create_reshape_node(const ParallelTensor input,
-                                       const std::vector<int> &shape);
+                                       std::vector<int> const &shape);
   PCG::Node get_or_create_softmax_node(const ParallelTensor input,
                                        int softmax_dim);
   PCG::Node get_or_create_split_node(const ParallelTensor input,
-                                     const std::vector<int> &splits,
+                                     std::vector<int> const &splits,
                                      int legion_axis);
   PCG::Node get_or_create_repartition_node(const ParallelTensor input,
                                            int repartition_dim,
@@ -725,8 +725,8 @@ public:
                                        int combine_degree);
   PCG::Node get_or_create_fused_parallel_node(
       const ParallelTensor input,
-      const std::vector<ParallelOpInfo> &parallel_ops);
-  PCG::Node get_or_create_conv2d_node(const LayerID &layer_guid,
+      std::vector<ParallelOpInfo> const &parallel_ops);
+  PCG::Node get_or_create_conv2d_node(LayerID const &layer_guid,
                                       const ParallelTensor input,
                                       int out_channels,
                                       int kernel_h,
@@ -739,7 +739,7 @@ public:
                                       int groups,
                                       bool use_bias);
   PCG::Node get_or_create_dropout_node(const ParallelTensor input,
-                                       const DropoutParams &params);
+                                       DropoutParams const &params);
   PCG::Node get_or_create_pool2d_node(const ParallelTensor input,
                                       int kernelH,
                                       int kernelW,
@@ -761,52 +761,52 @@ public:
   // ========================================
   void create_disjoint_partition(int num_dims,
                                  const ParallelDim dims[],
-                                 const Legion::IndexSpace &part_is,
-                                 const Legion::LogicalRegion &region,
+                                 Legion::IndexSpace const &part_is,
+                                 Legion::LogicalRegion const &region,
                                  Legion::LogicalPartition &part);
   template <int NDIM, int TDIM>
   void
   create_disjoint_partition_with_dim2(const ParallelDim dims[],
-                                      const Legion::IndexSpaceT<TDIM> &part_is,
-                                      const Legion::LogicalRegion &region,
+                                      Legion::IndexSpaceT<TDIM> const &part_is,
+                                      Legion::LogicalRegion const &region,
                                       Legion::LogicalPartition &part);
   void create_aliased_partition(int num_dims,
                                 const ParallelDim dims[],
                                 int aliased_dim,
-                                const Legion::IndexSpace &part_is,
-                                const Legion::LogicalRegion &region,
+                                Legion::IndexSpace const &part_is,
+                                Legion::LogicalRegion const &region,
                                 Legion::LogicalPartition &part);
   template <int NDIM, int TDIM>
   void
   create_aliased_partition_with_dim2(const ParallelDim dims[],
                                      int aliased_dim,
-                                     const Legion::IndexSpaceT<TDIM> &part_is,
-                                     const Legion::LogicalRegion &region,
+                                     Legion::IndexSpaceT<TDIM> const &part_is,
+                                     Legion::LogicalRegion const &region,
                                      Legion::LogicalPartition &part);
 
   template <int NDIM>
   void create_disjoint_partition(const ParallelTensor tensor,
-                                 const Legion::IndexSpaceT<NDIM> &part_is,
+                                 Legion::IndexSpaceT<NDIM> const &part_is,
                                  Legion::LogicalPartition &part_fwd,
                                  Legion::LogicalPartition &part_bwd);
 
   template <int NDIM, int TDIM>
   void create_data_parallel_partition_with_diff_dims(
       const ParallelTensor tensor,
-      const Legion::IndexSpaceT<TDIM> &task_is,
+      Legion::IndexSpaceT<TDIM> const &task_is,
       Legion::LogicalPartition &part_fwd,
       Legion::LogicalPartition &part_bwd);
   template <int NDIM>
-  void map_conv_weight(ParallelTensor p, const Op *parallel_op);
+  void map_conv_weight(ParallelTensor p, Op const *parallel_op);
   template <int NDIM, int TDIM>
-  void map_linear_weight(ParallelTensor p, const Op *parallel_op);
+  void map_linear_weight(ParallelTensor p, Op const *parallel_op);
   template <int NDIM, int TDIM>
-  ParallelTensor create_linear_replica(const int *dims,
-                                       const Legion::IndexSpaceT<TDIM> &part_is,
+  ParallelTensor create_linear_replica(int const *dims,
+                                       Legion::IndexSpaceT<TDIM> const &part_is,
                                        DataType data_type);
   static PerfMetrics
-  update_metrics_task(const Legion::Task *task,
-                      const std::vector<Legion::PhysicalRegion> &regions,
+  update_metrics_task(Legion::Task const *task,
+                      std::vector<Legion::PhysicalRegion> const &regions,
                       Legion::Context ctx,
                       Legion::Runtime *runtime);
   void reset_metrics();
@@ -817,34 +817,34 @@ public:
   void get_metrics();
   void backward(int seq_length = -1);
   void update();
-  bool apply_fusion(const std::vector<Op *> &operators,
+  bool apply_fusion(std::vector<Op *> const &operators,
                     std::vector<Op *> &new_operators);
   Op *get_final_operator() const;
   void compile(LossType loss_type,
-               const std::vector<MetricsType> &metrics,
+               std::vector<MetricsType> const &metrics,
                CompMode comp_mode = COMP_MODE_TRAINING);
   void compile(Optimizer *optimizer,
                LossType loss_type,
-               const std::vector<MetricsType> &metrics,
+               std::vector<MetricsType> const &metrics,
                CompMode comp_mode = COMP_MODE_TRAINING);
   void graph_optimize(size_t budget,
                       bool only_data_parallel,
                       std::unique_ptr<PCG::Graph> &best_graph,
                       std::unordered_map<PCG::Node, MachineView> &optimal_view);
-  void mcmc_optimize(std::map<const Op *, ParallelConfig> &best,
+  void mcmc_optimize(std::map<Op const *, ParallelConfig> &best,
                      size_t budget,
                      float alpha,
                      CompMode comp_mode,
                      bool use_propagation) const;
 #ifdef FF_USE_NCCL
-  ncclComm_t *find_nccl_comms(const MachineView &view) const;
+  ncclComm_t *find_nccl_comms(MachineView const &view) const;
 #endif
 #ifdef FF_USE_PROPAGATE
   void propagate(std::map<Op *, ParallelConfig> const &current,
                  std::map<Op *, ParallelConfig> &next) const;
 #endif
-  void rewrite(const std::map<const Op *, ParallelConfig> &current,
-               std::map<const Op *, ParallelConfig> &next,
+  void rewrite(std::map<Op const *, ParallelConfig> const &current,
+               std::map<Op const *, ParallelConfig> &next,
                bool use_propagation) const;
   void recompile_on_condition(RecompileState &r);
   void zero_gradients();
@@ -854,16 +854,16 @@ public:
   get_bwd_edge_map() const;
 
   // Internal funcitons
-  Legion::IndexSpace get_or_create_task_is(const ParallelConfig &pc);
-  Legion::IndexSpace get_or_create_task_is(const MachineView &view);
-  Legion::IndexSpace get_or_create_task_is(const Legion::Domain &domain);
+  Legion::IndexSpace get_or_create_task_is(ParallelConfig const &pc);
+  Legion::IndexSpace get_or_create_task_is(MachineView const &view);
+  Legion::IndexSpace get_or_create_task_is(Legion::Domain const &domain);
   Legion::IndexSpace get_or_create_task_is(const ParallelTensor);
-  Legion::IndexSpace get_task_is(const Legion::Domain &domain) const;
-  Legion::IndexSpace get_task_is(const ParallelConfig &pc) const;
-  Legion::IndexSpace get_task_is(const MachineView &view) const;
+  Legion::IndexSpace get_task_is(Legion::Domain const &domain) const;
+  Legion::IndexSpace get_task_is(ParallelConfig const &pc) const;
+  Legion::IndexSpace get_task_is(MachineView const &view) const;
   void create_operators_from_layers();
   Op *create_operator_from_layer(Layer *layer,
-                                 const std::vector<ParallelTensor> &inputs);
+                                 std::vector<ParallelTensor> const &inputs);
   // APIs for setting iteration configs
 public:
   void set_iteration_config_sequence_length(int seq_length);
@@ -931,11 +931,11 @@ private:
   std::map<MachineView, Legion::IndexSpace, MachineViewDimCompare> all_task_is;
 
   template <int NDIM>
-  void map_tensor_with_dim(ParallelTensor tensor, const Op *parallel_op);
+  void map_tensor_with_dim(ParallelTensor tensor, Op const *parallel_op);
   template <int NDIM, int TDIM>
-  void map_tensor_with_dim2(ParallelTensor tensor, const Op *parallel_op);
+  void map_tensor_with_dim2(ParallelTensor tensor, Op const *parallel_op);
   template <int NDIM>
-  void map_weight_with_dim(ParallelTensor weight, const Op *parallel_op);
+  void map_weight_with_dim(ParallelTensor weight, Op const *parallel_op);
 
   Tensor binary(OperatorType op,
                 Tensor const x,
@@ -956,43 +956,43 @@ private:
 class UtilityTasks {
 public:
   static FFHandler
-  init_cuda_task(const Legion::Task *task,
-                 const std::vector<Legion::PhysicalRegion> &regions,
+  init_cuda_task(Legion::Task const *task,
+                 std::vector<Legion::PhysicalRegion> const &regions,
                  Legion::Context ctx,
                  Legion::Runtime *runtime);
-  static void dummy_task(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  static void dummy_task(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   static void
-  init_images_task(const Legion::Task *task,
-                   const std::vector<Legion::PhysicalRegion> &regions,
+  init_images_task(Legion::Task const *task,
+                   std::vector<Legion::PhysicalRegion> const &regions,
                    Legion::Context ctx,
                    Legion::Runtime *runtime);
   static void
-  init_labels_task(const Legion::Task *task,
-                   const std::vector<Legion::PhysicalRegion> &regions,
+  init_labels_task(Legion::Task const *task,
+                   std::vector<Legion::PhysicalRegion> const &regions,
                    Legion::Context ctx,
                    Legion::Runtime *runtime);
   static void
-  load_images_task(const Legion::Task *task,
-                   const std::vector<Legion::PhysicalRegion> &regions,
+  load_images_task(Legion::Task const *task,
+                   std::vector<Legion::PhysicalRegion> const &regions,
                    Legion::Context ctx,
                    Legion::Runtime *runtime);
   static void
-  normalize_images_task(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  normalize_images_task(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
 };
 
-void top_level_task(const Legion::Task *task,
-                    const std::vector<Legion::PhysicalRegion> &regions,
+void top_level_task(Legion::Task const *task,
+                    std::vector<Legion::PhysicalRegion> const &regions,
                     Legion::Context ctx,
                     Legion::Runtime *runtime);
 
-void data_load_task(const Legion::Task *task,
-                    const std::vector<Legion::PhysicalRegion> &regions,
+void data_load_task(Legion::Task const *task,
+                    std::vector<Legion::PhysicalRegion> const &regions,
                     Legion::Context ctx,
                     Legion::Runtime *runtime);
 

--- a/include/flexflow/node.h
+++ b/include/flexflow/node.h
@@ -12,7 +12,7 @@ namespace PCG {
 struct Node {
   Node(void);
   Node(size_t _guid, Op *_ptr) : guid(_guid), ptr(_ptr) {}
-  inline bool operator==(const Node &b) const {
+  inline bool operator==(Node const &b) const {
     if (guid != b.guid)
       return false;
     if (ptr != b.ptr)
@@ -21,7 +21,7 @@ struct Node {
       return false;
     return true;
   }
-  inline bool operator!=(const Node &b) const {
+  inline bool operator!=(Node const &b) const {
     if (guid != b.guid)
       return true;
     if (ptr != b.ptr)
@@ -30,7 +30,7 @@ struct Node {
       return false;
     return false;
   }
-  inline bool operator<(const Node &b) const {
+  inline bool operator<(Node const &b) const {
     if (guid != b.guid)
       return guid < b.guid;
     if (ptr != b.ptr)
@@ -39,13 +39,13 @@ struct Node {
       return false;
     return false;
   }
-  Node &operator=(const Node &n) {
+  Node &operator=(Node const &n) {
     guid = n.guid;
     ptr = n.ptr;
     original_guid = n.original_guid;
     return *this;
   }
-  std::string op_to_string(const Op *ptr) const;
+  std::string op_to_string(Op const *ptr) const;
   std::string to_string(void) const {
     if (ptr != NULL) {
       return op_to_string(ptr) + "_" + std::to_string(guid);
@@ -55,7 +55,7 @@ struct Node {
   }
   static const Node INVALID_NODE;
   size_t guid;
-  const Op *ptr;
+  Op const *ptr;
 
   tl::optional<size_t> original_guid = tl::nullopt;
 };

--- a/include/flexflow/operator.h
+++ b/include/flexflow/operator.h
@@ -136,7 +136,7 @@ protected:
 public:
   Op(FFModel &model,
      OperatorType type,
-     const char *_name,
+     char const *_name,
      int numInputs,
      int numWeights,
      bool allocate_weights,
@@ -147,7 +147,7 @@ public:
      const ParallelTensor input4 = NULL);
   Op(FFModel &model,
      OperatorType type,
-     const char *_name,
+     char const *_name,
      int numInputs,
      int numWeights,
      int numOutputs,
@@ -158,7 +158,7 @@ public:
   Op(int guid,
      bool profiling,
      OperatorType type,
-     const char *name,
+     char const *name,
      int numInputs,
      int numWeights,
      int numOutputs,
@@ -168,46 +168,46 @@ public:
      const ParallelTensor input4 = NULL);
   Op(FFModel &model,
      OperatorType type,
-     const char *_name,
+     char const *_name,
      int numInputs,
      int numWeights,
      int numOutputs,
-     const ParallelTensor *tensors);
+     ParallelTensor const *tensors);
   // graph substitution related methods
   virtual bool get_int_parameter(PMParameter, int *) const;
   virtual bool get_tensor_parameter(TNParameter, DIMParameter, int *) const;
   virtual bool get_input_parameter(TNParameter, DIMParameter, int *) const;
   virtual bool get_weight_parameter(TNParameter, DIMParameter, int *) const;
   // Pure virtual functions that must be implemented
-  virtual void init(const FFModel &) = 0;
-  virtual void forward(const FFModel &) = 0;
-  virtual void backward(const FFModel &) = 0;
-  virtual void print_layer(const FFModel &model) = 0;
+  virtual void init(FFModel const &) = 0;
+  virtual void forward(FFModel const &) = 0;
+  virtual void backward(FFModel const &) = 0;
+  virtual void print_layer(FFModel const &model) = 0;
   virtual bool measure_operator_cost(Simulator *sim,
-                                     const MachineView &mv,
+                                     MachineView const &mv,
                                      CostMetrics &cost_metrics) const = 0;
   virtual bool estimate_sync_cost(Simulator *sim,
-                                  const MachineView &pc,
+                                  MachineView const &pc,
                                   CostMetrics &cost_metrics) const;
   // Other virtual functions that can be optionally overwritten
-  virtual ParallelConfig get_random_parallel_config(const FFModel &ff) const;
-  virtual ParallelConfig get_data_parallel_config(const FFModel &ff) const;
-  virtual Legion::Domain get_input_tensor_shape(const ParallelConfig &pc,
+  virtual ParallelConfig get_random_parallel_config(FFModel const &ff) const;
+  virtual ParallelConfig get_data_parallel_config(FFModel const &ff) const;
+  virtual Legion::Domain get_input_tensor_shape(ParallelConfig const &pc,
                                                 int input_idx,
                                                 int part_idx) const;
-  virtual Legion::Domain get_output_tensor_shape(const ParallelConfig &pc,
+  virtual Legion::Domain get_output_tensor_shape(ParallelConfig const &pc,
                                                  int output_idx,
                                                  int part_idx) const;
-  virtual Legion::Domain get_weight_tensor_shape(const ParallelConfig &pc,
+  virtual Legion::Domain get_weight_tensor_shape(ParallelConfig const &pc,
                                                  int weight_idx,
                                                  int part_idx) const;
-  virtual bool is_valid_parallel_config(const FFModel &ff,
-                                        const ParallelConfig &pc) const;
+  virtual bool is_valid_parallel_config(FFModel const &ff,
+                                        ParallelConfig const &pc) const;
   virtual bool is_adoptable_parallel_config(FFModel const &ff,
                                             ParallelConfig const &pc) const;
   // Helper functions
-  void prefetch(const FFModel &);
-  void zero_grad(const FFModel &);
+  void prefetch(FFModel const &);
+  void zero_grad(FFModel const &);
   ParallelTensor get_parameter(int index);
   virtual bool can_inplace_output();
   virtual bool has_inplace_output();
@@ -224,28 +224,28 @@ public:
   int get_dimension() const;
 #ifdef FF_USE_NCCL
   static ncclUniqueId
-  get_nccl_unique_id_task(const Legion::Task *task,
-                          const std::vector<Legion::PhysicalRegion> &regions,
+  get_nccl_unique_id_task(Legion::Task const *task,
+                          std::vector<Legion::PhysicalRegion> const &regions,
                           Legion::Context ctx,
                           Legion::Runtime *runtime);
   static ncclComm_t
-  init_nccl_comms_task(const Legion::Task *task,
-                       const std::vector<Legion::PhysicalRegion> &regions,
+  init_nccl_comms_task(Legion::Task const *task,
+                       std::vector<Legion::PhysicalRegion> const &regions,
                        Legion::Context ctx,
                        Legion::Runtime *runtime);
 #endif
 protected:
-  void set_argumentmap_for_init(const FFModel &ff, Legion::ArgumentMap &argmap);
-  void set_argumentmap_for_forward(const FFModel &ff,
+  void set_argumentmap_for_init(FFModel const &ff, Legion::ArgumentMap &argmap);
+  void set_argumentmap_for_forward(FFModel const &ff,
                                    Legion::ArgumentMap &argmap);
-  void set_argumentmap_for_backward(const FFModel &ff,
+  void set_argumentmap_for_backward(FFModel const &ff,
                                     Legion::ArgumentMap &argmap);
-  void set_opmeta_from_futuremap(const FFModel &ff,
-                                 const Legion::FutureMap &fm);
+  void set_opmeta_from_futuremap(FFModel const &ff,
+                                 Legion::FutureMap const &fm);
   void
-  solve_parallel_dim_mappings(const std::vector<ParallelDim const *> &inputs,
-                              const std::vector<ParallelDim *> &weights,
-                              const std::vector<ParallelDim *> &outputs) const;
+  solve_parallel_dim_mappings(std::vector<ParallelDim const *> const &inputs,
+                              std::vector<ParallelDim *> const &weights,
+                              std::vector<ParallelDim *> const &outputs) const;
 
 public:
   OperatorType op_type;

--- a/include/flexflow/ops/aggregate.h
+++ b/include/flexflow/ops/aggregate.h
@@ -20,52 +20,52 @@ public:
 class Aggregate : public Op {
 public:
   Aggregate(FFModel &model,
-            const ParallelTensor *inputs,
+            ParallelTensor const *inputs,
             int _n,
             float _lambda_bal,
-            const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+            char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_kernel_wrapper(const AggregateMeta *m,
+  static void forward_kernel_wrapper(AggregateMeta const *m,
                                      float **exp_preds,
-                                     const int *acc_gate_assign_ptr,
-                                     const float *acc_gate_pred_ptr,
+                                     int const *acc_gate_assign_ptr,
+                                     float const *acc_gate_pred_ptr,
                                      float *acc_output_ptr,
                                      int n,
-                                     const int k,
+                                     int const k,
                                      int rows,
-                                     const int batch_size,
+                                     int const batch_size,
                                      int out_dim);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void backward_kernel_wrapper(const AggregateMeta *m,
+  static void backward_kernel_wrapper(AggregateMeta const *m,
                                       float **exp_preds,
                                       float **exp_grads,
-                                      const int *acc_gate_assign_ptr,
-                                      const int *acc_true_gate_assign_ptr,
-                                      const float *acc_gate_pred_ptr,
+                                      int const *acc_gate_assign_ptr,
+                                      int const *acc_true_gate_assign_ptr,
+                                      float const *acc_gate_pred_ptr,
                                       float *full_acc_gate_grad_ptr,
-                                      const float *acc_output_grad_ptr,
+                                      float const *acc_output_grad_ptr,
                                       int n,
-                                      const int k,
+                                      int const k,
                                       int rows,
                                       float lambda_bal,
-                                      const int batch_size,
+                                      int const batch_size,
                                       int out_dim);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &mv,
+                             MachineView const &mv,
                              CostMetrics &cost_metrics) const override;
 
 public:

--- a/include/flexflow/ops/aggregate_spec.h
+++ b/include/flexflow/ops/aggregate_spec.h
@@ -19,50 +19,50 @@ public:
 class AggregateSpec : public Op {
 public:
   AggregateSpec(FFModel &model,
-                const ParallelTensor *inputs,
+                ParallelTensor const *inputs,
                 int _n,
                 float _lambda_bal,
-                const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+                char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_kernel_wrapper(const AggregateSpecMeta *m,
+  static void forward_kernel_wrapper(AggregateSpecMeta const *m,
                                      float **exp_preds,
-                                     const int *acc_gate_assign_ptr,
+                                     int const *acc_gate_assign_ptr,
                                      float *acc_output_ptr,
                                      int n,
-                                     const int k,
+                                     int const k,
                                      int rows,
-                                     const int batch_size,
+                                     int const batch_size,
                                      int out_dim);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void backward_kernel_wrapper(const AggregateSpecMeta *m,
+  static void backward_kernel_wrapper(AggregateSpecMeta const *m,
                                       float **exp_grads,
-                                      const int *acc_gate_assign_ptr,
-                                      const int *acc_true_gate_assign_ptr,
-                                      const float *acc_gate_pred_ptr,
+                                      int const *acc_gate_assign_ptr,
+                                      int const *acc_true_gate_assign_ptr,
+                                      float const *acc_gate_pred_ptr,
                                       float *acc_full_gate_grad_ptr,
-                                      const float *acc_output_grad_ptr,
+                                      float const *acc_output_grad_ptr,
                                       int n,
-                                      const int k,
+                                      int const k,
                                       int rows,
                                       float lambda_bal,
-                                      const int batch_size,
+                                      int const batch_size,
                                       int out_dim);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
 public:

--- a/include/flexflow/ops/attention.h
+++ b/include/flexflow/ops/attention.h
@@ -10,7 +10,7 @@ class MultiHeadAttentionMeta;
 class MultiHeadAttention : public Op {
 public:
   MultiHeadAttention(FFModel &model,
-                     const LayerID &layer_guid,
+                     LayerID const &layer_guid,
                      const ParallelTensor _query,
                      const ParallelTensor _key,
                      const ParallelTensor _value,
@@ -23,7 +23,7 @@ public:
                      bool _add_bias_kv,
                      bool _add_zero_attn,
                      bool allocate_weights,
-                     const char *name);
+                     char const *name);
   MultiHeadAttention(FFModel &model,
                      const ParallelTensor _query,
                      const ParallelTensor _key,
@@ -38,7 +38,7 @@ public:
                      bool _add_bias_kv,
                      bool _add_zero_attn,
                      bool allocate_weights,
-                     const char *name);
+                     char const *name);
   MultiHeadAttention(FFModel &model,
                      MultiHeadAttention const &other,
                      const ParallelTensor query,
@@ -47,64 +47,64 @@ public:
                      bool allocate_weights);
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   bool get_int_parameter(PMParameter, int *) const override;
   size_t get_params_hash() const override;
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &mv,
+                             MachineView const &mv,
                              CostMetrics &cost_metrics) const override;
-  static void forward_kernel(const MultiHeadAttentionMeta *m,
-                             const float *query_ptr,
-                             const float *key_ptr,
-                             const float *value_ptr,
-                             const float *weight_ptr,
+  static void forward_kernel(MultiHeadAttentionMeta const *m,
+                             float const *query_ptr,
+                             float const *key_ptr,
+                             float const *value_ptr,
+                             float const *weight_ptr,
                              float *output_ptr,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const MultiHeadAttentionMeta *m,
-                                     const float *query_ptr,
-                                     const float *key_ptr,
-                                     const float *value_ptr,
-                                     const float *weight_ptr,
+  static void forward_kernel_wrapper(MultiHeadAttentionMeta const *m,
+                                     float const *query_ptr,
+                                     float const *key_ptr,
+                                     float const *value_ptr,
+                                     float const *weight_ptr,
                                      float *output_ptr);
-  static void backward_kernel(const MultiHeadAttentionMeta *m,
-                              const float *query_ptr,
+  static void backward_kernel(MultiHeadAttentionMeta const *m,
+                              float const *query_ptr,
                               float *query_grad_ptr,
-                              const float *key_ptr,
+                              float const *key_ptr,
                               float *key_grad_ptr,
-                              const float *value_ptr,
+                              float const *value_ptr,
                               float *value_grad_ptr,
-                              const float *weight_ptr,
+                              float const *weight_ptr,
                               float *weight_grad_ptr,
-                              const float *output_grad_ptr,
+                              float const *output_grad_ptr,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const MultiHeadAttentionMeta *m,
-                                      const float *query_ptr,
+  static void backward_kernel_wrapper(MultiHeadAttentionMeta const *m,
+                                      float const *query_ptr,
                                       float *query_grad_ptr,
-                                      const float *key_ptr,
+                                      float const *key_ptr,
                                       float *key_grad_ptr,
-                                      const float *value_ptr,
+                                      float const *value_ptr,
                                       float *value_grad_ptr,
-                                      const float *weight_ptr,
+                                      float const *weight_ptr,
                                       float *weight_grad_ptr,
-                                      const float *output_grad_ptr);
+                                      float const *output_grad_ptr);
 
 public:
   int num_heads;
@@ -118,7 +118,7 @@ public:
 class MultiHeadAttentionMeta : public OpMeta {
 public:
   MultiHeadAttentionMeta(FFHandler handler,
-                         const MultiHeadAttention *attn,
+                         MultiHeadAttention const *attn,
                          Legion::Memory gpu_mem,
                          int num_samples,
                          int num_heads);

--- a/include/flexflow/ops/batch_matmul.h
+++ b/include/flexflow/ops/batch_matmul.h
@@ -18,27 +18,27 @@ public:
               const ParallelTensor B,
               int a_seq_length_dim,
               int b_seq_length_dim);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override;
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override;
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void forward_kernel(const BatchMatmulMeta *meta,
+  static void forward_kernel(BatchMatmulMeta const *meta,
                              float *o_ptr,
-                             const float *a_ptr,
-                             const float *b_ptr,
-                             const float *c_ptr,
+                             float const *a_ptr,
+                             float const *b_ptr,
+                             float const *c_ptr,
                              int m,
                              int n,
                              int k,
@@ -47,11 +47,11 @@ public:
                              int a_seq_length_dim = -1,
                              int b_seq_length_dim = -1,
                              int seq_length = -1);
-  static void forward_kernel_wrapper(const BatchMatmulMeta *meta,
+  static void forward_kernel_wrapper(BatchMatmulMeta const *meta,
                                      float *o_ptr,
-                                     const float *a_ptr,
-                                     const float *b_ptr,
-                                     const float *c_ptr,
+                                     float const *a_ptr,
+                                     float const *b_ptr,
+                                     float const *c_ptr,
                                      int m,
                                      int n,
                                      int k,
@@ -59,12 +59,12 @@ public:
                                      int a_seq_length_dim = -1,
                                      int b_seq_length_dim = -1,
                                      int seq_length = -1);
-  static void backward_kernel(const BatchMatmulMeta *meta,
-                              const float *o_ptr,
-                              const float *o_grad_ptr,
-                              const float *a_ptr,
+  static void backward_kernel(BatchMatmulMeta const *meta,
+                              float const *o_ptr,
+                              float const *o_grad_ptr,
+                              float const *a_ptr,
                               float *a_grad_ptr,
-                              const float *b_ptr,
+                              float const *b_ptr,
                               float *b_grad_ptr,
                               float *c_grad_ptr,
                               int m,
@@ -72,12 +72,12 @@ public:
                               int k,
                               int batch,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const BatchMatmulMeta *meta,
-                                      const float *o_ptr,
-                                      const float *o_grad_ptr,
-                                      const float *a_ptr,
+  static void backward_kernel_wrapper(BatchMatmulMeta const *meta,
+                                      float const *o_ptr,
+                                      float const *o_grad_ptr,
+                                      float const *a_ptr,
                                       float *a_grad_ptr,
-                                      const float *b_ptr,
+                                      float const *b_ptr,
                                       float *b_grad_ptr,
                                       float *c_grad_ptr,
                                       int m,
@@ -85,13 +85,13 @@ public:
                                       int k,
                                       int batch);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
 private:
-  template <int NDIM> void init_with_dim(const FFModel &ff);
-  template <int NDIM> void forward_with_dim(const FFModel &ff);
-  template <int NDIM> void backward_with_dim(const FFModel &ff);
+  template <int NDIM> void init_with_dim(FFModel const &ff);
+  template <int NDIM> void forward_with_dim(FFModel const &ff);
+  template <int NDIM> void backward_with_dim(FFModel const &ff);
 
 public:
   int a_seq_length_dim, b_seq_length_dim;

--- a/include/flexflow/ops/batch_norm.h
+++ b/include/flexflow/ops/batch_norm.h
@@ -13,27 +13,27 @@ public:
             const ParallelTensor scale,
             const ParallelTensor bias,
             bool relu,
-            const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void update(const FFModel &);
-  void print_layer(const FFModel &model) override { assert(0); }
+            char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void update(FFModel const &);
+  void print_layer(FFModel const &model) override { assert(0); }
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
   static void forward_kernel(BatchNormMeta *m,
                              float const *input_ptr,
@@ -59,7 +59,7 @@ public:
 class BatchNormMeta : public OpMeta {
 public:
   BatchNormMeta(FFHandler handle,
-                const BatchNorm *bn,
+                BatchNorm const *bn,
                 Legion::Memory gpu_mem,
                 int output_n,
                 int output_c,

--- a/include/flexflow/ops/cache.h
+++ b/include/flexflow/ops/cache.h
@@ -15,42 +15,42 @@ class Cache : public Op {
 public:
   Cache(
       FFModel &model,
-      const ParallelTensor &_input,
+      ParallelTensor const &_input,
       int _num_batches,
-      std::function<float(float *, const void *, const void *, int)> &_score_f,
-      const char *name);
+      std::function<float(float *, void const *, void const *, int)> &_score_f,
+      char const *name);
   ~Cache(void);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   // void create_weights(FFModel& model);
   // void create_output_and_partition(FFModel& model);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static float update_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static float update_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
   template <typename T>
-  static void cache_forward(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void cache_forward(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename T>
-  static float cache_update(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static float cache_update(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
   void use_cached(bool cached);
 
@@ -59,7 +59,7 @@ public:
   void *batch_cmp;
   bool load_cached;
   int num_batches;
-  std::function<float(float *, const void *, const void *, int)> score_f;
+  std::function<float(float *, void const *, void const *, int)> score_f;
   std::vector<Legion::Future> score_futures;
   int batch_ctr;
 };

--- a/include/flexflow/ops/cast.h
+++ b/include/flexflow/ops/cast.h
@@ -26,51 +26,51 @@ public:
 class Cast : public Op {
 public:
   Cast(FFModel &model,
-       const ParallelTensor &input,
+       ParallelTensor const &input,
        DataType dtype,
-       const char *name);
-  void init(const FFModel &);
-  void forward(const FFModel &);
-  void backward(const FFModel &);
-  void print_layer(const FFModel &model) { assert(0); }
+       char const *name);
+  void init(FFModel const &);
+  void forward(FFModel const &);
+  void backward(FFModel const &);
+  void print_layer(FFModel const &model) { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
   template <typename IDT>
   static void
-  forward_task_with_1_type(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_with_1_type(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
   template <typename IDT, typename ODT>
   static void
-  forward_task_with_2_type(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_with_2_type(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename IDT>
   static void
-  backward_task_with_1_type(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_1_type(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename IDT, typename ODT>
   static void
-  backward_task_with_2_type(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_2_type(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename IDT, typename ODT>
@@ -90,7 +90,7 @@ public:
   static void
   backward_kernel_wrapper(const IDT *src_ptr, ODT *dst_ptr, size_t volume);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const;
 };
 

--- a/include/flexflow/ops/concat.h
+++ b/include/flexflow/ops/concat.h
@@ -13,10 +13,10 @@ namespace FlexFlow {
 struct ConcatParams {
   int axis;
 
-  bool is_valid(const std::vector<ParallelTensorShape> &) const;
+  bool is_valid(std::vector<ParallelTensorShape> const &) const;
 };
 
-bool operator==(const ConcatParams &, const ConcatParams &);
+bool operator==(ConcatParams const &, ConcatParams const &);
 
 class ConcatMeta : public OpMeta {
 public:
@@ -32,65 +32,65 @@ public:
 
   Concat(FFModel &model,
          int n,
-         const ParallelTensor *inputs,
+         ParallelTensor const *inputs,
          int axis,
-         const char *name);
+         char const *name);
   Concat(FFModel &model,
-         const ConcatParams &params,
-         const std::vector<ParallelTensor> &inputs,
-         const char *name = nullptr);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+         ConcatParams const &params,
+         std::vector<ParallelTensor> const &inputs,
+         char const *name = nullptr);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   bool get_int_parameter(PMParameter, int *) const override;
-  void print_layer(const FFModel &model) override { assert(0); }
+  void print_layer(FFModel const &model) override { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
   void init_meta(ConcatMeta *meta) const;
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   static void forward_kernel(float *output,
                              float const *const *inputs,
                              int num_inputs,
                              int axis,
-                             const Legion::Domain &out_domain,
-                             const Legion::Domain *in_domain,
+                             Legion::Domain const &out_domain,
+                             Legion::Domain const *in_domain,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const ConcatMeta *m,
+  static void forward_kernel_wrapper(ConcatMeta const *m,
                                      float *output,
                                      float const *const *inputs,
                                      int num_inputs,
                                      int axis,
-                                     const Legion::Domain &out_domain,
-                                     const Legion::Domain *in_domain);
-  static void backward_kernel(const float *output_grad,
+                                     Legion::Domain const &out_domain,
+                                     Legion::Domain const *in_domain);
+  static void backward_kernel(float const *output_grad,
                               float **input_grads,
                               int num_inputs,
                               int axis,
-                              const Legion::Domain &out_grad_domain,
-                              const Legion::Domain *in_grad_domain,
+                              Legion::Domain const &out_grad_domain,
+                              Legion::Domain const *in_grad_domain,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const ConcatMeta *m,
-                                      const float *output_grad,
+  static void backward_kernel_wrapper(ConcatMeta const *m,
+                                      float const *output_grad,
                                       float **input_grads,
                                       int num_inputs,
                                       int axis,
-                                      const Legion::Domain &out_grad_domain,
-                                      const Legion::Domain *in_grad_domain);
+                                      Legion::Domain const &out_grad_domain,
+                                      Legion::Domain const *in_grad_domain);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
   Params get_params() const;
@@ -103,7 +103,7 @@ public:
 
 namespace std {
 template <> struct hash<FlexFlow::ConcatParams> {
-  size_t operator()(const FlexFlow::ConcatParams &) const;
+  size_t operator()(FlexFlow::ConcatParams const &) const;
 };
 }; // namespace std
 

--- a/include/flexflow/ops/conv_2d.h
+++ b/include/flexflow/ops/conv_2d.h
@@ -110,7 +110,7 @@ public:
   using Input = ParallelTensor;
 
   Conv2D(FFModel &model,
-         const LayerID &layer_guid,
+         LayerID const &layer_guid,
          const ParallelTensor input,
          int outChannels,
          int kernelH,
@@ -123,7 +123,7 @@ public:
          int groups,
          bool use_bias,
          bool allocate_weights,
-         const char *name);
+         char const *name);
   Conv2D(FFModel &model,
          Conv2D const &other,
          const ParallelTensor input,
@@ -131,26 +131,26 @@ public:
   Conv2D(FFModel &model,
          Conv2DParams const &params,
          ParallelTensor input,
-         const char *name = nullptr,
+         char const *name = nullptr,
          bool allocate_weights = false);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   // void update(const FFModel&);
-  void print_layer(const FFModel &model) override;
+  void print_layer(FFModel const &model) override;
   // Parameter* get_parameter(int index);
   // void create_weights(FFModel& model);
   // void create_input_partition(FFModel& model);
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void init_kernel(const Conv2D *conv,
+  static void init_kernel(Conv2D const *conv,
                           Conv2DMeta *m,
                           int input_w,
                           int input_h,
@@ -162,51 +162,51 @@ public:
                           int output_n,
                           int pad_h,
                           int pad_w,
-                          const float *input_ptr,
+                          float const *input_ptr,
                           float *output_ptr,
-                          const float *kernel_ptr,
+                          float const *kernel_ptr,
                           float *kernel_grad_ptr);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void forward_kernel(const Conv2DMeta *m,
-                             const float *input_ptr,
+  static void forward_kernel(Conv2DMeta const *m,
+                             float const *input_ptr,
                              float *output_ptr,
-                             const float *filter_ptr,
-                             const float *bias_ptr,
+                             float const *filter_ptr,
+                             float const *bias_ptr,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const Conv2DMeta *m,
-                                     const float *input_ptr,
+  static void forward_kernel_wrapper(Conv2DMeta const *m,
+                                     float const *input_ptr,
                                      float *output_ptr,
-                                     const float *filter_ptr,
-                                     const float *bias_ptr);
-  static void backward_kernel(const Conv2DMeta *m,
-                              const float *input_ptr,
+                                     float const *filter_ptr,
+                                     float const *bias_ptr);
+  static void backward_kernel(Conv2DMeta const *m,
+                              float const *input_ptr,
                               float *input_grad_ptr,
-                              const float *output_ptr,
+                              float const *output_ptr,
                               float *output_grad_ptr,
-                              const float *kernel_ptr,
+                              float const *kernel_ptr,
                               float *kernel_grad_ptr,
                               float *bias_ptr,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const Conv2DMeta *m,
-                                      const float *input_ptr,
+  static void backward_kernel_wrapper(Conv2DMeta const *m,
+                                      float const *input_ptr,
                                       float *input_grad_ptr,
-                                      const float *output_ptr,
+                                      float const *output_ptr,
                                       float *output_grad_ptr,
-                                      const float *kernel_ptr,
+                                      float const *kernel_ptr,
                                       float *kernel_grad_ptr,
                                       float *bias_grad_ptr);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
   bool estimate_sync_cost(Simulator *sim,
-                          const MachineView &pc,
+                          MachineView const &pc,
                           CostMetrics &cost_metrics) const override;
 
   void serialize(Legion::Serializer &s) const override;

--- a/include/flexflow/ops/dropout.h
+++ b/include/flexflow/ops/dropout.h
@@ -19,27 +19,27 @@ public:
           const ParallelTensor input,
           float rate,
           unsigned long long seed,
-          const char *name);
+          char const *name);
   Dropout(FFModel &model, Dropout const &other, const ParallelTensor input);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   static void forward_kernel(DropoutMeta *m,
@@ -57,7 +57,7 @@ public:
                                       float const *output_grad_ptr,
                                       float *input_grad_ptr);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
   void serialize(Legion::Serializer &s) const override;
@@ -78,9 +78,9 @@ public:
 class DropoutMeta : public OpMeta {
 public:
   DropoutMeta(FFHandler handle,
-              const Dropout *dropout,
+              Dropout const *dropout,
               Legion::Memory gpu_mem,
-              const Legion::Domain &output_domain);
+              Legion::Domain const &output_domain);
   ~DropoutMeta(void);
   Realm::RegionInstance reserveInst;
 #if defined(FF_USE_CUDA) || defined(FF_USE_HIP_CUDA)

--- a/include/flexflow/ops/element_binary.h
+++ b/include/flexflow/ops/element_binary.h
@@ -14,10 +14,10 @@ struct ElementBinaryParams {
   OperatorType type;
 
   bool
-  is_valid(const std::pair<ParallelTensorShape, ParallelTensorShape> &) const;
+  is_valid(std::pair<ParallelTensorShape, ParallelTensorShape> const &) const;
 };
 
-bool operator==(const ElementBinaryParams &, const ElementBinaryParams &);
+bool operator==(ElementBinaryParams const &, ElementBinaryParams const &);
 
 class ElementBinaryMeta : public OpMeta {
 public:
@@ -46,63 +46,63 @@ public:
                 const ParallelTensor x,
                 const ParallelTensor y,
                 bool inplace_a,
-                const char *name);
+                char const *name);
   ElementBinary(FFModel &model,
-                const Params &params,
-                const Input &inputs,
-                const char *name = nullptr,
+                Params const &params,
+                Input const &inputs,
+                char const *name = nullptr,
                 bool inplace_a = false);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   bool can_inplace_output() override;
   bool has_inplace_output() override;
   void do_inplace_output() override;
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   static void init_kernel(ElementBinaryMeta *m,
-                          const Legion::Domain &input1_domain,
-                          const Legion::Domain &input2_domain,
-                          const Legion::Domain &output_domain);
-  static void forward_kernel(const ElementBinaryMeta *m,
-                             const float *in1_ptr,
-                             const float *in2_ptr,
+                          Legion::Domain const &input1_domain,
+                          Legion::Domain const &input2_domain,
+                          Legion::Domain const &output_domain);
+  static void forward_kernel(ElementBinaryMeta const *m,
+                             float const *in1_ptr,
+                             float const *in2_ptr,
                              float *out_ptr,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const ElementBinaryMeta *m,
-                                     const float *in1_ptr,
-                                     const float *in2_ptr,
+  static void forward_kernel_wrapper(ElementBinaryMeta const *m,
+                                     float const *in1_ptr,
+                                     float const *in2_ptr,
                                      float *out_ptr);
-  static void backward_kernel(const ElementBinaryMeta *m,
-                              const float *out_grad_ptr,
-                              const float *in1_ptr,
-                              const float *in2_ptr,
+  static void backward_kernel(ElementBinaryMeta const *m,
+                              float const *out_grad_ptr,
+                              float const *in1_ptr,
+                              float const *in2_ptr,
                               float *in1_grad_ptr,
                               float *in2_grad_ptr,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const ElementBinaryMeta *m,
-                                      const float *out_grad_ptr,
-                                      const float *in1_ptr,
-                                      const float *in2_ptr,
+  static void backward_kernel_wrapper(ElementBinaryMeta const *m,
+                                      float const *out_grad_ptr,
+                                      float const *in1_ptr,
+                                      float const *in2_ptr,
                                       float *in1_grad_ptr,
                                       float *in2_grad_ptr);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
   Params get_params() const;
 
@@ -115,7 +115,7 @@ public:
 
 namespace std {
 template <> struct hash<FlexFlow::ElementBinaryParams> {
-  size_t operator()(const FlexFlow::ElementBinaryParams &) const;
+  size_t operator()(FlexFlow::ElementBinaryParams const &) const;
 };
 }; // namespace std
 

--- a/include/flexflow/ops/element_unary.h
+++ b/include/flexflow/ops/element_unary.h
@@ -15,10 +15,10 @@ struct ElementUnaryParams {
   bool inplace;
   float scalar;
 
-  bool is_valid(const ParallelTensorShape &) const;
+  bool is_valid(ParallelTensorShape const &) const;
 };
 
-bool operator==(const ElementUnaryParams &, const ElementUnaryParams &);
+bool operator==(ElementUnaryParams const &, ElementUnaryParams const &);
 
 class ElementUnaryMeta : public OpMeta {
 public:
@@ -45,64 +45,64 @@ public:
                OperatorType type,
                const ParallelTensor x,
                bool inplace,
-               const char *name,
+               char const *name,
                float scalar);
   ElementUnary(FFModel &model,
-               const Params &params,
+               Params const &params,
                const Input x,
-               const char *name = nullptr);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+               char const *name = nullptr);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   bool can_inplace_output() override;
   bool has_inplace_output() override;
   void do_inplace_output() override;
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename T>
   static void
-  forward_task_with_type(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_with_type(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   template <typename T>
   static void
-  backward_task_with_type(const Legion::Task *task,
-                          const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_type(Legion::Task const *task,
+                          std::vector<Legion::PhysicalRegion> const &regions,
                           Legion::Context ctx,
                           Legion::Runtime *runtime);
   static void init_kernel(ElementUnaryMeta *m,
-                          const Legion::Domain &input_domain,
-                          const Legion::Domain &output_domain);
+                          Legion::Domain const &input_domain,
+                          Legion::Domain const &output_domain);
   template <typename T>
-  static void forward_kernel(const ElementUnaryMeta *m,
+  static void forward_kernel(ElementUnaryMeta const *m,
                              const T *in_ptr,
                              T *out_ptr,
                              size_t num_elements,
                              ffStream_t stream);
   template <typename T>
-  static void forward_kernel_wrapper(const ElementUnaryMeta *m,
+  static void forward_kernel_wrapper(ElementUnaryMeta const *m,
                                      const T *in_ptr,
                                      T *out_ptr,
                                      size_t num_elements);
   template <typename T>
-  static void backward_kernel(const ElementUnaryMeta *m,
+  static void backward_kernel(ElementUnaryMeta const *m,
                               const T *in_ptr,
                               T *in_grad_ptr,
                               const T *out_ptr,
@@ -110,14 +110,14 @@ public:
                               size_t num_elements,
                               ffStream_t stream);
   template <typename T>
-  static void backward_kernel_wrapper(const ElementUnaryMeta *m,
+  static void backward_kernel_wrapper(ElementUnaryMeta const *m,
                                       const T *in_ptr,
                                       T *in_grad_ptr,
                                       const T *out_ptr,
                                       const T *out_grad_ptr,
                                       size_t num_elements);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
   static bool use_cudnn(OperatorType type);
 
@@ -143,7 +143,7 @@ public:
 
 namespace std {
 template <> struct hash<FlexFlow::ElementUnaryParams> {
-  size_t operator()(const FlexFlow::ElementUnaryParams &) const;
+  size_t operator()(FlexFlow::ElementUnaryParams const &) const;
 };
 } // namespace std
 

--- a/include/flexflow/ops/embedding.h
+++ b/include/flexflow/ops/embedding.h
@@ -33,50 +33,50 @@ struct EmbeddingParams {
 class Embedding : public Op {
 public:
   Embedding(FFModel &model,
-            const LayerID &_layer_guid,
+            LayerID const &_layer_guid,
             const ParallelTensor _input,
             int _num_entries,
             int _out_channels,
             AggrMode _aggr,
             bool allocate_weights,
-            const char *name);
+            char const *name);
   Embedding(FFModel &model,
             Embedding const &other,
             const ParallelTensor input,
             bool allocate_weights);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   // void update(const FFModel&);
-  void print_layer(const FFModel &model) override { assert(0); }
+  void print_layer(FFModel const &model) override { assert(0); }
   // Parameter* get_parameter(int index);
   // void create_weights(FFModel& model);
   // void create_input_partition(FFModel& model);
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   static void
-  forward_task_cpu(const Legion::Task *task,
-                   const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_cpu(Legion::Task const *task,
+                   std::vector<Legion::PhysicalRegion> const &regions,
                    Legion::Context ctx,
                    Legion::Runtime *runtime);
   static void
-  backward_task_cpu(const Legion::Task *task,
-                    const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_cpu(Legion::Task const *task,
+                    std::vector<Legion::PhysicalRegion> const &regions,
                     Legion::Context ctx,
                     Legion::Runtime *runtime);
   template <typename TI>
@@ -90,7 +90,7 @@ public:
                              int outputSize,
                              ffStream_t stream);
   template <typename TI>
-  static void forward_kernel_wrapper(const EmbeddingMeta *m,
+  static void forward_kernel_wrapper(EmbeddingMeta const *m,
                                      TI const *input_ptr,
                                      float *output_ptr,
                                      float const *weight_ptr,
@@ -110,7 +110,7 @@ public:
                               int outputSize,
                               ffStream_t stream);
   template <typename TI>
-  static void backward_kernel_wrapper(const EmbeddingMeta *m,
+  static void backward_kernel_wrapper(EmbeddingMeta const *m,
                                       TI const *input_ptr,
                                       float const *output_ptr,
                                       float *weight_grad_ptr,
@@ -121,7 +121,7 @@ public:
                                       int outputSize);
   void rand_generate_int64_wrapper(int64_t *ptr, size_t size, int64_t p) const;
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
   size_t get_params_hash() const override;
@@ -131,14 +131,14 @@ public:
 private:
   template <typename TI>
   static void
-  forward_task_with_type(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_with_type(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   template <typename TI>
   static void
-  backward_task_with_type(const Legion::Task *task,
-                          const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_type(Legion::Task const *task,
+                          std::vector<Legion::PhysicalRegion> const &regions,
                           Legion::Context ctx,
                           Legion::Runtime *runtime);
 

--- a/include/flexflow/ops/flat.h
+++ b/include/flexflow/ops/flat.h
@@ -21,47 +21,47 @@ public:
 
 class Flat : public Op {
 public:
-  Flat(FFModel &model, const ParallelTensor input, const char *name);
+  Flat(FFModel &model, const ParallelTensor input, char const *name);
 
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void forward_kernel(const float *input_ptr,
+  static void forward_kernel(float const *input_ptr,
                              float *output_ptr,
                              size_t num_elements,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const float *input_ptr,
+  static void forward_kernel_wrapper(float const *input_ptr,
                                      float *output_ptr,
                                      size_t num_elements);
   static void backward_kernel(float *input_grad_ptr,
-                              const float *output_grad_ptr,
+                              float const *output_grad_ptr,
                               size_t num_elements,
                               ffStream_t stream);
   static void backward_kernel_wrapper(float *input_grad_ptr,
-                                      const float *output_grad_ptr,
+                                      float const *output_grad_ptr,
                                       size_t num_elements);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
-  Legion::Domain get_input_tensor_shape(const ParallelConfig &pc,
+  Legion::Domain get_input_tensor_shape(ParallelConfig const &pc,
                                         int input_idx,
                                         int part_idx) const override;
 

--- a/include/flexflow/ops/fused.h
+++ b/include/flexflow/ops/fused.h
@@ -28,24 +28,24 @@ public:
     assert(0);
     return ParallelTensor();
   }
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
 public:

--- a/include/flexflow/ops/groupby.h
+++ b/include/flexflow/ops/groupby.h
@@ -19,27 +19,27 @@ public:
            const ParallelTensor _assign,
            int _n,
            float _alpha,
-           const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+           char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   static void
-  forward_kernel_wrapper(const GroupByMeta *m,
-                         const float *input,
-                         const int *exp_assign,
+  forward_kernel_wrapper(GroupByMeta const *m,
+                         float const *input,
+                         int const *exp_assign,
                          float **outputs,
                          int n,       // num experts
                          int k,       // chosen experts
@@ -47,9 +47,9 @@ public:
                          int batch_size,
                          int data_dim);
   static void
-  backward_kernel_wrapper(const GroupByMeta *m,
+  backward_kernel_wrapper(GroupByMeta const *m,
                           float *input_grad,
-                          const int *exp_assign,
+                          int const *exp_assign,
                           float **output_grads,
                           int n,       // num experts
                           int k,       // chosen experts
@@ -57,7 +57,7 @@ public:
                           int batch_size,
                           int data_dim);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
 public:

--- a/include/flexflow/ops/layer_norm.h
+++ b/include/flexflow/ops/layer_norm.h
@@ -9,51 +9,51 @@ class LayerNormMeta;
 class LayerNorm : public Op {
 public:
   LayerNorm(FFModel &model,
-            const LayerID &_layer_guid,
+            LayerID const &_layer_guid,
             const ParallelTensor _input,
-            const std::vector<int> &axes,
+            std::vector<int> const &axes,
             bool _elementwise_affine,
             float _eps,
             bool allocate_weights,
-            const char *name);
-  void init(const FFModel &);
-  void forward(const FFModel &);
-  void backward(const FFModel &);
-  void print_layer(const FFModel &model) { assert(0); }
+            char const *name);
+  void init(FFModel const &);
+  void forward(FFModel const &);
+  void backward(FFModel const &);
+  void print_layer(FFModel const &model) { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const;
   template <typename T>
-  static void forward_kernel(const LayerNormMeta *m,
+  static void forward_kernel(LayerNormMeta const *m,
                              const T *input_ptr,
                              T *output_ptr,
                              T *gamma_ptr,
                              T *beta_ptr,
                              ffStream_t stream);
   template <typename T>
-  static void forward_kernel_wrapper(const LayerNormMeta *m,
+  static void forward_kernel_wrapper(LayerNormMeta const *m,
                                      const T *input_ptr,
                                      T *output_ptr,
                                      T *gamma_ptr,
                                      T *beta_ptr);
   template <typename T>
-  static void backward_kernel(const LayerNormMeta *m,
+  static void backward_kernel(LayerNormMeta const *m,
                               const T *output_grad_ptr,
                               const T *input_ptr,
                               T *input_grad_ptr,
@@ -62,7 +62,7 @@ public:
                               T *beta_grad_ptr,
                               ffStream_t stream);
   template <typename T>
-  static void backward_kernel_wrapper(const LayerNormMeta *m,
+  static void backward_kernel_wrapper(LayerNormMeta const *m,
                                       const T *output_grad_ptr,
                                       const T *input_ptr,
                                       T *input_grad_ptr,
@@ -78,7 +78,7 @@ public:
 
 class LayerNormMeta : public OpMeta {
 public:
-  LayerNormMeta(FFHandler handle, const LayerNorm *ln);
+  LayerNormMeta(FFHandler handle, LayerNorm const *ln);
 
 public:
   bool elementwise_affine;

--- a/include/flexflow/ops/linear.h
+++ b/include/flexflow/ops/linear.h
@@ -22,7 +22,7 @@ public:
   miopenTensorDescriptor_t outputTensor;
   miopenActivationDescriptor_t actiDesc;
 #endif
-  const float *one_ptr;
+  float const *one_ptr;
   ActiMode activation;
   bool use_bias;
   DataType input_type, weight_type, output_type;
@@ -96,14 +96,14 @@ public:
   using Input = ParallelTensor;
 
   Linear(FFModel &model,
-         const LayerID &layer_guid,
+         LayerID const &layer_guid,
          const ParallelTensor input,
          int out_dim,
          ActiMode activation,
          bool _use_bias,
          DataType _data_type,
          bool allocate_weights,
-         const char *name);
+         char const *name);
   Linear(FFModel &model,
          Linear const &other,
          ParallelTensor const input,
@@ -111,80 +111,80 @@ public:
   Linear(FFModel &model,
          LinearParams const &params,
          ParallelTensor input,
-         const char *name = nullptr,
+         char const *name = nullptr,
          bool allocate_weights = false);
 
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override;
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override;
   bool get_int_parameter(PMParameter, int *) const override;
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
   static void init_kernel(LinearMeta *m, int batch_size, int channel);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void forward_kernel(const LinearMeta *m,
-                             const void *input_ptr,
+  static void forward_kernel(LinearMeta const *m,
+                             void const *input_ptr,
                              void *output_ptr,
-                             const void *filter_ptr,
-                             const void *bias_ptr,
+                             void const *filter_ptr,
+                             void const *bias_ptr,
                              int in_dim,
                              int out_dim,
                              int batch_size,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const LinearMeta *m,
-                                     const void *input_ptr,
+  static void forward_kernel_wrapper(LinearMeta const *m,
+                                     void const *input_ptr,
                                      void *output_ptr,
-                                     const void *filter_ptr,
-                                     const void *bias_ptr,
+                                     void const *filter_ptr,
+                                     void const *bias_ptr,
                                      int in_dim,
                                      int out_dim,
                                      int batch_size);
-  static void backward_kernel(const LinearMeta *m,
-                              const void *input_ptr,
+  static void backward_kernel(LinearMeta const *m,
+                              void const *input_ptr,
                               void *input_grad_ptr,
-                              const void *output_ptr,
+                              void const *output_ptr,
                               void *output_grad_ptr,
-                              const void *kernel_ptr,
+                              void const *kernel_ptr,
                               void *kernel_grad_ptr,
                               void *bias_ptr,
                               int in_dim,
                               int out_dim,
                               int batch_size,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const LinearMeta *m,
-                                      const void *input_ptr,
+  static void backward_kernel_wrapper(LinearMeta const *m,
+                                      void const *input_ptr,
                                       void *input_grad_ptr,
-                                      const void *output_ptr,
+                                      void const *output_ptr,
                                       void *output_grad_ptr,
-                                      const void *kernel_ptr,
+                                      void const *kernel_ptr,
                                       void *kernel_grad_ptr,
                                       void *bias_ptr,
                                       int in_dim,
                                       int out_dim,
                                       int batch_size);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
   bool estimate_sync_cost(Simulator *sim,
-                          const MachineView &pc,
+                          MachineView const &pc,
                           CostMetrics &cost_metrics) const override;
-  ParallelConfig get_random_parallel_config(const FFModel &ff) const override;
-  bool is_valid_parallel_config(const FFModel &ff,
-                                const ParallelConfig &pc) const override;
+  ParallelConfig get_random_parallel_config(FFModel const &ff) const override;
+  bool is_valid_parallel_config(FFModel const &ff,
+                                ParallelConfig const &pc) const override;
 
   void serialize(Legion::Serializer &) const override;
   static PCG::Node deserialize(FFModel &ff,
@@ -203,24 +203,24 @@ private:
          ActiMode activation,
          bool use_bias,
          bool allocate_weights,
-         const char *name);
+         char const *name);
 
   template <int NDIM>
   static OpMeta *
-  init_task_with_dim(const Legion::Task *task,
-                     const std::vector<Legion::PhysicalRegion> &regions,
+  init_task_with_dim(Legion::Task const *task,
+                     std::vector<Legion::PhysicalRegion> const &regions,
                      Legion::Context ctx,
                      Legion::Runtime *runtime);
   template <int NDIM>
   static void
-  forward_task_with_dim(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_with_dim(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
   template <int NDIM>
   static void
-  backward_task_with_dim(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_dim(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   static bool use_activation(ActiMode mode);

--- a/include/flexflow/ops/mean.h
+++ b/include/flexflow/ops/mean.h
@@ -8,28 +8,28 @@ class Mean : public Op {
 public:
   Mean(FFModel &model,
        const ParallelTensor input,
-       const std::vector<int> &dims,
+       std::vector<int> const &dims,
        bool keepdims,
-       const char *name);
-  void init(const FFModel &);
-  void forward(const FFModel &);
-  void backward(const FFModel &);
-  void print_layer(const FFModel &model) { assert(0); }
+       char const *name);
+  void init(FFModel const &);
+  void forward(FFModel const &);
+  void backward(FFModel const &);
+  void print_layer(FFModel const &model) { assert(0); }
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const;
 };
 

--- a/include/flexflow/ops/noop.h
+++ b/include/flexflow/ops/noop.h
@@ -10,21 +10,21 @@ public:
   NoOp(FFModel &model,
        OperatorType type,
        const ParallelTensor output,
-       const char *name = NULL);
+       char const *name = NULL);
   NoOp(FFModel &model,
        OperatorType type,
        size_t input_tensor_guid,
        const ParallelTensor output,
-       const char *name = NULL);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+       char const *name = NULL);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
 

--- a/include/flexflow/ops/pool_2d.h
+++ b/include/flexflow/ops/pool_2d.h
@@ -52,27 +52,27 @@ public:
          int paddingW,
          PoolType type,
          ActiMode activation,
-         const char *name);
+         char const *name);
   Pool2D(FFModel &model, Pool2D const &other, ParallelTensor const input);
   Pool2D(FFModel &model,
-         const Params &params,
+         Params const &params,
          const Input input,
-         const char *name = nullptr);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void update(const FFModel &);
-  void print_layer(const FFModel &model) override { assert(0); }
+         char const *name = nullptr);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void update(FFModel const &);
+  void print_layer(FFModel const &model) override { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void init_kernel(const Pool2D *pool,
+  static void init_kernel(Pool2D const *pool,
                           Pool2DMeta *m,
                           int input_w,
                           int input_h,
@@ -84,34 +84,34 @@ public:
                           int output_n,
                           int pad_h,
                           int pad_w);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void forward_kernel(const Pool2DMeta *m,
-                             const float *input_ptr,
+  static void forward_kernel(Pool2DMeta const *m,
+                             float const *input_ptr,
                              float *output_ptr,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const Pool2DMeta *m,
-                                     const float *input_ptr,
+  static void forward_kernel_wrapper(Pool2DMeta const *m,
+                                     float const *input_ptr,
                                      float *output_ptr);
-  static void backward_kernel(const Pool2DMeta *m,
-                              const float *input_ptr,
+  static void backward_kernel(Pool2DMeta const *m,
+                              float const *input_ptr,
                               float *input_grad_ptr,
-                              const float *output_ptr,
-                              const float *output_grad_ptr,
+                              float const *output_ptr,
+                              float const *output_grad_ptr,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const Pool2DMeta *m,
-                                      const float *input_ptr,
+  static void backward_kernel_wrapper(Pool2DMeta const *m,
+                                      float const *input_ptr,
                                       float *input_grad_ptr,
-                                      const float *output_ptr,
-                                      const float *output_grad_ptr);
+                                      float const *output_ptr,
+                                      float const *output_grad_ptr);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
   void serialize(Legion::Serializer &) const override;

--- a/include/flexflow/ops/pool_2d_params.h
+++ b/include/flexflow/ops/pool_2d_params.h
@@ -21,13 +21,13 @@ private:
                   ParallelDim output_dims[MAX_TENSOR_DIM]) const;
 };
 
-bool operator==(const Pool2DParams &, const Pool2DParams &);
+bool operator==(Pool2DParams const &, Pool2DParams const &);
 
 } // namespace FlexFlow
 
 namespace std {
 template <> struct hash<FlexFlow::Pool2DParams> {
-  size_t operator()(const FlexFlow::Pool2DParams &) const;
+  size_t operator()(FlexFlow::Pool2DParams const &) const;
 };
 } // namespace std
 

--- a/include/flexflow/ops/reshape.h
+++ b/include/flexflow/ops/reshape.h
@@ -12,7 +12,7 @@ public:
 };
 
 struct ReshapeParams {
-  ReshapeParams(const std::vector<int> &_shape);
+  ReshapeParams(std::vector<int> const &_shape);
   size_t get_hash(const ParallelTensor input) const;
   std::vector<int> shape;
 };
@@ -21,27 +21,27 @@ class Reshape : public Op {
 public:
   Reshape(FFModel &model,
           const ParallelTensor input,
-          const std::vector<int> &shape,
-          const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+          std::vector<int> const &shape,
+          char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename T>
@@ -63,7 +63,7 @@ public:
                                       const T *output_grad_ptr,
                                       size_t num_elements);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
   size_t get_params_hash() const override;
   void serialize(Legion::Serializer &s) const override;

--- a/include/flexflow/ops/reverse.h
+++ b/include/flexflow/ops/reverse.h
@@ -10,22 +10,22 @@ public:
   Reverse(FFModel &model,
           const ParallelTensor input,
           int axis,
-          const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+          char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   static void forward_kernel(float const *in_ptr,
@@ -55,7 +55,7 @@ public:
                                       Legion::coord_t in_blk_size,
                                       Legion::coord_t input_size);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
 public:

--- a/include/flexflow/ops/softmax.h
+++ b/include/flexflow/ops/softmax.h
@@ -10,8 +10,8 @@ class Softmax;
 class SoftmaxMeta : public OpMeta {
 public:
   SoftmaxMeta(FFHandler handle,
-              const Softmax *softmax,
-              const Legion::Domain &input_domain);
+              Softmax const *softmax,
+              Legion::Domain const &input_domain);
 #if defined(FF_USE_CUDA) || defined(FF_USE_HIP_CUDA)
   cudnnTensorDescriptor_t inputTensor;
 #else
@@ -27,46 +27,46 @@ public:
   Softmax(FFModel &model,
           const ParallelTensor logit,
           int dim,
-          const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+          char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   bool get_int_parameter(PMParameter, int *) const override;
-  void print_layer(const FFModel &model) override { assert(0); }
+  void print_layer(FFModel const &model) override { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   void init_meta(SoftmaxMeta *m,
                  Legion::Rect<2> const &input,
                  Legion::Rect<2> const &output) const;
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
-  static void forward_kernel(const SoftmaxMeta *m,
+  static void forward_kernel(SoftmaxMeta const *m,
                              float const *input_ptr,
                              float *output_ptr,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const SoftmaxMeta *m,
+  static void forward_kernel_wrapper(SoftmaxMeta const *m,
                                      float const *input_ptr,
                                      float *output_ptr);
   static void backward_kernel(float *input_grad_ptr,
                               float const *output_grad_ptr,
                               size_t num_elements,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const SoftmaxMeta *m,
+  static void backward_kernel_wrapper(SoftmaxMeta const *m,
                                       float *input_grad_ptr,
                                       float const *output_grad_ptr,
                                       size_t num_elements);
@@ -75,14 +75,14 @@ public:
 private:
   template <int NDIM>
   static void
-  forward_task_with_dim(const Legion::Task *task,
-                        const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_with_dim(Legion::Task const *task,
+                        std::vector<Legion::PhysicalRegion> const &regions,
                         Legion::Context ctx,
                         Legion::Runtime *runtime);
   template <int NDIM>
   static void
-  backward_task_with_dim(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_dim(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
 

--- a/include/flexflow/ops/split.h
+++ b/include/flexflow/ops/split.h
@@ -9,28 +9,28 @@ class Split : public Op {
 public:
   Split(FFModel &model,
         const ParallelTensor input,
-        const std::vector<int> &split,
+        std::vector<int> const &split,
         int legion_axis,
-        const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+        char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
   static Op *
   create_operator_from_layer(FFModel &model,
-                             const Layer *layer,
-                             const std::vector<ParallelTensor> &inputs);
+                             Layer const *layer,
+                             std::vector<ParallelTensor> const &inputs);
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   static void forward_kernel(float **out_ptrs,
@@ -60,7 +60,7 @@ public:
                                       Legion::coord_t num_blks,
                                       int numOutputs);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
   size_t get_params_hash() const override;

--- a/include/flexflow/ops/topk.h
+++ b/include/flexflow/ops/topk.h
@@ -17,29 +17,29 @@ public:
        const ParallelTensor input,
        int k,
        bool sorted,
-       const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+       char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
-  static void forward_kernel(const TopKMeta *m,
-                             const float *input_ptr,
+  static void forward_kernel(TopKMeta const *m,
+                             float const *input_ptr,
                              float *output_ptr,
                              int *indices_ptr,
                              size_t batch_size,
@@ -47,25 +47,25 @@ public:
                              int k,
                              bool sorted,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const TopKMeta *m,
-                                     const float *input_ptr,
+  static void forward_kernel_wrapper(TopKMeta const *m,
+                                     float const *input_ptr,
                                      float *output_ptr,
                                      int *indices_ptr,
                                      size_t batch_size,
                                      int length,
                                      int k,
                                      bool sorted);
-  static void backward_kernel(const TopKMeta *m,
-                              const float *out_grad_ptr,
-                              const int *indices_ptr,
+  static void backward_kernel(TopKMeta const *m,
+                              float const *out_grad_ptr,
+                              int const *indices_ptr,
                               float *in_grad_ptr,
                               size_t batch_size,
                               int length,
                               int k,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const TopKMeta *m,
-                                      const float *out_grad_ptr,
-                                      const int *indices_ptr,
+  static void backward_kernel_wrapper(TopKMeta const *m,
+                                      float const *out_grad_ptr,
+                                      int const *indices_ptr,
                                       float *in_grad_ptr,
                                       size_t batch_size,
                                       int length,

--- a/include/flexflow/ops/transpose.h
+++ b/include/flexflow/ops/transpose.h
@@ -16,52 +16,52 @@ class Transpose : public Op {
 public:
   Transpose(FFModel &model,
             const ParallelTensor input,
-            const std::vector<int> &perm,
-            const char *name);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
-  void print_layer(const FFModel &model) override { assert(0); }
+            std::vector<int> const &perm,
+            char const *name);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  void print_layer(FFModel const &model) override { assert(0); }
 
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
   void init_meta(TransposeMeta *m,
                  Legion::Domain const &in_domain,
                  Legion::Domain const &out_domain) const;
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void forward_kernel(const TransposeMeta *m,
-                             const float *input_ptr,
+  static void forward_kernel(TransposeMeta const *m,
+                             float const *input_ptr,
                              float *output_ptr,
                              Legion::Domain in_domain,
                              Legion::Domain out_domain,
                              ffStream_t stream);
-  static void forward_kernel_wrapper(const TransposeMeta *m,
-                                     const float *input_ptr,
+  static void forward_kernel_wrapper(TransposeMeta const *m,
+                                     float const *input_ptr,
                                      float *output_ptr,
                                      Legion::Domain in_domain,
                                      Legion::Domain out_domain);
-  static void backward_kernel(const TransposeMeta *m,
+  static void backward_kernel(TransposeMeta const *m,
                               float *input_grad_ptr,
-                              const float *output_grad_ptr,
+                              float const *output_grad_ptr,
                               Legion::Domain in_grad_domain,
                               Legion::Domain out_grad_domain,
                               ffStream_t stream);
-  static void backward_kernel_wrapper(const TransposeMeta *m,
+  static void backward_kernel_wrapper(TransposeMeta const *m,
                                       float *input_grad_ptr,
-                                      const float *output_grad_ptr,
+                                      float const *output_grad_ptr,
                                       Legion::Domain in_grad_domain,
                                       Legion::Domain out_grad_domain);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
 public:

--- a/include/flexflow/optimizer.h
+++ b/include/flexflow/optimizer.h
@@ -26,16 +26,16 @@ class OpMeta;
 
 class Optimizer {
 public:
-  Optimizer(const FFModel *_model);
+  Optimizer(FFModel const *_model);
   virtual void init(void) = 0;
   virtual void next(void) = 0;
   virtual void update(const ParallelTensor p) = 0;
-  const FFModel *model;
+  FFModel const *model;
 };
 
 class SGDOptimizer : public Optimizer {
 public:
-  SGDOptimizer(const FFModel *_model,
+  SGDOptimizer(FFModel const *_model,
                double lr = 0.01f,
                double momentum = 0.0f,
                bool nesterov = false,
@@ -44,25 +44,25 @@ public:
   void next(void);
   void update(const ParallelTensor p);
   void set_weight_decay(double _weight_decay);
-  static void ps_update_task(const Legion::Task *task,
-                             const std::vector<Legion::PhysicalRegion> &regions,
+  static void ps_update_task(Legion::Task const *task,
+                             std::vector<Legion::PhysicalRegion> const &regions,
                              Legion::Context ctx,
                              Legion::Runtime *runtime);
-  static void ps_update_task_gpu(const SGDOptimizer *op,
-                                 const float *w_grad_ptr,
+  static void ps_update_task_gpu(SGDOptimizer const *op,
+                                 float const *w_grad_ptr,
                                  size_t size,
                                  int num_replicas,
                                  float *w_ptr,
                                  float *v_ptr);
 #ifdef FF_USE_NCCL
   static void
-  nccl_update_task(const Legion::Task *task,
-                   const std::vector<Legion::PhysicalRegion> &regions,
+  nccl_update_task(Legion::Task const *task,
+                   std::vector<Legion::PhysicalRegion> const &regions,
                    Legion::Context ctx,
                    Legion::Runtime *runtime);
-  static void nccl_update_task_gpu(const SGDOptimizer *op,
-                                   const OpMeta *meta,
-                                   const float *w_grad_ptr,
+  static void nccl_update_task_gpu(SGDOptimizer const *op,
+                                   OpMeta const *meta,
+                                   float const *w_grad_ptr,
                                    size_t size,
                                    float *w_ptr,
                                    float *v_ptr);
@@ -76,7 +76,7 @@ public:
 
 class AdamOptimizer : public Optimizer {
 public:
-  AdamOptimizer(const FFModel *_model,
+  AdamOptimizer(FFModel const *_model,
                 double _alpha = 0.001f,
                 double _beta1 = 0.9f,
                 double _beta2 = 0.999f,
@@ -86,12 +86,12 @@ public:
   void next(void);
   void update(const ParallelTensor p);
   void set_weight_decay(double _weight_decay);
-  static void ps_update_task(const Legion::Task *task,
-                             const std::vector<Legion::PhysicalRegion> &regions,
+  static void ps_update_task(Legion::Task const *task,
+                             std::vector<Legion::PhysicalRegion> const &regions,
                              Legion::Context ctx,
                              Legion::Runtime *runtime);
-  static void ps_update_task_gpu(const AdamOptimizer *op,
-                                 const float *w_grad_ptr,
+  static void ps_update_task_gpu(AdamOptimizer const *op,
+                                 float const *w_grad_ptr,
                                  size_t size,
                                  int num_replicas,
                                  float *w_ptr,
@@ -99,13 +99,13 @@ public:
                                  float *m_ptr);
 #ifdef FF_USE_NCCL
   static void
-  nccl_update_task(const Legion::Task *task,
-                   const std::vector<Legion::PhysicalRegion> &regions,
+  nccl_update_task(Legion::Task const *task,
+                   std::vector<Legion::PhysicalRegion> const &regions,
                    Legion::Context ctx,
                    Legion::Runtime *runtime);
-  static void nccl_update_task_gpu(const AdamOptimizer *op,
-                                   const OpMeta *meta,
-                                   const float *w_grad_ptr,
+  static void nccl_update_task_gpu(AdamOptimizer const *op,
+                                   OpMeta const *meta,
+                                   float const *w_grad_ptr,
                                    size_t size,
                                    float *w_ptr,
                                    float *v_ptr,

--- a/include/flexflow/parallel_ops/combine.h
+++ b/include/flexflow/parallel_ops/combine.h
@@ -17,36 +17,36 @@ public:
           const ParallelTensor input,
           int combine_legion_dim,
           int combine_degree,
-          const char *name = NULL);
+          char const *name = NULL);
   void create_input_partition(FFModel &model) override;
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   bool get_int_parameter(PMParameter, int *) const override;
   bool append_parallel_op_info(
       std::vector<ParallelOpInfo> &parallel_ops) const override;
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename T>
   static void
-  forward_task_with_type(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_with_type(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   template <typename T>
   static void
-  backward_task_with_type(const Legion::Task *task,
-                          const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_type(Legion::Task const *task,
+                          std::vector<Legion::PhysicalRegion> const &regions,
                           Legion::Context ctx,
                           Legion::Runtime *runtime);
   template <typename T>
@@ -57,7 +57,7 @@ public:
                               T *input_grad_ptr,
                               size_t num_elements);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &mv,
+                             MachineView const &mv,
                              CostMetrics &cost_metrics) const override;
 
   size_t get_params_hash() const override;

--- a/include/flexflow/parallel_ops/fused_parallel_op.h
+++ b/include/flexflow/parallel_ops/fused_parallel_op.h
@@ -9,19 +9,19 @@ class FusedParallelOp : public ParallelOp {
 public:
   FusedParallelOp(FFModel &model,
                   const ParallelTensor input,
-                  const std::vector<ParallelOpInfo> &parallel_ops);
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+                  std::vector<ParallelOpInfo> const &parallel_ops);
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   bool append_parallel_op_info(
       std::vector<ParallelOpInfo> &parallel_ops) const override;
   void create_input_partition(FFModel &model) override;
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename T>
@@ -32,9 +32,9 @@ public:
                               T *input_grad_ptr,
                               size_t num_elements);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &mv,
+                             MachineView const &mv,
                              CostMetrics &cost_metrics) const override;
-  void set_parallel_ops(const std::vector<ParallelOpInfo> &_parallel_ops);
+  void set_parallel_ops(std::vector<ParallelOpInfo> const &_parallel_ops);
   bool check_no_redundant_parallel_ops(void) const;
 
   size_t get_params_hash() const override;

--- a/include/flexflow/parallel_ops/parallel_op.h
+++ b/include/flexflow/parallel_ops/parallel_op.h
@@ -26,15 +26,15 @@ class ParallelOp : public Op {
 public:
   ParallelOp(FFModel &model,
              OperatorType type,
-             const char *_name,
+             char const *_name,
              const ParallelTensor input);
-  virtual void init(const FFModel &) = 0;
-  virtual void forward(const FFModel &) = 0;
-  virtual void backward(const FFModel &) = 0;
+  virtual void init(FFModel const &) = 0;
+  virtual void forward(FFModel const &) = 0;
+  virtual void backward(FFModel const &) = 0;
   virtual void create_input_partition(FFModel &model) = 0;
-  void print_layer(const FFModel &model){};
+  void print_layer(FFModel const &model){};
   virtual bool measure_operator_cost(Simulator *sim,
-                                     const MachineView &pc,
+                                     MachineView const &pc,
                                      CostMetrics &cost_metrics) const = 0;
   virtual bool
   append_parallel_op_info(std::vector<ParallelOpInfo> &parallel_ops) const = 0;

--- a/include/flexflow/parallel_ops/partition.h
+++ b/include/flexflow/parallel_ops/partition.h
@@ -17,36 +17,36 @@ public:
               const ParallelTensor input,
               int repartition_legion_dim,
               int repartition_degree,
-              const char *name = NULL);
+              char const *name = NULL);
   void create_input_partition(FFModel &model) override;
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   bool get_int_parameter(PMParameter, int *) const override;
   bool append_parallel_op_info(
       std::vector<ParallelOpInfo> &parallel_ops) const override;
-  static OpMeta *init_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename T>
   static void
-  forward_task_with_type(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  forward_task_with_type(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   template <typename T>
   static void
-  backward_task_with_type(const Legion::Task *task,
-                          const std::vector<Legion::PhysicalRegion> &regions,
+  backward_task_with_type(Legion::Task const *task,
+                          std::vector<Legion::PhysicalRegion> const &regions,
                           Legion::Context ctx,
                           Legion::Runtime *runtime);
   template <typename T>
@@ -57,7 +57,7 @@ public:
                               T *input_grad_ptr,
                               size_t num_elements);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
   size_t get_params_hash() const override;

--- a/include/flexflow/parallel_ops/reduction.h
+++ b/include/flexflow/parallel_ops/reduction.h
@@ -11,21 +11,21 @@ public:
             const ParallelTensor input,
             int reduction_legion_dim,
             int reduction_degree,
-            const char *name = NULL);
+            char const *name = NULL);
 
   void create_input_partition(FFModel &model) override;
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   bool get_int_parameter(PMParameter, int *) const override;
   bool append_parallel_op_info(
       std::vector<ParallelOpInfo> &parallel_ops) const override;
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename T>
@@ -38,7 +38,7 @@ public:
                               T *input_grad_ptr,
                               size_t num_elements);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
   size_t get_params_hash() const override;

--- a/include/flexflow/parallel_ops/replicate.h
+++ b/include/flexflow/parallel_ops/replicate.h
@@ -11,20 +11,20 @@ public:
             const ParallelTensor input,
             int replicate_legion_dim,
             int replicate_degree,
-            const char *name = NULL);
+            char const *name = NULL);
   void create_input_partition(FFModel &model) override;
-  void init(const FFModel &) override;
-  void forward(const FFModel &) override;
-  void backward(const FFModel &) override;
+  void init(FFModel const &) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
   bool get_int_parameter(PMParameter, int *) const override;
   bool append_parallel_op_info(
       std::vector<ParallelOpInfo> &parallel_ops) const override;
-  static void forward_task(const Legion::Task *task,
-                           const std::vector<Legion::PhysicalRegion> &regions,
+  static void forward_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
                            Legion::Context ctx,
                            Legion::Runtime *runtime);
-  static void backward_task(const Legion::Task *task,
-                            const std::vector<Legion::PhysicalRegion> &regions,
+  static void backward_task(Legion::Task const *task,
+                            std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
   template <typename T>
@@ -36,7 +36,7 @@ public:
                               size_t num_elements,
                               size_t num_replicas);
   bool measure_operator_cost(Simulator *sim,
-                             const MachineView &pc,
+                             MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
 
   size_t get_params_hash() const override;

--- a/include/flexflow/parallel_tensor.h
+++ b/include/flexflow/parallel_tensor.h
@@ -36,7 +36,7 @@ struct ParallelDim {
   static constexpr int UNKNOWN_DEGREE = -1;
   static constexpr int UNKNOWN_INDEX = -2;
 
-  bool operator==(const ParallelDim &rhs) const {
+  bool operator==(ParallelDim const &rhs) const {
     if (size != rhs.size)
       return false;
     if (degree != rhs.degree)
@@ -46,7 +46,7 @@ struct ParallelDim {
     return true;
   }
 
-  bool operator!=(const ParallelDim &rhs) const {
+  bool operator!=(ParallelDim const &rhs) const {
     if (size != rhs.size)
       return true;
     if (degree != rhs.degree)
@@ -87,8 +87,8 @@ struct ParallelTensorShape {
   ParallelDim dims[MAX_TENSOR_DIM]; ///< Details of each dimension
   DataType data_type;               ///< Data type
 
-  bool operator==(const ParallelTensorShape &other) const;
-  bool operator!=(const ParallelTensorShape &other) const;
+  bool operator==(ParallelTensorShape const &other) const;
+  bool operator!=(ParallelTensorShape const &other) const;
 
   RecordFormatter as_dot() const;
 
@@ -125,7 +125,7 @@ class FFConfig;
 struct ParallelTensorBase {
   static constexpr ParallelTensorBase *NO_TENSOR = nullptr;
   ParallelTensorBase(void) = default;
-  ParallelTensorBase(const ParallelTensorBase &rhs);
+  ParallelTensorBase(ParallelTensorBase const &rhs);
   // Tensor& operator=(const Tensor& rhs);
   // bool operator==(const Tensor& rhs) const;
   void inline_map(FFConfig &config);
@@ -133,12 +133,12 @@ struct ParallelTensorBase {
   template <typename T> T *get_raw_ptr(FFConfig &config);
   void attach_raw_ptr(FFConfig &config, void *raw_ptr, bool column_major);
   void detach_raw_ptr(FFConfig &config);
-  bool get_input_sub_tensor(const ParallelConfig &pc,
+  bool get_input_sub_tensor(ParallelConfig const &pc,
                             ParallelTensorBase &tensor,
                             OperatorType type);
-  bool get_sub_tensor(const MachineView &mv,
+  bool get_sub_tensor(MachineView const &mv,
                       ParallelTensorBase &subtensor) const;
-  bool get_output_sub_tensor(const ParallelConfig &pc,
+  bool get_output_sub_tensor(ParallelConfig const &pc,
                              ParallelTensorBase &tensor,
                              OperatorType type);
   size_t get_owner_independent_hash() const;
@@ -148,19 +148,19 @@ struct ParallelTensorBase {
   int get_num_replicas() const;
   Legion::Domain get_domain() const;
   bool check_valid() const;
-  bool is_valid_machine_view(const MachineView &view) const;
-  void print(const std::string &name) const;
+  bool is_valid_machine_view(MachineView const &view) const;
+  void print(std::string const &name) const;
   static bool update_parallel_ids(int numdim, ParallelDim *dims);
   template <typename T>
   bool
-  set_tensor(const FFModel *model, const std::vector<int> &dims, const T *data);
+  set_tensor(FFModel const *model, std::vector<int> const &dims, const T *data);
   template <typename T>
-  bool get_tensor(const FFModel *model, T *data, bool get_parameters);
+  bool get_tensor(FFModel const *model, T *data, bool get_parameters);
   ParallelTensorShape get_shape() const;
 
 private:
   template <typename T>
-  bool get_input_sub_tensor_via_mappings(const ParallelConfig &pc,
+  bool get_input_sub_tensor_via_mappings(ParallelConfig const &pc,
                                          ParallelTensorBase &tensor) const;
 
 public:
@@ -172,7 +172,7 @@ public:
   ParameterSyncType sync_type = ParameterSyncType::NONE;
   Initializer *initializer = nullptr;
   // Describes the ownership of this tensor
-  const Op *owner_op = nullptr;
+  Op const *owner_op = nullptr;
   int owner_idx = 0;
   bool create_gradients = false;
 

--- a/include/flexflow/simulator.h
+++ b/include/flexflow/simulator.h
@@ -154,8 +154,8 @@ public:
                     NetworkRoutingStrategy *routing);
   /* pick one of the weighted ECMP path */
   Route expand_to_physical() const;
-  const EcmpRoutes &get_all_routes();
-  void set_physical_paths(const EcmpRoutes &rs);
+  EcmpRoutes const &get_all_routes();
+  void set_physical_paths(EcmpRoutes const &rs);
   void reset();
 
 public:
@@ -343,8 +343,8 @@ private:
 class WeightedShortestPathRoutingStrategy : public NetworkRoutingStrategy {
 public:
   WeightedShortestPathRoutingStrategy(
-      const ConnectionMatrix &c,
-      const std::map<size_t, CommDevice *> &devmap,
+      ConnectionMatrix const &c,
+      std::map<size_t, CommDevice *> const &devmap,
       int total_devs);
   virtual EcmpRoutes get_routes(int src_node, int dst_node);
   virtual std::vector<EcmpRoutes> get_routes_from_src(int src_node);
@@ -353,16 +353,16 @@ public:
   void clear();
 
 public:
-  const ConnectionMatrix &conn;
-  const std::map<size_t, CommDevice *> &devmap;
+  ConnectionMatrix const &conn;
+  std::map<size_t, CommDevice *> const &devmap;
   int total_devs;
 };
 
 class ShortestPathNetworkRoutingStrategy : public NetworkRoutingStrategy {
 public:
   ShortestPathNetworkRoutingStrategy(
-      const ConnectionMatrix &c,
-      const std::map<size_t, CommDevice *> &devmap,
+      ConnectionMatrix const &c,
+      std::map<size_t, CommDevice *> const &devmap,
       int total_devs);
   virtual EcmpRoutes get_routes(int src_node, int dst_node);
   virtual std::vector<EcmpRoutes> get_routes_from_src(int src_node);
@@ -371,8 +371,8 @@ public:
   void clear();
 
 public:
-  const ConnectionMatrix &conn;
-  const std::map<size_t, CommDevice *> &devmap;
+  ConnectionMatrix const &conn;
+  std::map<size_t, CommDevice *> const &devmap;
   int total_devs;
 };
 
@@ -384,7 +384,7 @@ class NetworkTopologyGenerator {
 public:
   virtual ConnectionMatrix generate_topology() const = 0;
   static void
-  print_conn_matrix(const ConnectionMatrix &conn, int nnode, int nswitch) {
+  print_conn_matrix(ConnectionMatrix const &conn, int nnode, int nswitch) {
     int nnwdevs = nnode + nswitch;
     for (int i = 0; i < nnwdevs; i++) {
       if (i == nnode)
@@ -411,7 +411,7 @@ public:
 
 public:
   inline int get_id(int i, int j) const;
-  inline int get_if_in_use(int node, const ConnectionMatrix &conn) const;
+  inline int get_if_in_use(int node, ConnectionMatrix const &conn) const;
   int num_nodes;
   int degree;
 };
@@ -481,7 +481,7 @@ public:
                         int num_gpus_per_node,
                         int num_switches,
                         float network_latency,
-                        const std::vector<int> &topology,
+                        std::vector<int> const &topology,
                         size_t capacity,
                         float link_bandwidth);
   ~NetworkedMachineModel();
@@ -505,12 +505,12 @@ public:
   /* return only the nominal device. For recording tg. */
   CommDevice *get_nominal_path(MemDevice *src_mem, MemDevice *tar_mem) const;
   /* stores the network topology as a json */
-  void save_topology_json(const std::string &fname) const;
+  void save_topology_json(std::string const &fname) const;
   void update_route();
 
-  void set_topology(const std::vector<int> &topology);
-  const ConnectionMatrix &get_conn_matrix();
-  const std::map<size_t, NominalCommDevice *> &get_nomm_comm_devs();
+  void set_topology(std::vector<int> const &topology);
+  ConnectionMatrix const &get_conn_matrix();
+  std::map<size_t, NominalCommDevice *> const &get_nomm_comm_devs();
 
   void set_pcie(bool state);
   void set_pipeline(bool state);
@@ -616,13 +616,13 @@ public:
   SimTask *new_nominal_comm_task(std::string const &name,
                                  CommDevice *comm_device,
                                  size_t message_size);
-  SimTask *new_forward_task(const Op *op, int idx);
-  SimTask *new_allreduce_task(const Op *op,
-                              const std::vector<int> &node_ids,
+  SimTask *new_forward_task(Op const *op, int idx);
+  SimTask *new_allreduce_task(Op const *op,
+                              std::vector<int> const &node_ids,
                               size_t message_size);
-  SimTask *new_backward_task(const Op *op, int idx);
-  SimTask *get_forward_task(const Op *op, int idx);
-  SimTask *get_backward_task(const Op *op, int idx);
+  SimTask *new_backward_task(Op const *op, int idx);
+  SimTask *get_forward_task(Op const *op, int idx);
+  SimTask *get_backward_task(Op const *op, int idx);
 
   SimTask *new_task();
 
@@ -640,7 +640,7 @@ using ProfilingRecordKey = std::tuple<OperatorParameters, MachineView>;
 class Simulator {
 public:
   static constexpr float MAXIMUM_TASK_RUN_TIME = 1e7;
-  Simulator(const FFModel *model,
+  Simulator(FFModel const *model,
             FFHandler handler,
             Legion::Memory memory,
             MachineModel *machine);
@@ -651,32 +651,32 @@ public:
                                        SimTask *dst_task,
                                        size_t message_size,
                                        bool force_zero_cost = false);
-  CostMetrics measure_operator_cost(const Op *op, const ParallelConfig &config);
-  CostMetrics measure_operator_cost(const Op *op, const MachineView &view);
-  float estimate_xfer_cost(const Op *op,
+  CostMetrics measure_operator_cost(Op const *op, ParallelConfig const &config);
+  CostMetrics measure_operator_cost(Op const *op, MachineView const &view);
+  float estimate_xfer_cost(Op const *op,
                            int input_idx,
-                           const MachineView &source_view,
-                           const MachineView &sink_view);
+                           MachineView const &source_view,
+                           MachineView const &sink_view);
   float
   default_estimate_sync_cost(const ParallelDim tensor_dims[MAX_TENSOR_DIM],
                              int tensor_ndims,
-                             const MachineView &view);
+                             MachineView const &view);
   float default_estimate_sync_cost(ParallelTensorShape const &tensor_shape,
-                                   const MachineView &view,
+                                   MachineView const &view,
                                    int num_replicate_dims);
   float default_estimate_sync_cost(const ParallelTensor tensor,
-                                   const MachineView &view,
+                                   MachineView const &view,
                                    int num_replicate_dims);
-  float simulate_runtime(const FFModel *model,
-                         const std::map<const Op *, ParallelConfig> &global,
+  float simulate_runtime(FFModel const *model,
+                         std::map<Op const *, ParallelConfig> const &global,
                          CompMode comp_mode);
-  float simulate_runtime(const FFModel *model,
-                         const std::map<const Op *, ParallelConfig> &global,
+  float simulate_runtime(FFModel const *model,
+                         std::map<Op const *, ParallelConfig> const &global,
                          CompMode comp_mode,
                          std::string const &export_file_name);
   static void
-  strategy_search_task(const Legion::Task *task,
-                       const std::vector<Legion::PhysicalRegion> &regions,
+  strategy_search_task(Legion::Task const *task,
+                       std::vector<Legion::PhysicalRegion> const &regions,
                        Legion::Context ctx,
                        Legion::Runtime *runtime);
 
@@ -720,10 +720,10 @@ private:
   float
   estimate_repartition_xfer_cost(int repartition_dim,
                                  int repartition_degree,
-                                 const ParallelTensorShape &input_tensor_shape,
-                                 const ParallelTensorShape &output_tensor_shape,
-                                 const MachineView &source_view,
-                                 const MachineView &target_view) const;
+                                 ParallelTensorShape const &input_tensor_shape,
+                                 ParallelTensorShape const &output_tensor_shape,
+                                 MachineView const &source_view,
+                                 MachineView const &target_view) const;
 };
 
 /**
@@ -733,7 +733,7 @@ private:
  */
 class LogicalTaskgraphBasedSimulator : public Simulator {
 public:
-  LogicalTaskgraphBasedSimulator(const FFModel *model,
+  LogicalTaskgraphBasedSimulator(FFModel const *model,
                                  FFHandler handler,
                                  Legion::Memory memory,
                                  MachineModel *machine);
@@ -741,12 +741,12 @@ public:
   SimTask *new_comm_task_unrecorded();
   SimTask *new_update_task_unrecorded();
   virtual float
-  simulate_runtime(const FFModel *model,
-                   const std::map<const Op *, ParallelConfig> &global,
+  simulate_runtime(FFModel const *model,
+                   std::map<Op const *, ParallelConfig> const &global,
                    CompMode comp_mode);
   virtual float
-  simulate_runtime(const FFModel *model,
-                   const std::map<const Op *, ParallelConfig> &global,
+  simulate_runtime(FFModel const *model,
+                   std::map<Op const *, ParallelConfig> const &global,
                    CompMode comp_mode,
                    std::string const &export_file_name);
   virtual float route_transfer(SimTask *transfer_task,
@@ -765,8 +765,8 @@ public:
                                        SimTask *dst_task,
                                        size_t message_size);
   static void
-  simulation_task(const Legion::Task *task,
-                  const std::vector<Legion::PhysicalRegion> &regions,
+  simulation_task(Legion::Task const *task,
+                  std::vector<Legion::PhysicalRegion> const &regions,
                   Legion::Context ctx,
                   Legion::Runtime *runtime);
   bool segment_transfer;

--- a/include/flexflow/substitution.h
+++ b/include/flexflow/substitution.h
@@ -65,7 +65,7 @@ struct TensorX {
   static const TensorX NO_TX;
   TensorX(void) : op(NULL), idx(0) {}
   TensorX(OpX *_op, int _idx) : op(_op), idx(_idx) {}
-  tl::optional<ParallelTensor> to_tensor(const GraphXfer *xfer) const;
+  tl::optional<ParallelTensor> to_tensor(GraphXfer const *xfer) const;
   OpX *op;
   int idx;
 
@@ -74,7 +74,7 @@ struct TensorX {
 };
 
 struct TensorXCompare {
-  bool operator()(const TensorX &a, const TensorX &b) const {
+  bool operator()(TensorX const &a, TensorX const &b) const {
     if (a.op != b.op)
       return a.op < b.op;
     return a.idx < b.idx;
@@ -86,14 +86,14 @@ public:
   OpX(OperatorType type,
       int numInputs,
       int numOutputs,
-      const TensorX &input1 = TensorX::NO_TX,
-      const TensorX &input2 = TensorX::NO_TX,
-      const TensorX &input3 = TensorX::NO_TX,
-      const TensorX &input4 = TensorX::NO_TX);
+      TensorX const &input1 = TensorX::NO_TX,
+      TensorX const &input2 = TensorX::NO_TX,
+      TensorX const &input3 = TensorX::NO_TX,
+      TensorX const &input4 = TensorX::NO_TX);
   OpX(OperatorType type,
       int num_inputs,
       int num_outputs,
-      const TensorX *inputs);
+      TensorX const *inputs);
   bool add_pm_constraint(Compare, PMParameter para, int value);
   bool add_input_constraint(Compare, TNParameter, DIMParameter, int);
   bool add_input_constraint(
@@ -103,7 +103,7 @@ public:
 public:
   OperatorType type;
   Node mapOp;
-  const OpX *matchOpX;
+  OpX const *matchOpX;
   std::vector<TensorX> inputs, weights, outputs;
   std::vector<PMConstraint> pmConstraints;
   std::vector<TNConstraint> tnConstraints;
@@ -157,47 +157,47 @@ class GraphXfer {
 public:
   GraphXfer(FFModel *_model);
   TensorX new_tensor(void);
-  bool can_match(OpX *srcOp, const Node &op, Graph const *graph);
-  void match(OpX *srcOp, const Node &op, Graph const *graph);
-  void unmatch(OpX *srcOp, const Node &op, Graph const *graph);
+  bool can_match(OpX *srcOp, Node const &op, Graph const *graph);
+  void match(OpX *srcOp, Node const &op, Graph const *graph);
+  void unmatch(OpX *srcOp, Node const &op, Graph const *graph);
   // Compute Ops
   template <typename T>
-  OpX *create_opx(const TensorX &input, const OpX *matchOpX);
+  OpX *create_opx(TensorX const &input, OpX const *matchOpX);
 
-  OpX *create_noop(const TensorX &input);
-  OpX *create_concat(const TensorX *inputs,
+  OpX *create_noop(TensorX const &input);
+  OpX *create_concat(TensorX const *inputs,
                      int num_inputs,
-                     const OpX *match_opx,
+                     OpX const *match_opx,
                      int concat_dim);
-  OpX *create_element_binary(const TensorX &input1,
-                             const TensorX &input2,
+  OpX *create_element_binary(TensorX const &input1,
+                             TensorX const &input2,
                              OperatorType op_type);
-  OpX *create_element_unary(const TensorX &input, OperatorType op_type);
-  OpX *create_relu(const TensorX &input);
-  OpX *create_linear(const TensorX &input,
-                     const OpX *match_opx,
+  OpX *create_element_unary(TensorX const &input, OperatorType op_type);
+  OpX *create_relu(TensorX const &input);
+  OpX *create_linear(TensorX const &input,
+                     OpX const *match_opx,
                      int num_dims,
                      ActiMode acti_mode,
                      bool use_bias);
-  OpX *create_conv2d(const TensorX &input, const OpX *match_opx);
-  OpX *create_pool2d(const TensorX &input, const OpX *match_opx);
-  OpX *create_attention(const TensorX &query,
-                        const TensorX &key,
-                        const TensorX &value,
-                        const OpX *match_opx,
+  OpX *create_conv2d(TensorX const &input, OpX const *match_opx);
+  OpX *create_pool2d(TensorX const &input, OpX const *match_opx);
+  OpX *create_attention(TensorX const &query,
+                        TensorX const &key,
+                        TensorX const &value,
+                        OpX const *match_opx,
                         int num_heads);
-  OpX *create_softmax(const TensorX &input, int softmax_dim);
+  OpX *create_softmax(TensorX const &input, int softmax_dim);
   // Parallel Ops
   OpX *
-  create_repartition(const TensorX &input, int repartition_dim, int num_parts);
-  OpX *create_replicate(const TensorX &input, int replicate_dim, int num_parts);
-  OpX *create_reduction(const TensorX &input, int reduction_dim, int num_parts);
-  OpX *create_combine(const TensorX &input, int combine_dim, int num_parts);
-  bool map_output(const TensorX &src, const TensorX &dst);
+  create_repartition(TensorX const &input, int repartition_dim, int num_parts);
+  OpX *create_replicate(TensorX const &input, int replicate_dim, int num_parts);
+  OpX *create_reduction(TensorX const &input, int reduction_dim, int num_parts);
+  OpX *create_combine(TensorX const &input, int combine_dim, int num_parts);
+  bool map_output(TensorX const &src, TensorX const &dst);
 
   Graph *create_new_graph(Graph const *graph,
                           SimplificationSettings const &settings);
-  bool create_new_operator(const OpX *opx, Node &op);
+  bool create_new_operator(OpX const *opx, Node &op);
 
   std::string get_name() const;
 

--- a/include/flexflow/tensor.h
+++ b/include/flexflow/tensor.h
@@ -28,7 +28,7 @@ class ParallelTensorBase;
 
 struct TensorBase {
   TensorBase(void) = default;
-  TensorBase(const TensorBase &rhs);
+  TensorBase(TensorBase const &rhs);
   // void inline_map(FFConfig &config);
   // void inline_unmap(FFConfig &config);
   // template<typename T>
@@ -47,13 +47,13 @@ struct TensorBase {
   Legion::Domain get_domain() const;
   // bool check_valid() const;
   // bool is_valid_machine_view(const MachineView& view) const;
-  void print(const std::string &name) const;
+  void print(std::string const &name) const;
   // static bool update_parallel_ids(int numdim, ParallelDim* dims);
   template <typename T>
   bool
-  set_tensor(const FFModel *model, const std::vector<int> &dims, const T *data);
+  set_tensor(FFModel const *model, std::vector<int> const &dims, const T *data);
   template <typename T>
-  bool get_tensor(const FFModel *model, T *data, bool get_gradients);
+  bool get_tensor(FFModel const *model, T *data, bool get_gradients);
   // TensorShape get_shape() const;
 private:
   // template <typename T>
@@ -69,7 +69,7 @@ public:
   Initializer *initializer = nullptr;
   ParallelTensorBase *parallel_tensor = nullptr;
   // Describes the ownership of this tensor
-  const Layer *owner_layer = nullptr;
+  Layer const *owner_layer = nullptr;
   int owner_idx = 0;
   bool create_gradients = false;
 };

--- a/include/flexflow/utils/cuda_helper.h
+++ b/include/flexflow/utils/cuda_helper.h
@@ -62,11 +62,11 @@
        i += blockDim.x * gridDim.x)
 
 // Use 1024 threads per block, which requires cuda sm_2x or above
-const int CUDA_NUM_THREADS = 1024;
-const int BLOCK_SIZE_LIMIT = 32768;
+int const CUDA_NUM_THREADS = 1024;
+int const BLOCK_SIZE_LIMIT = 32768;
 
 // CUDA: number of blocks for threads.
-inline int GET_BLOCKS(const int N) {
+inline int GET_BLOCKS(int const N) {
   int ret = (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
   return (ret > BLOCK_SIZE_LIMIT) ? BLOCK_SIZE_LIMIT : ret;
 }
@@ -93,13 +93,13 @@ __global__ void sigmoid_backward_kernel(T *grad_ptr, const T *input, size_t n);
 
 __host__ void relu_backward_kernel(DataType data_type,
                                    void *output_grad_ptr,
-                                   const void *output_ptr,
+                                   void const *output_ptr,
                                    size_t output_size,
                                    cudaStream_t stream);
 
 __host__ void sigmoid_backward_kernel(DataType data_type,
                                       void *output_grad_ptr,
-                                      const void *output_ptr,
+                                      void const *output_ptr,
                                       size_t output_size,
                                       cudaStream_t stream);
 
@@ -112,24 +112,24 @@ gelu_forward_kernel(size_t size, float B, float C, float *input);
 
 // Use by concat and split
 __global__ void add_with_stride(float *output,
-                                const float *input,
+                                float const *input,
                                 int num_blocks,
                                 int output_blk_size,
                                 int input_blk_size);
 __global__ void copy_with_stride(float *output,
-                                 const float *input,
+                                 float const *input,
                                  int num_blocks,
                                  int output_blk_size,
                                  int input_blk_size);
 
 __host__ void updateGAS(float *para_ptr,
-                        const float *grad_ptr,
+                        float const *grad_ptr,
                         size_t replica_size,
                         int num_replica,
                         float learning_rate);
 
 template <typename T>
-void print_tensor(const T *ptr, size_t num_elements, const char *prefix);
+void print_tensor(const T *ptr, size_t num_elements, char const *prefix);
 
 cudnnStatus_t cudnnSetTensorDescriptorFromDomain(cudnnTensorDescriptor_t tensor,
                                                  Legion::Domain domain);

--- a/include/flexflow/utils/hash_utils.h
+++ b/include/flexflow/utils/hash_utils.h
@@ -21,7 +21,7 @@ private:
   //
   template <size_t Idx, typename... TupleTypes>
   inline typename std::enable_if<Idx == sizeof...(TupleTypes), void>::type
-  hash_combine_tup(size_t &seed, const std::tuple<TupleTypes...> &tup) const {}
+  hash_combine_tup(size_t &seed, std::tuple<TupleTypes...> const &tup) const {}
 
   //  this is the computation function
   //  continues till condition N < sizeof...(TupleTypes) holds
@@ -30,7 +30,7 @@ private:
       inline typename std::enable_if <
       Idx<sizeof...(TupleTypes), void>::type
       hash_combine_tup(size_t &seed,
-                       const std::tuple<TupleTypes...> &tup) const {
+                       std::tuple<TupleTypes...> const &tup) const {
     hash_combine(seed, std::get<Idx>(tup));
 
     //  on to next element
@@ -38,7 +38,7 @@ private:
   }
 
 public:
-  size_t operator()(const std::tuple<TupleArgs...> &tupleValue) const {
+  size_t operator()(std::tuple<TupleArgs...> const &tupleValue) const {
     size_t seed = 0;
     //  begin with the first iteration
     hash_combine_tup<0>(seed, tupleValue);
@@ -47,7 +47,7 @@ public:
 };
 
 template <typename L, typename R> struct hash<std::pair<L, R>> {
-  size_t operator()(const std::pair<L, R> &p) const {
+  size_t operator()(std::pair<L, R> const &p) const {
     size_t seed = 283746;
 
     hash_combine(seed, p.first);
@@ -58,10 +58,10 @@ template <typename L, typename R> struct hash<std::pair<L, R>> {
 };
 
 template <typename T> struct hash<std::vector<T>> {
-  size_t operator()(const std::vector<T> &vec) const {
+  size_t operator()(std::vector<T> const &vec) const {
     size_t seed = 0;
     hash_combine(seed, vec.size());
-    for (const auto &ele : vec) {
+    for (auto const &ele : vec) {
       hash_combine(seed, ele);
     }
     return seed;

--- a/include/flexflow/utils/hip_helper.h
+++ b/include/flexflow/utils/hip_helper.h
@@ -62,11 +62,11 @@
        i += blockDim.x * gridDim.x)
 
 // Use 1024 threads per block, which requires cuda sm_2x or above
-const int CUDA_NUM_THREADS = 1024;
-const int BLOCK_SIZE_LIMIT = 32768;
+int const CUDA_NUM_THREADS = 1024;
+int const BLOCK_SIZE_LIMIT = 32768;
 
 // CUDA: number of blocks for threads.
-inline int GET_BLOCKS(const int N) {
+inline int GET_BLOCKS(int const N) {
   int ret = (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
   return (ret > BLOCK_SIZE_LIMIT) ? BLOCK_SIZE_LIMIT : ret;
 }
@@ -93,13 +93,13 @@ __global__ void sigmoid_backward_kernel(T *grad_ptr, const T *input, size_t n);
 
 __host__ void relu_backward_kernel(DataType data_type,
                                    void *output_grad_ptr,
-                                   const void *output_ptr,
+                                   void const *output_ptr,
                                    size_t output_size,
                                    hipStream_t stream);
 
 __host__ void sigmoid_backward_kernel(DataType data_type,
                                       void *output_grad_ptr,
-                                      const void *output_ptr,
+                                      void const *output_ptr,
                                       size_t output_size,
                                       hipStream_t stream);
 
@@ -112,24 +112,24 @@ gelu_forward_kernel(size_t size, float B, float C, float *input);
 
 // Use by concat and split
 __global__ void add_with_stride(float *output,
-                                const float *input,
+                                float const *input,
                                 int num_blocks,
                                 int output_blk_size,
                                 int input_blk_size);
 __global__ void copy_with_stride(float *output,
-                                 const float *input,
+                                 float const *input,
                                  int num_blocks,
                                  int output_blk_size,
                                  int input_blk_size);
 
 __host__ void updateGAS(float *para_ptr,
-                        const float *grad_ptr,
+                        float const *grad_ptr,
                         size_t replica_size,
                         int num_replica,
                         float learning_rate);
 
 template <typename T>
-void print_tensor(const T *ptr, size_t num_elements, const char *prefix);
+void print_tensor(const T *ptr, size_t num_elements, char const *prefix);
 
 miopenStatus_t
 cudnnSetTensorDescriptorFromDomain(miopenTensorDescriptor_t tensor,

--- a/include/flexflow/utils/test_utils.h
+++ b/include/flexflow/utils/test_utils.h
@@ -12,26 +12,26 @@ struct ArgsConfig;
 
 void initialize_tensor_from_file(const std::string file_path,
                                  Tensor label,
-                                 const FFModel &ff,
+                                 FFModel const &ff,
                                  std::string data_type = "float",
                                  int num_dim = 3);
 
 void initialize_tensor_gradient_from_file(const std::string file_path,
                                           Tensor label,
-                                          const FFModel &ff,
+                                          FFModel const &ff,
                                           std::string data_type,
                                           int num_dim);
 
 void initialize_tensor_from_file(const std::string file_path,
                                  Tensor label,
-                                 const FFModel &ff,
+                                 FFModel const &ff,
                                  std::string data_type,
                                  int num_dim);
 
 template <int DIM>
 void initialize_tensor_from_file_task(
-    const Legion::Task *task,
-    const std::vector<Legion::PhysicalRegion> &regions,
+    Legion::Task const *task,
+    std::vector<Legion::PhysicalRegion> const &regions,
     Legion::Context ctx,
     Legion::Runtime *runtime);
 
@@ -41,8 +41,8 @@ void dump_region_to_file(FFModel &ff,
                          int dims = 4);
 
 template <int DIM>
-void dump_tensor_task(const Legion::Task *task,
-                      const std::vector<Legion::PhysicalRegion> &regions,
+void dump_tensor_task(Legion::Task const *task,
+                      std::vector<Legion::PhysicalRegion> const &regions,
                       Legion::Context ctx,
                       Legion::Runtime *runtime);
 

--- a/include/flexflow/utils/tuple.h
+++ b/include/flexflow/utils/tuple.h
@@ -39,12 +39,12 @@ T &&get(std::tuple<Types...> &&t) noexcept {
 }
 
 template <typename T, typename... Types>
-const T &get(const std::tuple<Types...> &t) noexcept {
+const T &get(std::tuple<Types...> const &t) noexcept {
   return std::get<TupleUtils::index_of<T, Types...>::value>(t);
 }
 
 template <typename T, typename... Types>
-const T &&get(const std::tuple<Types...> &&t) noexcept {
+const T &&get(std::tuple<Types...> const &&t) noexcept {
   return move(std::get<TupleUtils::index_of<T, Types...>::value>(t));
 }
 

--- a/nmt/linear.cu
+++ b/nmt/linear.cu
@@ -154,13 +154,13 @@ Linear::Linear(RnnConfig config,
   regions[1](I): w
   regions[2](O): y
  */
-OpMeta *Linear::init_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+OpMeta *Linear::init_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   assert(regions.size() == 3);
   assert(task->regions.size() == 3);
-  const LinearInitParams *linear = (LinearInitParams *)task->args;
+  LinearInitParams const *linear = (LinearInitParams *)task->args;
   Rect<3> rect_x = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   Rect<1> rect_w = runtime->get_index_space_domain(
@@ -191,7 +191,7 @@ OpMeta *Linear::init_task(const Task *task,
   return m;
 }
 
-void Linear::init(const RnnModel &model) {
+void Linear::init(RnnModel const &model) {
   Context ctx = model.config.lg_ctx;
   Runtime *runtime = model.config.lg_hlr;
   int idx = 0;
@@ -239,18 +239,18 @@ void Linear::init(const RnnModel &model) {
   regions[1] (I): w
   regions[2] (O): y
  */
-void Linear::forward_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+void Linear::forward_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
 #ifndef DISABLE_COMPUTATION
   assert(regions.size() == 3);
   assert(task->regions.size() == 3);
   float alpha = 1.0f, beta = 0.0f;
-  const LinearMeta *m = *((LinearMeta **)task->args);
-  const AccessorRO<float, 3> acc_x(regions[0], FID_DATA);
-  const AccessorRO<float, 1> acc_w(regions[1], FID_DATA);
-  const AccessorWO<float, 3> acc_y(regions[2], FID_DATA);
+  LinearMeta const *m = *((LinearMeta **)task->args);
+  AccessorRO<float, 3> const acc_x(regions[0], FID_DATA);
+  AccessorRO<float, 1> const acc_w(regions[1], FID_DATA);
+  AccessorWO<float, 3> const acc_y(regions[2], FID_DATA);
   Rect<3> rect_x = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   Rect<1> rect_w = runtime->get_index_space_domain(
@@ -263,9 +263,9 @@ void Linear::forward_task(const Task *task,
   int input_size = rect_x.hi[0] - rect_x.lo[0] + 1;
   int output_size = rect_y.hi[0] - rect_y.lo[0] + 1;
   int batch_size = (rect_x.hi[1] - rect_x.lo[1] + 1) * LSTM_PER_NODE_LENGTH;
-  const float *x_ptr = acc_x.ptr(rect_x.lo);
-  const float *w_ptr = acc_w.ptr(rect_w.lo);
-  const float *bias_ptr = w_ptr + input_size;
+  float const *x_ptr = acc_x.ptr(rect_x.lo);
+  float const *w_ptr = acc_w.ptr(rect_w.lo);
+  float const *bias_ptr = w_ptr + input_size;
   float *y_ptr = acc_y.ptr(rect_y.lo);
   cudaEvent_t t_start, t_end;
   if (m->profiling_runtime) {
@@ -319,7 +319,7 @@ void Linear::forward_task(const Task *task,
 #endif
 }
 
-void Linear::forward(const RnnModel &model) {
+void Linear::forward(RnnModel const &model) {
   Context ctx = model.config.lg_ctx;
   Runtime *runtime = model.config.lg_hlr;
   int idx = 0;
@@ -365,21 +365,21 @@ void Linear::forward(const RnnModel &model) {
   regions[4](I/O): w_grad
   regions[5](I): y_grad
 */
-void Linear::backward_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+void Linear::backward_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
 #ifndef DISABLE_COMPUTATION
   assert(regions.size() == 6);
   assert(task->regions.size() == 6);
   float alpha = 1.0f, beta = 0.0f;
-  const LinearMeta *m = *((LinearMeta **)task->args);
-  const AccessorRO<float, 3> acc_x(regions[0], FID_DATA);
-  const AccessorRO<float, 1> acc_w(regions[1], FID_DATA);
-  const AccessorRO<float, 3> acc_y(regions[2], FID_DATA);
-  const AccessorWO<float, 3> acc_replica_grad(regions[3], FID_DATA);
-  const AccessorRW<float, 1> acc_w_grad(regions[4], FID_DATA);
-  const AccessorRO<float, 3> acc_y_grad(regions[5], FID_DATA);
+  LinearMeta const *m = *((LinearMeta **)task->args);
+  AccessorRO<float, 3> const acc_x(regions[0], FID_DATA);
+  AccessorRO<float, 1> const acc_w(regions[1], FID_DATA);
+  AccessorRO<float, 3> const acc_y(regions[2], FID_DATA);
+  AccessorWO<float, 3> const acc_replica_grad(regions[3], FID_DATA);
+  AccessorRW<float, 1> const acc_w_grad(regions[4], FID_DATA);
+  AccessorRO<float, 3> const acc_y_grad(regions[5], FID_DATA);
 
   Rect<3> rect_x = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
@@ -402,15 +402,15 @@ void Linear::backward_task(const Task *task,
   int input_size = rect_x.hi[0] - rect_x.lo[0] + 1;
   int output_size = rect_y.hi[0] - rect_y.lo[0] + 1;
   int batch_size = (rect_x.hi[1] - rect_x.lo[1] + 1) * LSTM_PER_NODE_LENGTH;
-  const float *x_ptr = acc_x.ptr(rect_x.lo);
-  const float *w_ptr = acc_w.ptr(rect_w.lo);
-  const float *y_ptr = acc_y.ptr(rect_y.lo);
+  float const *x_ptr = acc_x.ptr(rect_x.lo);
+  float const *w_ptr = acc_w.ptr(rect_w.lo);
+  float const *y_ptr = acc_y.ptr(rect_y.lo);
   float *replica_grad_ptr = acc_replica_grad.ptr(rect_replica_grad.lo);
   // Note that w_grad might be bigger than w
   assert(rect_w_grad.contains(rect_w));
   float *w_grad_ptr = acc_w_grad.ptr(rect_w_grad.lo);
   float *bias_grad_ptr = w_grad_ptr + input_size;
-  const float *y_grad_ptr = acc_y_grad.ptr(rect_y_grad.lo);
+  float const *y_grad_ptr = acc_y_grad.ptr(rect_y_grad.lo);
   cudaEvent_t t_start, t_end;
   if (m->profiling_runtime) {
     cudaEventCreate(&t_start);
@@ -483,14 +483,14 @@ void Linear::backward_task(const Task *task,
   regions[0](O): input
   regions[1..num_par_c](I): replicas
 */
-void Linear::backward2_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void Linear::backward2_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
 #ifndef DISABLE_COMPUTATION
   float alpha = 1.0f;
-  const LinearMeta *m = *((LinearMeta **)task->args);
-  const AccessorWO<float, 3> acc_input(regions[0], FID_DATA);
+  LinearMeta const *m = *((LinearMeta **)task->args);
+  AccessorWO<float, 3> const acc_input(regions[0], FID_DATA);
   Rect<3> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_input.accessor.is_dense_arbitrary(rect_input));
@@ -499,12 +499,12 @@ void Linear::backward2_task(const Task *task,
   checkCUDA(cudaStreamCreate(&stream));
   checkCUDA(cublasSetStream(m->handle.blas, stream));
   for (int i = 1; i < task->regions.size(); i++) {
-    const AccessorRO<float, 3> acc_replica(regions[i], FID_DATA);
+    AccessorRO<float, 3> const acc_replica(regions[i], FID_DATA);
     Rect<3> rect_replica = runtime->get_index_space_domain(
         ctx, task->regions[i].region.get_index_space());
     assert(rect_replica.volume() == rect_input.volume());
     assert(acc_replica.accessor.is_dense_arbitrary(rect_replica));
-    const float *replica_ptr = acc_replica.ptr(rect_replica.lo);
+    float const *replica_ptr = acc_replica.ptr(rect_replica.lo);
     if (i == 1)
       checkCUDA(cublasScopy(
           m->handle.blas, rect_input.volume(), replica_ptr, 1, input_ptr, 1));
@@ -520,7 +520,7 @@ void Linear::backward2_task(const Task *task,
 #endif
 }
 
-void Linear::backward(const RnnModel &model) {
+void Linear::backward(RnnModel const &model) {
   Context ctx = model.config.lg_ctx;
   Runtime *runtime = model.config.lg_hlr;
   int idx = 0;
@@ -608,9 +608,9 @@ void Linear::backward(const RnnModel &model) {
   }
 }
 
-void Linear::update_task(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+void Linear::update_task(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime) {}
 
-void Linear::update(const RnnModel &model) {}
+void Linear::update(RnnModel const &model) {}

--- a/nmt/lstm.cu
+++ b/nmt/lstm.cu
@@ -157,18 +157,18 @@ LSTM::LSTM(RnnConfig config,
   regions[5] (O): hy
   regions[6] (O): cy
 */
-OpMeta *LSTM::init_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+OpMeta *LSTM::init_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {
-  const int numLayers = 1;
-  const int seqLength = LSTM_PER_NODE_LENGTH;
-  const float dropoutRate = 0.2f;
+  int const numLayers = 1;
+  int const seqLength = LSTM_PER_NODE_LENGTH;
+  float const dropoutRate = 0.2f;
   assert(regions.size() == 7);
   assert(task->regions.size() == 7);
   Rect<1> para_rect = runtime->get_index_space_domain(
       ctx, task->regions[3].region.get_index_space());
-  const LSTMInitParams *lstm = (LSTMInitParams *)task->args;
+  LSTMInitParams const *lstm = (LSTMInitParams *)task->args;
   LSTMMeta *m = new LSTMMeta(lstm->handle);
 #ifndef DISABLE_COMPUTATION
   checkCUDNN(cudnnCreateRNNDescriptor(&m->rnnDesc));
@@ -244,7 +244,7 @@ OpMeta *LSTM::init_task(const Task *task,
 #endif
 }
 
-void LSTM::init(const RnnModel &model) {
+void LSTM::init(RnnModel const &model) {
   Context ctx = model.config.lg_ctx;
   Runtime *runtime = model.config.lg_hlr;
   int idx = 0;
@@ -295,21 +295,21 @@ void LSTM::init(const RnnModel &model) {
   regions[5] (O): hy
   regions[6] (O): cy
 */
-void LSTM::forward_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+void LSTM::forward_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {
 #ifndef DISABLE_COMPUTATION
   assert(regions.size() == 7);
   assert(task->regions.size() == 7);
-  const LSTMMeta *m = *((LSTMMeta **)task->args);
-  const AccessorRO<float, 3> acc_x(regions[0], FID_DATA);
-  const AccessorRO<float, 2> acc_hx(regions[1], FID_DATA);
-  const AccessorRO<float, 2> acc_cx(regions[2], FID_DATA);
-  const AccessorRO<float, 1> acc_w(regions[3], FID_DATA);
-  const AccessorWO<float, 3> acc_y(regions[4], FID_DATA);
-  const AccessorWO<float, 2> acc_hy(regions[5], FID_DATA);
-  const AccessorWO<float, 2> acc_cy(regions[6], FID_DATA);
+  LSTMMeta const *m = *((LSTMMeta **)task->args);
+  AccessorRO<float, 3> const acc_x(regions[0], FID_DATA);
+  AccessorRO<float, 2> const acc_hx(regions[1], FID_DATA);
+  AccessorRO<float, 2> const acc_cx(regions[2], FID_DATA);
+  AccessorRO<float, 1> const acc_w(regions[3], FID_DATA);
+  AccessorWO<float, 3> const acc_y(regions[4], FID_DATA);
+  AccessorWO<float, 2> const acc_hy(regions[5], FID_DATA);
+  AccessorWO<float, 2> const acc_cy(regions[6], FID_DATA);
   Rect<3> rect_x, rect_y;
   Rect<2> rect_hx, rect_cx, rect_hy, rect_cy;
   Rect<1> rect_w;
@@ -337,10 +337,10 @@ void LSTM::forward_task(const Task *task,
   assert(rect_hx == rect_cx);
   assert(rect_hx == rect_hy);
   assert(rect_hx == rect_cy);
-  const float *x_ptr = acc_x.ptr(rect_x.lo);
-  const float *hx_ptr = acc_hx.ptr(rect_hx.lo);
-  const float *cx_ptr = acc_cx.ptr(rect_cx.lo);
-  const float *w_ptr = acc_w.ptr(rect_w.lo);
+  float const *x_ptr = acc_x.ptr(rect_x.lo);
+  float const *hx_ptr = acc_hx.ptr(rect_hx.lo);
+  float const *cx_ptr = acc_cx.ptr(rect_cx.lo);
+  float const *w_ptr = acc_w.ptr(rect_w.lo);
   float *y_ptr = acc_y.ptr(rect_y.lo);
   float *hy_ptr = acc_hy.ptr(rect_hy.lo);
   float *cy_ptr = acc_cy.ptr(rect_cy.lo);
@@ -389,7 +389,7 @@ void LSTM::forward_task(const Task *task,
 #endif
 }
 
-void LSTM::forward(const RnnModel &model) {
+void LSTM::forward(RnnModel const &model) {
   Context ctx = model.config.lg_ctx;
   Runtime *runtime = model.config.lg_hlr;
   int idx = 0;
@@ -439,28 +439,28 @@ void LSTM::forward(const RnnModel &model) {
  regions[12] (I): hy_grad
  regions[13] (I): cy_grad
 */
-void LSTM::backward_task(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+void LSTM::backward_task(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime) {
 #ifndef DISABLE_COMPUTATION
   assert(regions.size() == 14);
   assert(task->regions.size() == 14);
-  const LSTMMeta *m = *((LSTMMeta **)task->args);
-  const AccessorRO<float, 3> acc_x(regions[0], FID_DATA);
-  const AccessorRO<float, 2> acc_hx(regions[1], FID_DATA);
-  const AccessorRO<float, 2> acc_cx(regions[2], FID_DATA);
-  const AccessorRO<float, 1> acc_w(regions[3], FID_DATA);
-  const AccessorRO<float, 3> acc_y(regions[4], FID_DATA);
-  const AccessorRO<float, 2> acc_hy(regions[5], FID_DATA);
-  const AccessorRO<float, 2> acc_cy(regions[6], FID_DATA);
-  const AccessorWO<float, 3> acc_x_grad(regions[7], FID_DATA);
-  const AccessorWO<float, 2> acc_hx_grad(regions[8], FID_DATA);
-  const AccessorWO<float, 2> acc_cx_grad(regions[9], FID_DATA);
-  const AccessorRW<float, 1> acc_w_grad(regions[10], FID_DATA);
-  const AccessorRO<float, 3> acc_y_grad(regions[11], FID_DATA);
-  const AccessorRO<float, 2> acc_hy_grad(regions[12], FID_DATA);
-  const AccessorRO<float, 2> acc_cy_grad(regions[13], FID_DATA);
+  LSTMMeta const *m = *((LSTMMeta **)task->args);
+  AccessorRO<float, 3> const acc_x(regions[0], FID_DATA);
+  AccessorRO<float, 2> const acc_hx(regions[1], FID_DATA);
+  AccessorRO<float, 2> const acc_cx(regions[2], FID_DATA);
+  AccessorRO<float, 1> const acc_w(regions[3], FID_DATA);
+  AccessorRO<float, 3> const acc_y(regions[4], FID_DATA);
+  AccessorRO<float, 2> const acc_hy(regions[5], FID_DATA);
+  AccessorRO<float, 2> const acc_cy(regions[6], FID_DATA);
+  AccessorWO<float, 3> const acc_x_grad(regions[7], FID_DATA);
+  AccessorWO<float, 2> const acc_hx_grad(regions[8], FID_DATA);
+  AccessorWO<float, 2> const acc_cx_grad(regions[9], FID_DATA);
+  AccessorRW<float, 1> const acc_w_grad(regions[10], FID_DATA);
+  AccessorRO<float, 3> const acc_y_grad(regions[11], FID_DATA);
+  AccessorRO<float, 2> const acc_hy_grad(regions[12], FID_DATA);
+  AccessorRO<float, 2> const acc_cy_grad(regions[13], FID_DATA);
 
   Rect<3> rect_x, rect_y, rect_x_grad, rect_y_grad;
   Rect<2> rect_hx, rect_cx, rect_hy, rect_cy, rect_hx_grad, rect_cx_grad,
@@ -510,20 +510,20 @@ void LSTM::backward_task(const Task *task,
   assert(acc_hy_grad.accessor.is_dense_arbitrary(rect_hy_grad));
   assert(acc_cy_grad.accessor.is_dense_arbitrary(rect_cy_grad));
 
-  const float *x_ptr = acc_x.ptr(rect_x.lo);
-  const float *hx_ptr = acc_hx.ptr(rect_hx.lo);
-  const float *cx_ptr = acc_cx.ptr(rect_cx.lo);
-  const float *w_ptr = acc_w.ptr(rect_w.lo);
-  const float *y_ptr = acc_y.ptr(rect_y.lo);
-  const float *hy_ptr = acc_hy.ptr(rect_hy.lo);
-  const float *cy_ptr = acc_cy.ptr(rect_cy.lo);
+  float const *x_ptr = acc_x.ptr(rect_x.lo);
+  float const *hx_ptr = acc_hx.ptr(rect_hx.lo);
+  float const *cx_ptr = acc_cx.ptr(rect_cx.lo);
+  float const *w_ptr = acc_w.ptr(rect_w.lo);
+  float const *y_ptr = acc_y.ptr(rect_y.lo);
+  float const *hy_ptr = acc_hy.ptr(rect_hy.lo);
+  float const *cy_ptr = acc_cy.ptr(rect_cy.lo);
   float *x_grad_ptr = acc_x_grad.ptr(rect_x_grad.lo);
   float *hx_grad_ptr = acc_hx_grad.ptr(rect_hx_grad.lo);
   float *cx_grad_ptr = acc_cx_grad.ptr(rect_cx_grad.lo);
   float *w_grad_ptr = acc_w_grad.ptr(rect_w_grad.lo);
-  const float *y_grad_ptr = acc_y_grad.ptr(rect_y_grad.lo);
-  const float *hy_grad_ptr = acc_hy_grad.ptr(rect_hy_grad.lo);
-  const float *cy_grad_ptr = acc_cy_grad.ptr(rect_cy_grad.lo);
+  float const *y_grad_ptr = acc_y_grad.ptr(rect_y_grad.lo);
+  float const *hy_grad_ptr = acc_hy_grad.ptr(rect_hy_grad.lo);
+  float const *cy_grad_ptr = acc_cy_grad.ptr(rect_cy_grad.lo);
 
   cudaEvent_t t_start, t_end;
   if (m->profiling_runtime) {
@@ -594,7 +594,7 @@ void LSTM::backward_task(const Task *task,
 #endif
 }
 
-void LSTM::backward(const RnnModel &model) {
+void LSTM::backward(RnnModel const &model) {
   Context ctx = model.config.lg_ctx;
   Runtime *runtime = model.config.lg_hlr;
   int idx = 0;
@@ -649,4 +649,4 @@ void LSTM::backward(const RnnModel &model) {
   }
 }
 
-void LSTM::update(const RnnModel &model) {}
+void LSTM::update(RnnModel const &model) {}

--- a/nmt/nmt.cc
+++ b/nmt/nmt.cc
@@ -35,8 +35,8 @@ void set_global_config(GlobalConfig &global,
                        int workers_per_node,
                        int num_nodes);
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   int bs_per_worker = 64;
@@ -51,7 +51,7 @@ void top_level_task(const Task *task,
   int batch_size = bs_per_worker * num_parts;
   int num_iterations = 10;
   {
-    const InputArgs &command_args = HighLevelRuntime::get_input_args();
+    InputArgs const &command_args = HighLevelRuntime::get_input_args();
     char **argv = command_args.argv;
     int argc = command_args.argc;
     parse_input_args(argv,

--- a/nmt/ops.h
+++ b/nmt/ops.h
@@ -151,13 +151,13 @@ class Op {
 public:
   Op(Tensor input);
   Op(int num, Tensor *inputs);
-  virtual void init(const CnnModel &) = 0;
+  virtual void init(CnnModel const &) = 0;
 
-  virtual void forward(const CnnModel &) = 0;
+  virtual void forward(CnnModel const &) = 0;
 
-  virtual void backward(const CnnModel &) = 0;
+  virtual void backward(CnnModel const &) = 0;
 
-  virtual void update(const CnnModel &) = 0;
+  virtual void update(CnnModel const &) = 0;
 
 public:
   Tensor output;
@@ -169,8 +169,8 @@ public:
   // std::vector<LogicalRegion> inputs, grads;
 };
 
-DnnHandle init_cudnn(const Task *task,
-                     const std::vector<PhysicalRegion> &regions,
+DnnHandle init_cudnn(Task const *task,
+                     std::vector<PhysicalRegion> const &regions,
                      Context ctx,
                      Runtime *runtime);
 

--- a/nmt/rnn.cu
+++ b/nmt/rnn.cu
@@ -17,13 +17,13 @@
 #include "rnn.h"
 #include "rnn_mapper.h"
 
-DnnHandle init_cudnn(const Task *task,
-                     const std::vector<PhysicalRegion> &regions,
+DnnHandle init_cudnn(Task const *task,
+                     std::vector<PhysicalRegion> const &regions,
                      Context ctx,
                      HighLevelRuntime *runtime) {
   assert(regions.size() == 0);
   assert(task->arglen == sizeof(size_t));
-  size_t workSpaceSize = *(const size_t *)task->args;
+  size_t workSpaceSize = *(size_t const *)task->args;
   DnnHandle handle;
   handle.workSpaceSize = workSpaceSize;
   printf("workSpaceSize = %zu\n", workSpaceSize);
@@ -353,8 +353,8 @@ RnnModel::RnnModel(int batch_size,
   sharedVariables.push_back(linear);
 }
 
-void RnnModel::word_init_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void RnnModel::word_init_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   Rect<2> rect0 = runtime->get_index_space_domain(
@@ -367,7 +367,7 @@ void RnnModel::word_init_task(const Task *task,
   for (int i = 0; i < rect0.volume(); i++)
     host_ptr[i] = same ? 1 : i % 16;
   for (int i = 0; i < regions.size(); i++) {
-    const AccessorWO<int, 2> acc(regions[i], FID_DATA);
+    AccessorWO<int, 2> const acc(regions[i], FID_DATA);
     Rect<2> rect = runtime->get_index_space_domain(
         ctx, task->regions[i].region.get_index_space());
     assert(acc.accessor.is_dense_arbitrary(rect));
@@ -492,12 +492,12 @@ void RnnModel::init() {
     layers[i]->init(*this);
 }
 
-void RnnModel::zero_3d_init_task(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+void RnnModel::zero_3d_init_task(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  Runtime *runtime) {
   for (int i = 0; i < task->regions.size(); i++) {
-    const AccessorWO<float, 3> acc_w(regions[i], FID_DATA);
+    AccessorWO<float, 3> const acc_w(regions[i], FID_DATA);
     Rect<3> rect_w = runtime->get_index_space_domain(
         ctx, task->regions[i].region.get_index_space());
     assert(acc_w.accessor.is_dense_arbitrary(rect_w));
@@ -507,12 +507,12 @@ void RnnModel::zero_3d_init_task(const Task *task,
   }
 }
 
-void RnnModel::zero_2d_init_task(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+void RnnModel::zero_2d_init_task(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  Runtime *runtime) {
   for (int i = 0; i < task->regions.size(); i++) {
-    const AccessorWO<float, 2> acc_w(regions[i], FID_DATA);
+    AccessorWO<float, 2> const acc_w(regions[i], FID_DATA);
     Rect<2> rect_w = runtime->get_index_space_domain(
         ctx, task->regions[i].region.get_index_space());
     assert(acc_w.accessor.is_dense_arbitrary(rect_w));
@@ -522,12 +522,12 @@ void RnnModel::zero_2d_init_task(const Task *task,
   }
 }
 
-void RnnModel::zero_1d_init_task(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+void RnnModel::zero_1d_init_task(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  Runtime *runtime) {
   for (int i = 0; i < task->regions.size(); i++) {
-    const AccessorWO<float, 1> acc_w(regions[i], FID_DATA);
+    AccessorWO<float, 1> const acc_w(regions[i], FID_DATA);
     Rect<1> rect_w = runtime->get_index_space_domain(
         ctx, task->regions[i].region.get_index_space());
     assert(acc_w.accessor.is_dense_arbitrary(rect_w));
@@ -537,8 +537,8 @@ void RnnModel::zero_1d_init_task(const Task *task,
   }
 }
 
-void RnnModel::dummy_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+void RnnModel::dummy_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {}
 
@@ -601,14 +601,14 @@ void RnnModel::update() {
 /*
   regions[0](O): w
 */
-void RnnModel::params_init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+void RnnModel::params_init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   assert(regions.size() == 1);
   assert(task->regions.size() == 1);
   float value = *((float *)task->args);
-  const AccessorWO<float, 1> acc_w(regions[0], FID_DATA);
+  AccessorWO<float, 1> const acc_w(regions[0], FID_DATA);
   Rect<1> rect_w = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_w.accessor.is_dense_arbitrary(rect_w));
@@ -647,24 +647,24 @@ void RnnModel::init_shared_variable(SharedVariable params) {
   regions[0]: (I/O): w
   regions[1..]: (O): w_grad
  */
-void RnnModel::params_update_task(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+void RnnModel::params_update_task(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime) {
   assert(regions.size() == task->regions.size());
   float rate = *((float *)task->args);
-  const AccessorRW<float, 1> acc_w(regions[0], FID_DATA);
+  AccessorRW<float, 1> const acc_w(regions[0], FID_DATA);
   Rect<1> rect_w = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_w.accessor.is_dense_arbitrary(rect_w));
   for (int i = 1; i < regions.size(); i++) {
-    const AccessorRO<float, 1> acc_w_grad(regions[i], FID_DATA);
+    AccessorRO<float, 1> const acc_w_grad(regions[i], FID_DATA);
     Rect<1> rect_w_grad = runtime->get_index_space_domain(
         ctx, task->regions[i].region.get_index_space());
     assert(rect_w.contains(rect_w_grad));
     assert(acc_w_grad.accessor.is_dense_arbitrary(rect_w_grad));
     float *w_ptr = acc_w.ptr(rect_w_grad.lo);
-    const float *w_grad_ptr = acc_w_grad.ptr(rect_w_grad.lo);
+    float const *w_grad_ptr = acc_w_grad.ptr(rect_w_grad.lo);
     apply_add_with_scale<<<GET_BLOCKS(rect_w_grad.volume()),
                            CUDA_NUM_THREADS>>>(
         w_ptr, w_grad_ptr, rect_w_grad.volume(), rate);

--- a/nmt/rnn.h
+++ b/nmt/rnn.h
@@ -73,13 +73,13 @@ public:
         ParallelConfig pc,
         SharedVariable _params);
   RnnOp(int num, Tensor *inputs);
-  virtual void init(const RnnModel &) = 0;
+  virtual void init(RnnModel const &) = 0;
 
-  virtual void forward(const RnnModel &) = 0;
+  virtual void forward(RnnModel const &) = 0;
 
-  virtual void backward(const RnnModel &) = 0;
+  virtual void backward(RnnModel const &) = 0;
 
-  virtual void update(const RnnModel &) = 0;
+  virtual void update(RnnModel const &) = 0;
 
 public:
   Tensor outputs[MAX_NUM_OUTPUTS];
@@ -120,38 +120,38 @@ public:
 
   void update_shared_variable(SharedVariable params);
 
-  static void word_init_task(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+  static void word_init_task(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              HighLevelRuntime *runtime);
 
-  static void zero_1d_init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+  static void zero_1d_init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 HighLevelRuntime *runtime);
 
-  static void zero_2d_init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+  static void zero_2d_init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 HighLevelRuntime *runtime);
 
-  static void zero_3d_init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+  static void zero_3d_init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 HighLevelRuntime *runtime);
 
-  static void dummy_task(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void dummy_task(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          HighLevelRuntime *runtime);
 
-  static void params_init_task(const Task *task,
-                               const std::vector<PhysicalRegion> &regions,
+  static void params_init_task(Task const *task,
+                               std::vector<PhysicalRegion> const &regions,
                                Context ctx,
                                HighLevelRuntime *runtime);
 
-  static void params_update_task(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+  static void params_update_task(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  HighLevelRuntime *runtime);
 
@@ -198,31 +198,31 @@ public:
        ParallelConfig pc,
        SharedVariable params);
 
-  void init(const RnnModel &);
+  void init(RnnModel const &);
 
-  void forward(const RnnModel &);
+  void forward(RnnModel const &);
 
-  void backward(const RnnModel &);
+  void backward(RnnModel const &);
 
-  void update(const RnnModel &);
+  void update(RnnModel const &);
 
-  static OpMeta *init_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+  static OpMeta *init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 
-  static void forward_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+  static void forward_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 
-  static void backward_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+  static void backward_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             HighLevelRuntime *runtime);
 
-  static void update_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+  static void update_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           HighLevelRuntime *runtime);
 
@@ -253,36 +253,36 @@ public:
          SharedVariable params,
          IndexSpaceT<1> input_part_is);
 
-  void init(const RnnModel &);
+  void init(RnnModel const &);
 
-  void forward(const RnnModel &);
+  void forward(RnnModel const &);
 
-  void backward(const RnnModel &);
+  void backward(RnnModel const &);
 
-  void update(const RnnModel &);
+  void update(RnnModel const &);
 
-  static OpMeta *init_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+  static OpMeta *init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 
-  static void forward_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+  static void forward_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 
-  static void backward_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+  static void backward_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             HighLevelRuntime *runtime);
 
-  static void backward2_task(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+  static void backward2_task(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              HighLevelRuntime *runtime);
 
-  static void update_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+  static void update_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           HighLevelRuntime *runtime);
 
@@ -313,31 +313,31 @@ public:
         ParallelConfig pc,
         SharedVariable params);
 
-  void init(const RnnModel &);
+  void init(RnnModel const &);
 
-  void forward(const RnnModel &);
+  void forward(RnnModel const &);
 
-  void backward(const RnnModel &);
+  void backward(RnnModel const &);
 
-  void update(const RnnModel &);
+  void update(RnnModel const &);
 
-  static OpMeta *init_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+  static OpMeta *init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 
-  static void forward_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+  static void forward_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 
-  static void backward_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+  static void backward_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             HighLevelRuntime *runtime);
 
-  static void update_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+  static void update_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           HighLevelRuntime *runtime);
 
@@ -393,26 +393,26 @@ class SoftmaxDP : public RnnOp {
 public:
   SoftmaxDP(RnnConfig config, Tensor logit, Tensor label, ParallelConfig pc);
 
-  void init(const RnnModel &);
+  void init(RnnModel const &);
 
-  void forward(const RnnModel &);
+  void forward(RnnModel const &);
 
-  void backward(const RnnModel &);
+  void backward(RnnModel const &);
 
-  void update(const RnnModel &);
+  void update(RnnModel const &);
 
-  static OpMeta *init_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+  static OpMeta *init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 
-  static void forward_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+  static void forward_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 
-  static void backward_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+  static void backward_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             HighLevelRuntime *runtime);
 

--- a/nmt/rnn_mapper.cc
+++ b/nmt/rnn_mapper.cc
@@ -19,7 +19,7 @@
 RnnMapper::RnnMapper(MapperRuntime *rt,
                      Machine machine,
                      Processor local,
-                     const char *mapper_name,
+                     char const *mapper_name,
                      std::vector<Processor> *_gpus,
                      std::map<Processor, Memory> *_proc_fbmems,
                      std::vector<Processor> *_cpus)
@@ -27,7 +27,7 @@ RnnMapper::RnnMapper(MapperRuntime *rt,
       proc_fbmems(*_proc_fbmems), cpus(*_cpus) {}
 
 void RnnMapper::select_task_options(const MapperContext ctx,
-                                    const Task &task,
+                                    Task const &task,
                                     TaskOptions &output) {
   if ((task.tag & ASSIGN_TO_GPU_MASK) == ASSIGN_TO_GPU_MASK) {
     output.inline_task = false;
@@ -42,8 +42,8 @@ void RnnMapper::select_task_options(const MapperContext ctx,
 
 #ifdef DEADCODE
 void RnnMapper::map_task(const MapperContext ctx,
-                         const Task &task,
-                         const MapTaskInput &input,
+                         Task const &task,
+                         MapTaskInput const &input,
                          MapTaskOutput &output) {
   printf("Task(%s %zx):", task.get_task_name(), task.tag);
   for (size_t i = 0; i < input.valid_instances.size(); i++) {
@@ -58,8 +58,8 @@ void RnnMapper::map_task(const MapperContext ctx,
 }
 
 void RnnMapper::select_task_sources(const MapperContext ctx,
-                                    const Task &task,
-                                    const SelectTaskSrcInput &input,
+                                    Task const &task,
+                                    SelectTaskSrcInput const &input,
                                     SelectTaskSrcOutput &output) {
   printf("Slct(%s %zx)[%d]:",
          task.get_task_name(),
@@ -75,7 +75,7 @@ void RnnMapper::select_task_sources(const MapperContext ctx,
 
 void update_mappers(Machine machine,
                     Runtime *runtime,
-                    const std::set<Processor> &local_procs) {
+                    std::set<Processor> const &local_procs) {
   std::vector<Processor> *gpus = new std::vector<Processor>();
   std::map<Processor, Memory> *proc_fbmems = new std::map<Processor, Memory>();
   std::vector<Processor> *cpus = new std::vector<Processor>();

--- a/nmt/rnn_mapper.h
+++ b/nmt/rnn_mapper.h
@@ -28,14 +28,14 @@ public:
   RnnMapper(MapperRuntime *rt,
             Machine machine,
             Processor local,
-            const char *mapper_name,
+            char const *mapper_name,
             std::vector<Processor> *gpus,
             std::map<Processor, Memory> *proc_fbmems,
             std::vector<Processor> *cpus);
 
 public:
   virtual void select_task_options(const MapperContext ctx,
-                                   const Task &task,
+                                   Task const &task,
                                    TaskOptions &output);
   // virtual void slice_task(const MapperContext ctx,
   //                       const Task& task,
@@ -59,5 +59,5 @@ protected:
 
 void update_mappers(Machine machine,
                     Runtime *rt,
-                    const std::set<Processor> &local_procs);
+                    std::set<Processor> const &local_procs);
 #endif

--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -25,7 +25,7 @@ void begin_flexflow_task(std::vector<std::string> args) {
   // which are not compatible with the Realm CUDA hijack.
   setenv("NCCL_LAUNCH_MODE", "PARALLEL", true);
 
-  std::vector<const char *> argvec;
+  std::vector<char const *> argvec;
   argvec.push_back("python");
   for (auto &arg : args) {
     if (arg == "-ll:py") {
@@ -159,7 +159,7 @@ bool get_weights(Parameter parameter, FFModel &model, py::array &full_array) {
 
 bool set_weights(Parameter parameter,
                  FFModel &model,
-                 const std::vector<int> &dims,
+                 std::vector<int> const &dims,
                  py::array &full_array) {
   py::buffer_info info = full_array.request();
   if (info.format == "f") {
@@ -175,7 +175,7 @@ bool set_weights(Parameter parameter,
 //-------- FFModel --------
 
 Tensor create_tensor(FFModel &model,
-                     const std::vector<int> &dims,
+                     std::vector<int> const &dims,
                      DataType data_type,
                      bool create_grad) {
   Tensor tensor = NULL;
@@ -278,18 +278,18 @@ create_data_loader(FFModel &model, Tensor batch_tensor, py::array &full_array) {
 }
 
 Tensor concat(FFModel &model,
-              const std::vector<Tensor> &tensors,
+              std::vector<Tensor> const &tensors,
               int axis,
-              const char *name) {
+              char const *name) {
   int size = tensors.size();
   return model.concat(size, tensors.data(), axis, name);
 }
 
 std::vector<Tensor> split(FFModel &model,
-                          const Tensor &input,
-                          const std::vector<int> &split,
+                          Tensor const &input,
+                          std::vector<int> const &split,
                           int axis,
-                          const char *name) {
+                          char const *name) {
   std::vector<Tensor> outputs;
   outputs.resize(split.size());
   model.split(input, outputs.data(), split, axis, name);
@@ -339,7 +339,7 @@ PYBIND11_MODULE(flexflow_pybind11_internal, m) {
   py::class_<Optimizer>(m, "Optimizer");
 
   py::class_<SGDOptimizer, Optimizer>(m, "SGDOptimizer")
-      .def(py::init<const FFModel *, double, double, bool, double>(),
+      .def(py::init<FFModel const *, double, double, bool, double>(),
            "model"_a,
            "lr"_a = 0.01f,
            "momentum"_a = 0.0f,
@@ -349,7 +349,7 @@ PYBIND11_MODULE(flexflow_pybind11_internal, m) {
            [](SGDOptimizer &optimizer, double lr) { optimizer.lr = lr; });
 
   py::class_<AdamOptimizer, Optimizer>(m, "AdamOptimizer")
-      .def(py::init<const FFModel *, double, double, double, double, double>(),
+      .def(py::init<FFModel const *, double, double, double, double, double>(),
            "model"_a,
            "alpha"_a = 0.001f,
            "beta1"_a = 0.9f,
@@ -459,7 +459,7 @@ PYBIND11_MODULE(flexflow_pybind11_internal, m) {
       .def_readwrite("optimizer", &FFModel::optimizer)
       .def("_compile",
            static_cast<void (FFModel::*)(
-               LossType, const std::vector<MetricsType> &, CompMode)>(
+               LossType, std::vector<MetricsType> const &, CompMode)>(
                &FFModel::compile),
            "loss_type"_a,
            "metrics"_a,

--- a/python/flexflow_c.cc
+++ b/python/flexflow_c.cc
@@ -29,7 +29,7 @@ public:
   }                                                                            \
   static const T_ wrap_const(const T t) {                                      \
     T_ t_;                                                                     \
-    t_.impl = const_cast<void *>(static_cast<const void *>(t));                \
+    t_.impl = const_cast<void *>(static_cast<void const *>(t));                \
     return t_;                                                                 \
   }                                                                            \
   static T unwrap(T_ t_) { return static_cast<T>(t_.impl); }                   \
@@ -91,7 +91,7 @@ void flexflow_config_parse_args(flexflow_config_t handle_,
 
 void flexflow_config_parse_args_default(flexflow_config_t handle_) {
   FFConfig *handle = FFCObjectWrapper::unwrap(handle_);
-  const InputArgs &command_args = Runtime::get_input_args();
+  InputArgs const &command_args = Runtime::get_input_args();
   char **argv = command_args.argv;
   int argc = command_args.argc;
   handle->parse_args(argv, argc);
@@ -205,7 +205,7 @@ void flexflow_model_zero_gradients(flexflow_model_t handle_) {
 
 flexflow_tensor_t flexflow_model_add_exp(flexflow_model_t handle_,
                                          const flexflow_tensor_t x_,
-                                         const char *name) {
+                                         char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor x = FFCObjectWrapper::unwrap_const(x_);
   Tensor tensor = handle->exp(x, name);
@@ -217,7 +217,7 @@ flexflow_tensor_t flexflow_model_add_add(flexflow_model_t handle_,
                                          const flexflow_tensor_t x_,
                                          const flexflow_tensor_t y_,
                                          bool inplace_a,
-                                         const char *name) {
+                                         char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor x = FFCObjectWrapper::unwrap_const(x_);
   const Tensor y = FFCObjectWrapper::unwrap_const(y_);
@@ -230,7 +230,7 @@ flexflow_tensor_t flexflow_model_add_subtract(flexflow_model_t handle_,
                                               const flexflow_tensor_t x_,
                                               const flexflow_tensor_t y_,
                                               bool inplace_a,
-                                              const char *name) {
+                                              char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor x = FFCObjectWrapper::unwrap_const(x_);
   const Tensor y = FFCObjectWrapper::unwrap_const(y_);
@@ -244,7 +244,7 @@ flexflow_tensor_t flexflow_model_add_multiply(flexflow_model_t handle_,
                                               const flexflow_tensor_t x_,
                                               const flexflow_tensor_t y_,
                                               bool inplace_a,
-                                              const char *name) {
+                                              char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor x = FFCObjectWrapper::unwrap_const(x_);
   const Tensor y = FFCObjectWrapper::unwrap_const(y_);
@@ -258,7 +258,7 @@ flexflow_tensor_t flexflow_model_add_divide(flexflow_model_t handle_,
                                             const flexflow_tensor_t x_,
                                             const flexflow_tensor_t y_,
                                             bool inplace_a,
-                                            const char *name) {
+                                            char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor x = FFCObjectWrapper::unwrap_const(x_);
   const Tensor y = FFCObjectWrapper::unwrap_const(y_);
@@ -270,7 +270,7 @@ flexflow_tensor_t flexflow_model_add_divide(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_rsqrt(flexflow_model_t handle_,
                                            const flexflow_tensor_t input_,
-                                           const char *name) {
+                                           char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->rsqrt(input, name);
@@ -280,8 +280,8 @@ flexflow_tensor_t flexflow_model_add_rsqrt(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_pow(flexflow_model_t handle_,
                                          const flexflow_tensor_t input_,
-                                         const float exponent,
-                                         const char *name) {
+                                         float const exponent,
+                                         char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->pow(input, exponent, name);
@@ -298,7 +298,7 @@ flexflow_tensor_t flexflow_model_add_mean(flexflow_model_t handle_,
                                           int *dims,
                                           int n,
                                           bool keepdims,
-                                          const char *name) {
+                                          char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor input = FFCObjectWrapper::unwrap(input_);
   std::vector<int> dims_vec;
@@ -339,7 +339,7 @@ flexflow_model_add_conv2d(flexflow_model_t handle_,
                           flexflow_op_t shared_op_,
                           flexflow_initializer_t kernel_initializer_,
                           flexflow_initializer_t bias_initializer_,
-                          const char *name) {
+                          char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor input = FFCObjectWrapper::unwrap_const(input_);
   Layer *shared_op = FFCObjectWrapper::unwrap(shared_op_);
@@ -395,7 +395,7 @@ flexflow_model_add_embedding(flexflow_model_t handle_,
                              enum AggrMode aggr,
                              flexflow_op_t shared_op_,
                              flexflow_initializer_t kernel_initializer_,
-                             const char *name) {
+                             char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor input = FFCObjectWrapper::unwrap_const(input_);
   Layer *shared_op = FFCObjectWrapper::unwrap(shared_op_);
@@ -427,7 +427,7 @@ flexflow_model_add_pool2d(flexflow_model_t handle_,
                           int padding_w,
                           enum PoolType type /* POOL_MAX */,
                           enum ActiMode activation /* AC_MODE_NONE */,
-                          const char *name) {
+                          char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->pool2d(input,
@@ -464,7 +464,7 @@ flexflow_model_add_pool2d(flexflow_model_t handle_,
 flexflow_tensor_t flexflow_model_add_batch_norm(flexflow_model_t handle_,
                                                 const flexflow_tensor_t input_,
                                                 bool relu,
-                                                const char *name) {
+                                                char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->batch_norm(input, relu, name);
@@ -487,7 +487,7 @@ flexflow_tensor_t flexflow_model_add_layer_norm(flexflow_model_t handle_,
                                                 int *axes,
                                                 bool elementwise_affine,
                                                 float eps,
-                                                const char *name) {
+                                                char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor input = FFCObjectWrapper::unwrap(input_);
   std::vector<int> axes_vec;
@@ -530,7 +530,7 @@ flexflow_model_add_dense(flexflow_model_t handle_,
                          flexflow_op_t shared_op_,
                          flexflow_initializer_t kernel_initializer_,
                          flexflow_initializer_t bias_initializer_,
-                         const char *name) {
+                         char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   const Tensor input = FFCObjectWrapper::unwrap_const(input_);
   Layer *shared_op = FFCObjectWrapper::unwrap(shared_op_);
@@ -569,7 +569,7 @@ flexflow_tensor_t flexflow_model_add_concat(flexflow_model_t handle_,
                                             int n,
                                             flexflow_tensor_t *input_,
                                             int axis,
-                                            const char *name) {
+                                            char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor tensor;
   std::vector<Tensor> input_vec;
@@ -597,7 +597,7 @@ void flexflow_model_add_split(flexflow_model_t handle_,
                               flexflow_tensor_t *outputs_,
                               int *split,
                               int axis,
-                              const char *name) {
+                              char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   std::vector<int> split_vec;
@@ -626,7 +626,7 @@ void flexflow_model_add_split(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_flat(flexflow_model_t handle_,
                                           flexflow_tensor_t input_,
-                                          const char *name) {
+                                          char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->flat(input, name);
@@ -638,7 +638,7 @@ flexflow_tensor_t flexflow_model_add_flat(flexflow_model_t handle_,
 flexflow_tensor_t flexflow_model_add_softmax(flexflow_model_t handle_,
                                              const flexflow_tensor_t input_,
                                              int dim,
-                                             const char *name) {
+                                             char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->softmax(input, dim, name);
@@ -651,7 +651,7 @@ flexflow_tensor_t flexflow_model_add_transpose(flexflow_model_t handle_,
                                                const flexflow_tensor_t input_,
                                                int n,
                                                int *perm,
-                                               const char *name) {
+                                               char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   std::vector<int> perm_vec;
@@ -671,7 +671,7 @@ flexflow_tensor_t flexflow_model_add_reshape(flexflow_model_t handle_,
                                              const flexflow_tensor_t input_,
                                              int n,
                                              int *shape,
-                                             const char *name) {
+                                             char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   std::vector<int> shape_vec;
@@ -690,7 +690,7 @@ flexflow_tensor_t flexflow_model_add_reshape(flexflow_model_t handle_,
 flexflow_tensor_t flexflow_model_add_reverse(flexflow_model_t handle_,
                                              const flexflow_tensor_t input_,
                                              int axis,
-                                             const char *name) {
+                                             char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->reverse(input, axis, name);
@@ -705,9 +705,9 @@ flexflow_tensor_t flexflow_model_add_reverse(flexflow_model_t handle_,
 flexflow_tensor_t
 flexflow_model_add_scalar_multiply(flexflow_model_t handle_,
                                    const flexflow_tensor_t input_,
-                                   const float scalar,
+                                   float const scalar,
                                    bool inplace,
-                                   const char *name) {
+                                   char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->scalar_multiply(input, scalar, inplace, name);
@@ -721,9 +721,9 @@ flexflow_model_add_scalar_multiply(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_scalar_add(flexflow_model_t handle_,
                                                 const flexflow_tensor_t input_,
-                                                const float scalar,
+                                                float const scalar,
                                                 bool inplace,
-                                                const char *name) {
+                                                char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->scalar_add(input, scalar, inplace, name);
@@ -737,9 +737,9 @@ flexflow_tensor_t flexflow_model_add_scalar_add(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_scalar_sub(flexflow_model_t handle_,
                                                 const flexflow_tensor_t input_,
-                                                const float scalar,
+                                                float const scalar,
                                                 bool inplace,
-                                                const char *name) {
+                                                char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->scalar_sub(input, scalar, inplace, name);
@@ -755,9 +755,9 @@ flexflow_tensor_t flexflow_model_add_scalar_sub(flexflow_model_t handle_,
 flexflow_tensor_t
 flexflow_model_add_scalar_truediv(flexflow_model_t handle_,
                                   const flexflow_tensor_t input_,
-                                  const float scalar,
+                                  float const scalar,
                                   bool inplace,
-                                  const char *name) {
+                                  char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->scalar_truediv(input, scalar, inplace, name);
@@ -772,7 +772,7 @@ flexflow_model_add_scalar_truediv(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_gelu(flexflow_model_t handle_,
                                           const flexflow_tensor_t input_,
-                                          const char *name) {
+                                          char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->gelu(input, name);
@@ -782,7 +782,7 @@ flexflow_tensor_t flexflow_model_add_gelu(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_identity(flexflow_model_t handle_,
                                               const flexflow_tensor_t input_,
-                                              const char *name) {
+                                              char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->identity(input, name);
@@ -794,7 +794,7 @@ flexflow_tensor_t flexflow_model_add_identity(flexflow_model_t handle_,
 flexflow_tensor_t flexflow_model_add_relu(flexflow_model_t handle_,
                                           const flexflow_tensor_t input_,
                                           bool inplace,
-                                          const char *name) {
+                                          char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->relu(input, name);
@@ -804,7 +804,7 @@ flexflow_tensor_t flexflow_model_add_relu(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_sigmoid(flexflow_model_t handle_,
                                              const flexflow_tensor_t input_,
-                                             const char *name) {
+                                             char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->sigmoid(input, name);
@@ -815,7 +815,7 @@ flexflow_tensor_t flexflow_model_add_sigmoid(flexflow_model_t handle_,
 
 flexflow_tensor_t flexflow_model_add_tanh(flexflow_model_t handle_,
                                           const flexflow_tensor_t input_,
-                                          const char *name) {
+                                          char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->tanh(input, name);
@@ -826,7 +826,7 @@ flexflow_tensor_t flexflow_model_add_tanh(flexflow_model_t handle_,
 flexflow_tensor_t flexflow_model_add_elu(flexflow_model_t handle_,
                                          const flexflow_tensor_t input_,
                                          bool inplace,
-                                         const char *name) {
+                                         char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->elu(input, name);
@@ -838,7 +838,7 @@ flexflow_tensor_t flexflow_model_add_dropout(flexflow_model_t handle_,
                                              const flexflow_tensor_t input_,
                                              float rate,
                                              unsigned long long seed,
-                                             const char *name) {
+                                             char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor input = FFCObjectWrapper::unwrap(input_);
   Tensor tensor = handle->dropout(input, rate, seed, name);
@@ -865,7 +865,7 @@ flexflow_tensor_t flexflow_model_add_multihead_attention(
     bool add_bias_kv,
     bool add_zero_attn,
     flexflow_initializer_t kernel_initializer_,
-    const char *name) {
+    char const *name) {
   FFModel *handle = FFCObjectWrapper::unwrap(handle_);
   Tensor query = FFCObjectWrapper::unwrap(query_);
   Tensor key = FFCObjectWrapper::unwrap(key_);
@@ -964,7 +964,7 @@ flexflow_model_get_perf_metrics(flexflow_model_t handle_) {
 
 flexflow_tensor_t flexflow_tensor_create(flexflow_model_t model_,
                                          int num_dims,
-                                         const int *dims,
+                                         int const *dims,
                                          enum DataType data_type,
                                          bool create_grad /* true */) {
   Tensor tensor;
@@ -1035,7 +1035,7 @@ void flexflow_tensor_map(flexflow_model_t model_,
 
 flexflow_tensor_t flexflow_constant_create(flexflow_model_t model_,
                                            int num_dims,
-                                           const int *dims,
+                                           int const *dims,
                                            float value,
                                            enum DataType data_type) {
   Tensor tensor;
@@ -1215,7 +1215,7 @@ bool flexflow_tensor_set_tensor_float(flexflow_tensor_t handle_,
                                       flexflow_model_t model_,
                                       int num_dim,
                                       int *dims,
-                                      const float *data) {
+                                      float const *data) {
   Tensor handle = FFCObjectWrapper::unwrap(handle_);
   FFModel *model = FFCObjectWrapper::unwrap(model_);
   std::vector<int> dims_vec;
@@ -1238,7 +1238,7 @@ bool flexflow_tensor_set_tensor_int(flexflow_tensor_t handle_,
                                     flexflow_model_t model_,
                                     int num_dim,
                                     int *dims,
-                                    const int *data) {
+                                    int const *data) {
   Tensor handle = FFCObjectWrapper::unwrap(handle_);
   FFModel *model = FFCObjectWrapper::unwrap(model_);
   std::vector<int> dims_vec;
@@ -1261,7 +1261,7 @@ bool flexflow_tensor_set_tensor_int64(flexflow_tensor_t handle_,
                                       flexflow_model_t model_,
                                       int num_dim,
                                       int *dims,
-                                      const int64_t *data) {
+                                      int64_t const *data) {
   Tensor handle = FFCObjectWrapper::unwrap(handle_);
   FFModel *model = FFCObjectWrapper::unwrap(model_);
   std::vector<int> dims_vec;
@@ -1324,7 +1324,7 @@ flexflow_sgd_optimizer_create(flexflow_model_t model_,
                               double momentum, /* 0.0f */
                               bool nesterov,   /* false */
                               double weight_decay /* 0.0f */) {
-  const FFModel *model = FFCObjectWrapper::unwrap_const(model_);
+  FFModel const *model = FFCObjectWrapper::unwrap_const(model_);
   SGDOptimizer *optimizer =
       new SGDOptimizer(model, lr, momentum, nesterov, weight_decay);
   DEBUG_PRINT("[SGDOptimizer] new %p", optimizer);
@@ -1354,7 +1354,7 @@ flexflow_adam_optimizer_create(flexflow_model_t model_,
                                double beta2 /*0.999f*/,
                                double weight_decay /*0.0f*/,
                                double epsilon /*1e-8*/) {
-  const FFModel *model = FFCObjectWrapper::unwrap_const(model_);
+  FFModel const *model = FFCObjectWrapper::unwrap_const(model_);
   AdamOptimizer *optimizer =
       new AdamOptimizer(model, alpha, beta1, beta2, weight_decay, epsilon);
   DEBUG_PRINT("AdamOptimizer new %p", optimizer);
@@ -1478,10 +1478,10 @@ void flexflow_net_config_destroy(flexflow_net_config_t handle_) {
   delete handle;
 }
 
-const char *
+char const *
 flexflow_net_config_get_dataset_path(flexflow_net_config_t handle_) {
   NetConfig *handle = FFCObjectWrapper::unwrap(handle_);
-  const char *cstr = handle->dataset_path.c_str();
+  char const *cstr = handle->dataset_path.c_str();
   return cstr;
 }
 
@@ -1498,17 +1498,17 @@ void flexflow_dlrm_config_destroy(flexflow_dlrm_config_t handle_) {
   delete handle;
 }
 
-const char *
+char const *
 flexflow_dlrm_config_get_dataset_path(flexflow_dlrm_config_t handle_) {
   DLRMConfig *handle = FFCObjectWrapper::unwrap(handle_);
-  const char *cstr = handle->dataset_path.c_str();
+  char const *cstr = handle->dataset_path.c_str();
   return cstr;
 }
 
-const char *
+char const *
 flexflow_dlrm_config_get_arch_interaction_op(flexflow_dlrm_config_t handle_) {
   DLRMConfig *handle = FFCObjectWrapper::unwrap(handle_);
-  const char *cstr = handle->arch_interaction_op.c_str();
+  char const *cstr = handle->arch_interaction_op.c_str();
   return cstr;
 }
 
@@ -1854,7 +1854,7 @@ void flexflow_op_forward(flexflow_op_t handle_, flexflow_model_t model_) {
 // NetConfig implementation
 // -----------------------------------------------------------------------
 NetConfig::NetConfig(void) {
-  const InputArgs &command_args = Runtime::get_input_args();
+  InputArgs const &command_args = Runtime::get_input_args();
   char **argv = command_args.argv;
   int argc = command_args.argc;
   for (int i = 1; i < argc; i++) {
@@ -1878,7 +1878,7 @@ DLRMConfig::DLRMConfig(void)
   mlp_top.push_back(8);
   mlp_top.push_back(2);
 
-  const InputArgs &command_args = Runtime::get_input_args();
+  InputArgs const &command_args = Runtime::get_input_args();
   char **argv = command_args.argv;
   int argc = command_args.argc;
   for (int i = 1; i < argc; i++) {

--- a/python/flexflow_c.h
+++ b/python/flexflow_c.h
@@ -107,47 +107,47 @@ void flexflow_model_zero_gradients(flexflow_model_t handle);
 
 flexflow_tensor_t flexflow_model_add_exp(flexflow_model_t handle,
                                          const flexflow_tensor_t x,
-                                         const char *name);
+                                         char const *name);
 
 flexflow_tensor_t flexflow_model_add_add(flexflow_model_t handle,
                                          const flexflow_tensor_t x,
                                          const flexflow_tensor_t y,
                                          bool inplace_a,
-                                         const char *name);
+                                         char const *name);
 
 flexflow_tensor_t flexflow_model_add_subtract(flexflow_model_t handle,
                                               const flexflow_tensor_t x,
                                               const flexflow_tensor_t y,
                                               bool inplace_a,
-                                              const char *name);
+                                              char const *name);
 
 flexflow_tensor_t flexflow_model_add_multiply(flexflow_model_t handle,
                                               const flexflow_tensor_t x,
                                               const flexflow_tensor_t y,
                                               bool inplace_a,
-                                              const char *name);
+                                              char const *name);
 
 flexflow_tensor_t flexflow_model_add_divide(flexflow_model_t handle,
                                             const flexflow_tensor_t x,
                                             const flexflow_tensor_t y,
                                             bool inplace_a,
-                                            const char *name);
+                                            char const *name);
 
 flexflow_tensor_t flexflow_model_add_rsqrt(flexflow_model_t handle_,
                                            const flexflow_tensor_t input_,
-                                           const char *name);
+                                           char const *name);
 
 flexflow_tensor_t flexflow_model_add_pow(flexflow_model_t handle_,
                                          const flexflow_tensor_t input_,
-                                         const float exponent,
-                                         const char *name);
+                                         float const exponent,
+                                         char const *name);
 
 flexflow_tensor_t flexflow_model_add_mean(flexflow_model_t handle_,
                                           const flexflow_tensor_t input_,
                                           int *dims,
                                           int n,
                                           bool keepdims,
-                                          const char *name);
+                                          char const *name);
 
 flexflow_tensor_t
 flexflow_model_add_conv2d(flexflow_model_t handle,
@@ -165,7 +165,7 @@ flexflow_model_add_conv2d(flexflow_model_t handle,
                           flexflow_op_t shared_op,
                           flexflow_initializer_t kernel_initializer,
                           flexflow_initializer_t bias_initializer,
-                          const char *name);
+                          char const *name);
 
 flexflow_tensor_t
 flexflow_model_add_embedding(flexflow_model_t handle,
@@ -175,7 +175,7 @@ flexflow_model_add_embedding(flexflow_model_t handle,
                              enum AggrMode aggr,
                              flexflow_op_t shared_op,
                              flexflow_initializer_t kernel_initializer,
-                             const char *name);
+                             char const *name);
 
 flexflow_tensor_t
 flexflow_model_add_pool2d(flexflow_model_t handle,
@@ -188,12 +188,12 @@ flexflow_model_add_pool2d(flexflow_model_t handle,
                           int padding_w,
                           enum PoolType type /* POOL_MAX */,
                           enum ActiMode activation /* AC_MODE_NONE */,
-                          const char *name);
+                          char const *name);
 
 flexflow_tensor_t flexflow_model_add_batch_norm(flexflow_model_t handle,
                                                 const flexflow_tensor_t input,
                                                 bool relu,
-                                                const char *name);
+                                                char const *name);
 
 flexflow_tensor_t flexflow_model_add_layer_norm(flexflow_model_t handle,
                                                 const flexflow_tensor_t input,
@@ -201,7 +201,7 @@ flexflow_tensor_t flexflow_model_add_layer_norm(flexflow_model_t handle,
                                                 int *axes,
                                                 bool elementwise_affine,
                                                 float eps,
-                                                const char *name);
+                                                char const *name);
 
 flexflow_tensor_t
 flexflow_model_add_batch_matmul(flexflow_model_t handle,
@@ -220,13 +220,13 @@ flexflow_model_add_dense(flexflow_model_t handle,
                          flexflow_op_t shared_op,
                          flexflow_initializer_t kernel_initializer,
                          flexflow_initializer_t bias_initializer,
-                         const char *name);
+                         char const *name);
 
 flexflow_tensor_t flexflow_model_add_concat(flexflow_model_t handle,
                                             int n,
                                             flexflow_tensor_t *input,
                                             int axis,
-                                            const char *name);
+                                            char const *name);
 
 void flexflow_model_add_split(flexflow_model_t handle,
                               flexflow_tensor_t input,
@@ -234,91 +234,91 @@ void flexflow_model_add_split(flexflow_model_t handle,
                               flexflow_tensor_t *outputs,
                               int *split,
                               int axis,
-                              const char *name);
+                              char const *name);
 
 flexflow_tensor_t flexflow_model_add_flat(flexflow_model_t handle,
                                           flexflow_tensor_t input,
-                                          const char *name);
+                                          char const *name);
 
 flexflow_tensor_t flexflow_model_add_softmax(flexflow_model_t handle,
                                              const flexflow_tensor_t input,
                                              int dim,
-                                             const char *name);
+                                             char const *name);
 
 flexflow_tensor_t flexflow_model_add_transpose(flexflow_model_t handle,
                                                const flexflow_tensor_t input,
                                                int n,
                                                int *perm,
-                                               const char *name);
+                                               char const *name);
 
 flexflow_tensor_t flexflow_model_add_reshape(flexflow_model_t handle,
                                              const flexflow_tensor_t input,
                                              int n,
                                              int *shape,
-                                             const char *name);
+                                             char const *name);
 
 flexflow_tensor_t flexflow_model_add_reverse(flexflow_model_t handle,
                                              const flexflow_tensor_t input,
                                              int axis,
-                                             const char *name);
+                                             char const *name);
 
 flexflow_tensor_t flexflow_model_add_relu(flexflow_model_t handle,
                                           const flexflow_tensor_t input,
                                           bool inplace,
-                                          const char *name);
+                                          char const *name);
 
 flexflow_tensor_t
 flexflow_model_add_scalar_multiply(flexflow_model_t handle,
                                    const flexflow_tensor_t input,
-                                   const float scalar,
+                                   float const scalar,
                                    bool inplace,
-                                   const char *name);
+                                   char const *name);
 
 flexflow_tensor_t flexflow_model_add_scalar_add(flexflow_model_t handle,
                                                 const flexflow_tensor_t input,
-                                                const float scalar,
+                                                float const scalar,
                                                 bool inplace,
-                                                const char *name);
+                                                char const *name);
 
 flexflow_tensor_t flexflow_model_add_scalar_sub(flexflow_model_t handle,
                                                 const flexflow_tensor_t input,
-                                                const float scalar,
+                                                float const scalar,
                                                 bool inplace,
-                                                const char *name);
+                                                char const *name);
 
 flexflow_tensor_t
 flexflow_model_add_scalar_truediv(flexflow_model_t handle,
                                   const flexflow_tensor_t input,
-                                  const float scalar,
+                                  float const scalar,
                                   bool inplace,
-                                  const char *name);
+                                  char const *name);
 
 flexflow_tensor_t flexflow_model_add_gelu(flexflow_model_t handle,
                                           const flexflow_tensor_t input,
-                                          const char *name);
+                                          char const *name);
 
 flexflow_tensor_t flexflow_model_add_identity(flexflow_model_t handle,
                                               const flexflow_tensor_t input,
-                                              const char *name);
+                                              char const *name);
 
 flexflow_tensor_t flexflow_model_add_sigmoid(flexflow_model_t handle,
                                              const flexflow_tensor_t input,
-                                             const char *name);
+                                             char const *name);
 
 flexflow_tensor_t flexflow_model_add_tanh(flexflow_model_t handle,
                                           const flexflow_tensor_t input,
-                                          const char *name);
+                                          char const *name);
 
 flexflow_tensor_t flexflow_model_add_elu(flexflow_model_t handle,
                                          const flexflow_tensor_t input,
                                          bool inplace,
-                                         const char *name);
+                                         char const *name);
 
 flexflow_tensor_t flexflow_model_add_dropout(flexflow_model_t handle,
                                              const flexflow_tensor_t input,
                                              float rate,
                                              unsigned long long seed,
-                                             const char *name);
+                                             char const *name);
 
 flexflow_tensor_t flexflow_model_add_multihead_attention(
     flexflow_model_t handle,
@@ -334,7 +334,7 @@ flexflow_tensor_t flexflow_model_add_multihead_attention(
     bool add_bias_kv,
     bool add_zero_attn,
     flexflow_initializer_t kernel_initializer,
-    const char *name);
+    char const *name);
 
 void flexflow_model_set_sgd_optimizer(flexflow_model_t handle,
                                       flexflow_sgd_optimizer_t optimizer);
@@ -361,7 +361,7 @@ flexflow_model_get_perf_metrics(flexflow_model_t handle);
 
 flexflow_tensor_t flexflow_tensor_create(flexflow_model_t model,
                                          int num_dims,
-                                         const int *dims,
+                                         int const *dims,
                                          enum DataType data_type,
                                          bool create_grad /* true */);
 
@@ -371,7 +371,7 @@ void flexflow_tensor_map(flexflow_model_t model,
 
 flexflow_tensor_t flexflow_constant_create(flexflow_model_t model,
                                            int num_dims,
-                                           const int *dims,
+                                           int const *dims,
                                            float value,
                                            enum DataType data_type);
 
@@ -419,7 +419,7 @@ bool flexflow_tensor_set_tensor_float(flexflow_tensor_t handle,
                                       flexflow_model_t model,
                                       int num_dim,
                                       int *dims,
-                                      const float *data);
+                                      float const *data);
 
 bool flexflow_tensor_get_tensor_float(flexflow_tensor_t handle,
                                       flexflow_model_t model,
@@ -430,7 +430,7 @@ bool flexflow_tensor_set_tensor_int(flexflow_tensor_t handle,
                                     flexflow_model_t model,
                                     int num_dim,
                                     int *dims,
-                                    const int *data);
+                                    int const *data);
 
 bool flexflow_tensor_get_tensor_int(flexflow_tensor_t handle,
                                     flexflow_model_t model,
@@ -441,7 +441,7 @@ bool flexflow_tensor_set_tensor_int64(flexflow_tensor_t handle,
                                       flexflow_model_t model,
                                       int num_dim,
                                       int *dims,
-                                      const int64_t *data,
+                                      int64_t const *data,
                                       enum ParameterSyncType comm_type);
 
 bool flexflow_tensor_get_tensor_int64(flexflow_tensor_t handle,
@@ -556,7 +556,7 @@ flexflow_net_config_t flexflow_net_config_create();
 
 void flexflow_net_config_destroy(flexflow_net_config_t handle);
 
-const char *flexflow_net_config_get_dataset_path(flexflow_net_config_t handle);
+char const *flexflow_net_config_get_dataset_path(flexflow_net_config_t handle);
 
 // -----------------------------------------------------------------------
 // DLRMConfig
@@ -566,10 +566,10 @@ flexflow_dlrm_config_t flexflow_dlrm_config_create();
 
 void flexflow_dlrm_config_destroy(flexflow_dlrm_config_t handle);
 
-const char *
+char const *
 flexflow_dlrm_config_get_dataset_path(flexflow_dlrm_config_t handle);
 
-const char *
+char const *
 flexflow_dlrm_config_get_arch_interaction_op(flexflow_dlrm_config_t handle);
 
 int flexflow_dlrm_config_get_sparse_feature_size(flexflow_dlrm_config_t handle);

--- a/python/flexflow_dataloader.cc
+++ b/python/flexflow_dataloader.cc
@@ -86,7 +86,7 @@ ImgDataLoader4D::ImgDataLoader4D(FFModel &ff,
 }
 
 ImgDataLoader4D::ImgDataLoader4D(FFModel &ff,
-                                 const NetConfig &alexnet,
+                                 NetConfig const &alexnet,
                                  ParallelTensor input,
                                  ParallelTensor label) {
   Context ctx = ff.config.lg_ctx;
@@ -124,7 +124,7 @@ ImgDataLoader4D::ImgDataLoader4D(FFModel &ff,
   }
   // Load entire dataset
   // TODO: Use index launcher instead of task launcher
-  const NetConfig *ptr = &alexnet;
+  NetConfig const *ptr = &alexnet;
   TaskLauncher launcher(CUSTOM_CPU_TASK_ID_1,
                         TaskArgument(&ptr, sizeof(NetConfig *)));
   // regions[0]: full_input
@@ -147,16 +147,16 @@ ImgDataLoader4D::ImgDataLoader4D(FFModel &ff,
 }
 
 void ImgDataLoader4D::load_entire_dataset_from_numpy(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   assert(regions.size() == 4);
   assert(task->regions.size() == regions.size());
-  const AccessorWO<float, 4> acc_input(regions[0], FID_DATA);
-  const AccessorWO<int, 2> acc_label(regions[1], FID_DATA);
-  const AccessorRO<float, 4> acc_input_(regions[2], FID_DATA);
-  const AccessorRO<int, 2> acc_label_(regions[3], FID_DATA);
+  AccessorWO<float, 4> const acc_input(regions[0], FID_DATA);
+  AccessorWO<int, 2> const acc_label(regions[1], FID_DATA);
+  AccessorRO<float, 4> const acc_input_(regions[2], FID_DATA);
+  AccessorRO<int, 2> const acc_label_(regions[3], FID_DATA);
   Rect<4> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_input.accessor.is_dense_arbitrary(rect_input));
@@ -170,8 +170,8 @@ void ImgDataLoader4D::load_entire_dataset_from_numpy(
   assert(acc_label_.accessor.is_dense_arbitrary(rect_label_));
   float *input_ptr = acc_input.ptr(rect_input.lo);
   int *label_ptr = acc_label.ptr(rect_label.lo);
-  const float *input_ptr_ = acc_input_.ptr(rect_input_.lo);
-  const int *label_ptr_ = acc_label_.ptr(rect_label_.lo);
+  float const *input_ptr_ = acc_input_.ptr(rect_input_.lo);
+  int const *label_ptr_ = acc_label_.ptr(rect_label_.lo);
   printf("Check ptr input %p %lu %lu, label %p %lu %lu\n",
          input_ptr_,
          (uintptr_t)input_ptr_,
@@ -219,15 +219,15 @@ void nearest_neigh(unsigned char *image,
 }
 
 void ImgDataLoader4D::load_entire_dataset(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
-  const NetConfig *alexnet = *((NetConfig **)task->args);
+  NetConfig const *alexnet = *((NetConfig **)task->args);
   assert(regions.size() == 2);
   assert(task->regions.size() == regions.size());
-  const AccessorWO<float, 4> acc_input(regions[0], FID_DATA);
-  const AccessorWO<int, 2> acc_label(regions[1], FID_DATA);
+  AccessorWO<float, 4> const acc_input(regions[0], FID_DATA);
+  AccessorWO<int, 2> const acc_label(regions[1], FID_DATA);
   Rect<4> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_input.accessor.is_dense_arbitrary(rect_input));
@@ -375,7 +375,7 @@ void ImgDataLoader4D::next_batch(FFModel &ff) {
   next_index += ff.config.batchSize;
 }
 
-size_t ImgDataLoader4D::get_file_size(const std::string &filename) {
+size_t ImgDataLoader4D::get_file_size(std::string const &filename) {
   std::streampos begin, end;
   std::ifstream file(filename.c_str(), std::ios::binary);
   begin = file.tellg();
@@ -445,16 +445,16 @@ ImgDataLoader2D::ImgDataLoader2D(FFModel &ff,
 }
 
 void ImgDataLoader2D::load_entire_dataset_from_numpy(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   assert(regions.size() == 4);
   assert(task->regions.size() == regions.size());
-  const AccessorWO<float, 2> acc_input(regions[0], FID_DATA);
-  const AccessorWO<int, 2> acc_label(regions[1], FID_DATA);
-  const AccessorRO<float, 2> acc_input_(regions[2], FID_DATA);
-  const AccessorRO<int, 2> acc_label_(regions[3], FID_DATA);
+  AccessorWO<float, 2> const acc_input(regions[0], FID_DATA);
+  AccessorWO<int, 2> const acc_label(regions[1], FID_DATA);
+  AccessorRO<float, 2> const acc_input_(regions[2], FID_DATA);
+  AccessorRO<int, 2> const acc_label_(regions[3], FID_DATA);
   Rect<2> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_input.accessor.is_dense_arbitrary(rect_input));
@@ -468,8 +468,8 @@ void ImgDataLoader2D::load_entire_dataset_from_numpy(
   assert(acc_label_.accessor.is_dense_arbitrary(rect_label_));
   float *input_ptr = acc_input.ptr(rect_input.lo);
   int *label_ptr = acc_label.ptr(rect_label.lo);
-  const float *input_ptr_ = acc_input_.ptr(rect_input_.lo);
-  const int *label_ptr_ = acc_label_.ptr(rect_label_.lo);
+  float const *input_ptr_ = acc_input_.ptr(rect_input_.lo);
+  int const *label_ptr_ = acc_label_.ptr(rect_label_.lo);
   printf("Check ptr input %p %lu %lu, label %p %lu %lu\n",
          input_ptr_,
          (uintptr_t)input_ptr_,
@@ -866,8 +866,8 @@ void SingleDataLoader::next_batch_xd_launcher(FFModel &ff, int task_id) {
 // Task body
 template <typename DT>
 void SingleDataLoader::load_entire_dataset_from_numpy(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   assert(regions.size() == 2);
@@ -888,14 +888,14 @@ void SingleDataLoader::load_entire_dataset_from_numpy(
 
 template <typename DT, int NDIM>
 void SingleDataLoader::load_entire_dataset_from_numpy_with_dim(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == regions.size());
-  const AccessorWO<DT, NDIM> acc_input(regions[0], FID_DATA);
-  const AccessorRO<DT, NDIM> acc_input_(regions[1], FID_DATA);
+  AccessorWO<DT, NDIM> const acc_input(regions[0], FID_DATA);
+  AccessorRO<DT, NDIM> const acc_input_(regions[1], FID_DATA);
   Rect<NDIM> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_input.accessor.is_dense_arbitrary(rect_input));
@@ -924,8 +924,8 @@ void SingleDataLoader::load_entire_dataset_from_numpy_with_dim(
 // Task body
 template <typename DT>
 void SingleDataLoader::index_load_entire_dataset_from_numpy(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   assert(regions.size() == 1);
@@ -946,8 +946,8 @@ void SingleDataLoader::index_load_entire_dataset_from_numpy(
 
 template <typename DT, int NDIM>
 void SingleDataLoader::index_load_entire_dataset_from_numpy_with_dim(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   assert(regions.size() == 1);
@@ -957,7 +957,7 @@ void SingleDataLoader::index_load_entire_dataset_from_numpy_with_dim(
 #else
   IndexLoadArg *meta = (IndexLoadArg *)task->args;
 #endif
-  const AccessorWO<DT, NDIM> acc_input(regions[0], FID_DATA);
+  AccessorWO<DT, NDIM> const acc_input(regions[0], FID_DATA);
   Rect<NDIM> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_input.accessor.is_dense_arbitrary(rect_input));
@@ -1087,32 +1087,32 @@ template void SingleDataLoader::index_loader_xd_launcher<2>(
 template void SingleDataLoader::index_loader_xd_launcher<4>(
     FFModel &ff, int task_id, void *full_input_ptr, size_t size_per_sample);
 template void SingleDataLoader::load_entire_dataset_from_numpy<float>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);
 template void SingleDataLoader::load_entire_dataset_from_numpy<int32_t>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);
 template void SingleDataLoader::load_entire_dataset_from_numpy<int64_t>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);
 template void SingleDataLoader::index_load_entire_dataset_from_numpy<float>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);
 template void SingleDataLoader::index_load_entire_dataset_from_numpy<int32_t>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);
 template void SingleDataLoader::index_load_entire_dataset_from_numpy<int64_t>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);

--- a/python/flexflow_dataloader.cpp
+++ b/python/flexflow_dataloader.cpp
@@ -20,8 +20,8 @@
 using namespace Legion;
 using namespace FlexFlow;
 
-void ImgDataLoader::load_label(const Task *task,
-                               const std::vector<PhysicalRegion> &regions,
+void ImgDataLoader::load_label(Task const *task,
+                               std::vector<PhysicalRegion> const &regions,
                                Context ctx,
                                Runtime *runtime) {
   assert(regions.size() == 2);
@@ -40,7 +40,7 @@ void ImgDataLoader::load_label(const Task *task,
   assert(batch_size == meta->num_samples);
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
-  const int *input_zc = acc_full_label.ptr + meta->idxs[0];
+  int const *input_zc = acc_full_label.ptr + meta->idxs[0];
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
   hipLaunchKernelGGL(copy_kernel,
@@ -54,8 +54,8 @@ void ImgDataLoader::load_label(const Task *task,
   checkCUDA(hipDeviceSynchronize());
 }
 
-void ImgDataLoader4D::load_input(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+void ImgDataLoader4D::load_input(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  Runtime *runtime) {
   assert(regions.size() == 2);
@@ -80,7 +80,7 @@ void ImgDataLoader4D::load_input(const Task *task,
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
   coord_t start_idx = meta->idxs[0];
-  const float *input_zc =
+  float const *input_zc =
       acc_full_input.ptr + start_idx * channels * height * width;
   // printf("load input %d %d %d %d\n", meta->idxs[0], channels, height, width);
   hipStream_t stream;
@@ -96,8 +96,8 @@ void ImgDataLoader4D::load_input(const Task *task,
   checkCUDA(hipDeviceSynchronize());
 }
 
-void ImgDataLoader2D::load_input(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+void ImgDataLoader2D::load_input(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  Runtime *runtime) {
   assert(regions.size() == 2);
@@ -119,7 +119,7 @@ void ImgDataLoader2D::load_input(const Task *task,
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
   coord_t start_idx = meta->idxs[0];
-  const float *input_zc = acc_full_input.ptr + start_idx * width;
+  float const *input_zc = acc_full_input.ptr + start_idx * width;
   // printf("load input %d %d %d %d\n", meta->idxs[0], channels, height, width);
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -135,8 +135,8 @@ void ImgDataLoader2D::load_input(const Task *task,
 }
 
 template <typename DT>
-void SingleDataLoader::load_input(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+void SingleDataLoader::load_input(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime) {
   assert(regions.size() == 2);
@@ -188,8 +188,8 @@ void SingleDataLoader::load_input(const Task *task,
 #ifdef DEADCODE
 template <typename DT, int NDIM>
 void SingleDataLoader::load_input_with_dim(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   assert(regions.size() == 2);
@@ -237,17 +237,17 @@ void SingleDataLoader::load_input_with_dim(
 #endif
 
 template void
-SingleDataLoader::load_input<float>(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+SingleDataLoader::load_input<float>(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime);
 template void SingleDataLoader::load_input<int32_t>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);
 template void SingleDataLoader::load_input<int64_t>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);

--- a/python/flexflow_dataloader.cu
+++ b/python/flexflow_dataloader.cu
@@ -19,8 +19,8 @@
 using namespace Legion;
 using namespace FlexFlow;
 
-void ImgDataLoader::load_label(const Task *task,
-                               const std::vector<PhysicalRegion> &regions,
+void ImgDataLoader::load_label(Task const *task,
+                               std::vector<PhysicalRegion> const &regions,
                                Context ctx,
                                Runtime *runtime) {
   assert(regions.size() == 2);
@@ -39,7 +39,7 @@ void ImgDataLoader::load_label(const Task *task,
   assert(batch_size == meta->num_samples);
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
-  const int *input_zc = acc_full_label.ptr + meta->idxs[0];
+  int const *input_zc = acc_full_label.ptr + meta->idxs[0];
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
   copy_kernel<<<GET_BLOCKS(acc_batch_label.rect.volume()),
@@ -50,8 +50,8 @@ void ImgDataLoader::load_label(const Task *task,
   checkCUDA(cudaDeviceSynchronize());
 }
 
-void ImgDataLoader4D::load_input(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+void ImgDataLoader4D::load_input(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  Runtime *runtime) {
   assert(regions.size() == 2);
@@ -76,7 +76,7 @@ void ImgDataLoader4D::load_input(const Task *task,
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
   coord_t start_idx = meta->idxs[0];
-  const float *input_zc =
+  float const *input_zc =
       acc_full_input.ptr + start_idx * channels * height * width;
   // printf("load input %d %d %d %d\n", meta->idxs[0], channels, height, width);
   cudaStream_t stream;
@@ -89,8 +89,8 @@ void ImgDataLoader4D::load_input(const Task *task,
   checkCUDA(cudaDeviceSynchronize());
 }
 
-void ImgDataLoader2D::load_input(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+void ImgDataLoader2D::load_input(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  Runtime *runtime) {
   assert(regions.size() == 2);
@@ -112,7 +112,7 @@ void ImgDataLoader2D::load_input(const Task *task,
   for (int i = 1; i < batch_size; i++)
     assert(meta->idxs[i] == meta->idxs[0] + i);
   coord_t start_idx = meta->idxs[0];
-  const float *input_zc = acc_full_input.ptr + start_idx * width;
+  float const *input_zc = acc_full_input.ptr + start_idx * width;
   // printf("load input %d %d %d %d\n", meta->idxs[0], channels, height, width);
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -125,8 +125,8 @@ void ImgDataLoader2D::load_input(const Task *task,
 }
 
 template <typename DT>
-void SingleDataLoader::load_input(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+void SingleDataLoader::load_input(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime) {
   assert(regions.size() == 2);
@@ -175,8 +175,8 @@ void SingleDataLoader::load_input(const Task *task,
 #ifdef DEADCODE
 template <typename DT, int NDIM>
 void SingleDataLoader::load_input_with_dim(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   assert(regions.size() == 2);
@@ -221,17 +221,17 @@ void SingleDataLoader::load_input_with_dim(
 #endif
 
 template void
-SingleDataLoader::load_input<float>(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+SingleDataLoader::load_input<float>(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime);
 template void SingleDataLoader::load_input<int32_t>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);
 template void SingleDataLoader::load_input<int64_t>(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime);

--- a/python/flexflow_dataloader.h
+++ b/python/flexflow_dataloader.h
@@ -35,8 +35,8 @@ struct DLRMConfig {
 class ImgDataLoader {
 public:
   ImgDataLoader();
-  static void load_label(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  static void load_label(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   void reset(void);
@@ -56,27 +56,27 @@ public:
                   FlexFlow::ParallelTensor full_label_,
                   int num_samples_);
   ImgDataLoader4D(FlexFlow::FFModel &ff,
-                  const NetConfig &alexnet,
+                  NetConfig const &alexnet,
                   FlexFlow::ParallelTensor input,
                   FlexFlow::ParallelTensor label);
-  static void load_input(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  static void load_input(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   static void
-  load_entire_dataset(const Legion::Task *task,
-                      const std::vector<Legion::PhysicalRegion> &regions,
+  load_entire_dataset(Legion::Task const *task,
+                      std::vector<Legion::PhysicalRegion> const &regions,
                       Legion::Context ctx,
                       Legion::Runtime *runtime);
   static void load_entire_dataset_from_numpy(
-      const Legion::Task *task,
-      const std::vector<Legion::PhysicalRegion> &regions,
+      Legion::Task const *task,
+      std::vector<Legion::PhysicalRegion> const &regions,
       Legion::Context ctx,
       Legion::Runtime *runtime);
   void next_batch(FlexFlow::FFModel &);
 
 private:
-  size_t get_file_size(const std::string &filename);
+  size_t get_file_size(std::string const &filename);
 };
 
 class ImgDataLoader2D : public ImgDataLoader {
@@ -87,13 +87,13 @@ public:
                   FlexFlow::ParallelTensor full_input_,
                   FlexFlow::ParallelTensor full_label_,
                   int num_samples_);
-  static void load_input(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  static void load_input(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   static void load_entire_dataset_from_numpy(
-      const Legion::Task *task,
-      const std::vector<Legion::PhysicalRegion> &regions,
+      Legion::Task const *task,
+      std::vector<Legion::PhysicalRegion> const &regions,
       Legion::Context ctx,
       Legion::Runtime *runtime);
   void next_batch(FlexFlow::FFModel &);
@@ -122,8 +122,8 @@ public:
   static void register_gpu_tasks(void);
 
   template <typename DT>
-  static void load_input(const Legion::Task *task,
-                         const std::vector<Legion::PhysicalRegion> &regions,
+  static void load_input(Legion::Task const *task,
+                         std::vector<Legion::PhysicalRegion> const &regions,
                          Legion::Context ctx,
                          Legion::Runtime *runtime);
   // template<typename DT, int NDIM>
@@ -134,26 +134,26 @@ public:
   //     Legion::Runtime* runtime);
   template <typename DT>
   static void load_entire_dataset_from_numpy(
-      const Legion::Task *task,
-      const std::vector<Legion::PhysicalRegion> &regions,
+      Legion::Task const *task,
+      std::vector<Legion::PhysicalRegion> const &regions,
       Legion::Context ctx,
       Legion::Runtime *runtime);
   template <typename DT, int NDIM>
   static void load_entire_dataset_from_numpy_with_dim(
-      const Legion::Task *task,
-      const std::vector<Legion::PhysicalRegion> &regions,
+      Legion::Task const *task,
+      std::vector<Legion::PhysicalRegion> const &regions,
       Legion::Context ctx,
       Legion::Runtime *runtime);
   template <typename DT>
   static void index_load_entire_dataset_from_numpy(
-      const Legion::Task *task,
-      const std::vector<Legion::PhysicalRegion> &regions,
+      Legion::Task const *task,
+      std::vector<Legion::PhysicalRegion> const &regions,
       Legion::Context ctx,
       Legion::Runtime *runtime);
   template <typename DT, int NDIM>
   static void index_load_entire_dataset_from_numpy_with_dim(
-      const Legion::Task *task,
-      const std::vector<Legion::PhysicalRegion> &regions,
+      Legion::Task const *task,
+      std::vector<Legion::PhysicalRegion> const &regions,
       Legion::Context ctx,
       Legion::Runtime *runtime);
 

--- a/python/main.cc
+++ b/python/main.cc
@@ -28,10 +28,10 @@ using namespace FlexFlow;
 //   PYTHON_TOP_LEVEL_TASK_ID = 11111,
 // };
 
-VariantID preregister_python_task_variant(const TaskVariantRegistrar &registrar,
-                                          const char *module_name,
-                                          const char *function_name,
-                                          const void *userdata = NULL,
+VariantID preregister_python_task_variant(TaskVariantRegistrar const &registrar,
+                                          char const *module_name,
+                                          char const *function_name,
+                                          void const *userdata = NULL,
                                           size_t userlen = 0) {
   CodeDescriptor code_desc(
       Realm::Type::from_cpp_type<Processor::TaskFuncPtr>());

--- a/scripts/cnn.h
+++ b/scripts/cnn.h
@@ -41,15 +41,15 @@ size_t workSpaceSize;
 
 float conv2DForwardTime(cudnnHandle_t handle,
                         const cudnnTensorDescriptor_t xDesc,
-                        const void *x,
+                        void const *x,
                         const cudnnFilterDescriptor_t wDesc,
-                        const void *w,
+                        void const *w,
                         const cudnnConvolutionDescriptor_t convDesc,
                         void *workSpace,
                         size_t workSpaceSize,
                         const cudnnTensorDescriptor_t yDesc,
                         void *y) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   float alpha = 1.0f, beta = 0.0f;
   cudnnConvolutionFwdAlgoPerf_t perfResults[reqAlgCnt];
@@ -100,15 +100,15 @@ float conv2DForwardTime(cudnnHandle_t handle,
 
 float conv2DBackwardFilterTime(cudnnHandle_t handle,
                                const cudnnTensorDescriptor_t xDesc,
-                               const void *x,
+                               void const *x,
                                const cudnnTensorDescriptor_t dyDesc,
-                               const void *dy,
+                               void const *dy,
                                const cudnnConvolutionDescriptor_t convDesc,
                                void *workSpace,
                                size_t workSpaceSize,
                                const cudnnFilterDescriptor_t dwDesc,
                                void *dw) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   float alpha = 1.0f, beta = 0.0f;
   cudnnConvolutionBwdFilterAlgoPerf_t perfResults[reqAlgCnt];
@@ -159,15 +159,15 @@ float conv2DBackwardFilterTime(cudnnHandle_t handle,
 
 float conv2DBackwardDataTime(cudnnHandle_t handle,
                              const cudnnFilterDescriptor_t wDesc,
-                             const void *w,
+                             void const *w,
                              const cudnnTensorDescriptor_t dyDesc,
-                             const void *dy,
+                             void const *dy,
                              const cudnnConvolutionDescriptor_t convDesc,
                              void *workSpace,
                              size_t workSpaceSize,
                              const cudnnTensorDescriptor_t dxDesc,
                              void *dx) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   float alpha = 1.0f, beta = 0.0f;
   cudnnConvolutionBwdDataAlgoPerf_t perfResults[reqAlgCnt];
@@ -219,7 +219,7 @@ float conv2DBackwardDataTime(cudnnHandle_t handle,
 float pool2DForwardTime(cudnnHandle_t handle,
                         const cudnnPoolingDescriptor_t poolDesc,
                         const cudnnTensorDescriptor_t xDesc,
-                        const void *x,
+                        void const *x,
                         const cudnnTensorDescriptor_t yDesc,
                         void *y) {
   float alpha = 1.0f, beta = 0.0f;
@@ -243,13 +243,13 @@ float pool2DForwardTime(cudnnHandle_t handle,
 float pool2DBackwardTime(cudnnHandle_t handle,
                          const cudnnPoolingDescriptor_t poolDesc,
                          const cudnnTensorDescriptor_t xDesc,
-                         const void *x,
+                         void const *x,
                          const cudnnTensorDescriptor_t yDesc,
-                         const void *y,
+                         void const *y,
                          const cudnnTensorDescriptor_t dxDesc,
                          void *dx,
                          const cudnnTensorDescriptor_t dyDesc,
-                         const void *dy) {
+                         void const *dy) {
   float alpha = 1.0f, beta = 0.0f;
   cudaEvent_t t_start, t_end;
   cudaEventCreate(&t_start);

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -58,7 +58,7 @@ download_clang_tool() {
   fi
 }
 
-CLANG_FORMAT_VERSION="13"
+CLANG_FORMAT_VERSION="14"
 CLANG_FORMAT_PATH="$TOOLS_PATH/clang-format-$CLANG_FORMAT_VERSION"
 
 if [[ ! -e $CLANG_FORMAT_PATH ]]; then

--- a/scripts/simulator.cc
+++ b/scripts/simulator.cc
@@ -21,23 +21,23 @@
 #define NOT_USE_SIMULATE_OPT
 //#define VERBOSE
 
-const int SRC_LENGTH = 5;
-const int DST_LENGTH = 5;
-const int LSTM_PER_NODE_LENGTH = 8;
-const int NUM_LAYERS = 2;
-const int VOCAB_SIZE = 32000;
-const int LOCAL_BATCH_SIZE = 64;
-const int EMBEDDING_SIZE = 1024;
-const int HIDDEN_SIZE = 1024;
-const int NUM_NODES = 2;
-const int WORKERS_PER_NODE = 4;
-const int NUM_WORKERS =
+int const SRC_LENGTH = 5;
+int const DST_LENGTH = 5;
+int const LSTM_PER_NODE_LENGTH = 8;
+int const NUM_LAYERS = 2;
+int const VOCAB_SIZE = 32000;
+int const LOCAL_BATCH_SIZE = 64;
+int const EMBEDDING_SIZE = 1024;
+int const HIDDEN_SIZE = 1024;
+int const NUM_NODES = 2;
+int const WORKERS_PER_NODE = 4;
+int const NUM_WORKERS =
     NUM_NODES * WORKERS_PER_NODE; // NUM_WORKERS <= MAX_NUM_WORKERS
-const int NUM_PARTITIONS =
+int const NUM_PARTITIONS =
     NUM_NODES * WORKERS_PER_NODE; // NUM_PARTITIONS <= MAX_NUM_PARTS
-const int BATCH_SIZE = NUM_PARTITIONS * LOCAL_BATCH_SIZE;
-const float INTRA_NODE_BANDWIDTH = 4 * 1024 * 1024;
-const float CROSS_NODE_BANDWIDTH = 1 * 1024 * 1024;
+int const BATCH_SIZE = NUM_PARTITIONS * LOCAL_BATCH_SIZE;
+float const INTRA_NODE_BANDWIDTH = 4 * 1024 * 1024;
+float const CROSS_NODE_BANDWIDTH = 1 * 1024 * 1024;
 
 using namespace std;
 
@@ -108,7 +108,7 @@ public:
 
   virtual float compute(OpConfig c) = 0;
 
-  virtual float update(const std::vector<OpConfig> &vec) = 0;
+  virtual float update(std::vector<OpConfig> const &vec) = 0;
 
   virtual Rect
   get_tensor_shape(OpConfig c, int idx, Tensor t, bool is_input) = 0;
@@ -195,7 +195,7 @@ public:
     bestCompTime += bestV;
   }
   float compute(OpConfig c);
-  float update(const std::vector<OpConfig> &vec);
+  float update(std::vector<OpConfig> const &vec);
   Rect get_tensor_shape(OpConfig c, int idx, Tensor t, bool is_input);
   OpConfig get_random_config();
 
@@ -217,7 +217,7 @@ float Conv2D::compute(OpConfig c) {
   return computeTime[idx];
 };
 
-float Conv2D::update(const std::vector<OpConfig> &vec) {
+float Conv2D::update(std::vector<OpConfig> const &vec) {
   int used[NUM_WORKERS];
   assert(vec.size() == 1);
   OpConfig config = vec[0];
@@ -335,7 +335,7 @@ public:
     bestCompTime += bestV;
   }
   float compute(OpConfig c);
-  float update(const std::vector<OpConfig> &vec);
+  float update(std::vector<OpConfig> const &vec);
   Rect get_tensor_shape(OpConfig c, int idx, Tensor t, bool is_input);
   OpConfig get_random_config();
 
@@ -357,7 +357,7 @@ float Pool2D::compute(OpConfig c) {
   return computeTime[idx];
 }
 
-float Pool2D::update(const std::vector<OpConfig> &vec) { return 0; }
+float Pool2D::update(std::vector<OpConfig> const &vec) { return 0; }
 
 Rect Pool2D::get_tensor_shape(OpConfig config,
                               int idx,
@@ -412,7 +412,7 @@ public:
       config_x[nConfigs++] = i;
   }
   float compute(OpConfig c);
-  float update(const std::vector<OpConfig> &vec);
+  float update(std::vector<OpConfig> const &vec);
   Rect get_tensor_shape(OpConfig c, int idx, Tensor t, bool is_input);
   OpConfig get_random_config();
 
@@ -422,7 +422,7 @@ private:
 
 float Concat::compute(OpConfig c) { return 0.02 / c.nParts; }
 
-float Concat::update(const std::vector<OpConfig> &vec) { return 0; }
+float Concat::update(std::vector<OpConfig> const &vec) { return 0; }
 
 Rect Concat::get_tensor_shape(OpConfig config,
                               int idx,
@@ -470,7 +470,7 @@ public:
       config_x[nConfigs++] = i;
   }
   float compute(OpConfig c);
-  float update(const std::vector<OpConfig> &vec);
+  float update(std::vector<OpConfig> const &vec);
   Rect get_tensor_shape(OpConfig c, int idx, Tensor t, bool is_input);
   OpConfig get_random_config();
 
@@ -481,7 +481,7 @@ private:
 
 float Flat::compute(OpConfig c) { return 0; }
 
-float Flat::update(const std::vector<OpConfig> &vec) { return 0; }
+float Flat::update(std::vector<OpConfig> const &vec) { return 0; }
 
 Rect Flat::get_tensor_shape(OpConfig config, int idx, Tensor t, bool is_input) {
   assert(config.nDims == 1);
@@ -573,7 +573,7 @@ public:
            bestV);
   }
   float compute(OpConfig c);
-  float update(const std::vector<OpConfig> &vec);
+  float update(std::vector<OpConfig> const &vec);
   Rect get_tensor_shape(OpConfig c, int idx, Tensor t, bool is_input);
   // float xfer(Tensor t, OpConfig config, OpConfig preConfig);
   OpConfig get_random_config();
@@ -595,7 +595,7 @@ float LSTM::compute(OpConfig c) {
   return computeTime[idx];
 };
 
-float LSTM::update(const std::vector<OpConfig> &vec) {
+float LSTM::update(std::vector<OpConfig> const &vec) {
   int used[NUM_WORKERS];
   float xfer = hiddenSize * inputSize * 8 * sizeof(float);
   for (int i = 0; i < NUM_WORKERS; i++)
@@ -705,7 +705,7 @@ public:
   }
 
   float compute(OpConfig c);
-  float update(const std::vector<OpConfig> &c);
+  float update(std::vector<OpConfig> const &c);
   Rect get_tensor_shape(OpConfig c, int idx, Tensor t, bool is_input);
   // float xfer(Tensor t, OpConfig config, OpConfig preConfig);
   OpConfig get_random_config();
@@ -728,7 +728,7 @@ float Softmax::compute(OpConfig c) {
   return computeTime[idx];
 };
 
-float Softmax::update(const std::vector<OpConfig> &vec) {
+float Softmax::update(std::vector<OpConfig> const &vec) {
   int used[NUM_WORKERS][NUM_PARTITIONS];
   for (int i = 0; i < NUM_WORKERS; i++)
     for (int j = 0; j < NUM_PARTITIONS; j++)
@@ -840,7 +840,7 @@ public:
   }
 
   float compute(OpConfig c);
-  float update(const std::vector<OpConfig> &c);
+  float update(std::vector<OpConfig> const &c);
   Rect get_tensor_shape(OpConfig c, int idx, Tensor t, bool is_input);
   // float xfer(Tensor t, OpConfig config, OpConfig, preConfig, int idx);
   OpConfig get_random_config();
@@ -852,7 +852,7 @@ private:
 
 float Embed::compute(OpConfig c) { return 0.04f / c.nParts + 0.01; }
 
-float Embed::update(const std::vector<OpConfig> &vec) {
+float Embed::update(std::vector<OpConfig> const &vec) {
   int used[NUM_WORKERS];
   float xfer = vocabSize * outputSize * sizeof(float);
   for (int i = 0; i < NUM_WORKERS; i++)
@@ -996,7 +996,7 @@ public:
 typedef Task *TaskPtr;
 
 struct TaskCompare {
-  bool operator()(const TaskPtr &lhs, const TaskPtr &rhs) const {
+  bool operator()(TaskPtr const &lhs, TaskPtr const &rhs) const {
     // printf("lhs(%d %.2lf) rhs(%d %.2lf)\n", lhs->guid, lhs->readyTime,
     // rhs->guid, rhs->readyTime);
     if (lhs->readyTime != rhs->readyTime)
@@ -1030,7 +1030,7 @@ inline float bandwidth(int gpu1, int gpu2) {
 
 Task *tasks[MAX_NUM_OPS][NUM_PARTITIONS];
 Task *commTasks[MAX_NUM_OPS * NUM_PARTITIONS * NUM_PARTITIONS];
-float simulate_time(const std::map<Op *, OpConfig> &global,
+float simulate_time(std::map<Op *, OpConfig> const &global,
                     bool print = false) {
   // We need to reset task_global_guid
   task_global_guid = 0;
@@ -1197,7 +1197,7 @@ void generate_init_config(std::map<Op *, OpConfig> &global) {
   }
 }
 
-Op *rewrite(const std::map<Op *, OpConfig> &current,
+Op *rewrite(std::map<Op *, OpConfig> const &current,
             std::map<Op *, OpConfig> &next) {
   next = current;
   int opId = std::rand() % op_global_guid;
@@ -1598,7 +1598,7 @@ void build_nmt_model() {
   assert(idx == op_global_guid);
 }
 
-void print_global_config(const std::map<Op *, OpConfig> &global) {
+void print_global_config(std::map<Op *, OpConfig> const &global) {
   for (int i = 0; i < op_global_guid; i++) {
     OpConfig c = global.find(guidToOp[i])->second;
     printf("op[%d] %s:	dim(", i, guidToOp[i]->name.c_str());

--- a/src/loss_functions/loss_functions.cc
+++ b/src/loss_functions/loss_functions.cc
@@ -19,7 +19,7 @@ namespace FlexFlow {
 
 using namespace Legion;
 
-Loss::Loss(const std::string &loss, bool _repl_labels) {
+Loss::Loss(std::string const &loss, bool _repl_labels) {
   repl_labels = _repl_labels;
   if (loss == "categorical_crossentropy")
     loss_type = LOSS_CATEGORICAL_CROSSENTROPY;
@@ -87,8 +87,8 @@ void Loss::backward(FFModel *model,
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Loss::backward_task(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+void Loss::backward_task(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime) {
   Domain domain = runtime->get_index_space_domain(
@@ -105,13 +105,13 @@ void Loss::backward_task(const Task *task,
 }
 
 template <int NDIM>
-void Loss::backward_task_with_dim(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+void Loss::backward_task_with_dim(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime) {
   assert(regions.size() == 3);
   assert(task->regions.size() == 3);
-  const Loss *loss = (Loss *)task->args;
+  Loss const *loss = (Loss *)task->args;
 
   if (loss->loss_type == LOSS_SPARSE_CATEGORICAL_CROSSENTROPY) {
     // sparse_categorical_crossentropy has label of dim: (batch_size, 1)

--- a/src/loss_functions/loss_functions.cpp
+++ b/src/loss_functions/loss_functions.cpp
@@ -23,10 +23,10 @@ using namespace Legion;
 
 __global__ void
 sparse_categorical_crossentropy_loss_backward(float *logit_grad,
-                                              const int *label,
+                                              int const *label,
                                               coord_t num_samples,
                                               coord_t num_classes,
-                                              const int k) {
+                                              int const k) {
   CUDA_KERNEL_LOOP(i, num_samples) {
     int label_idx = label[i / k];
     logit_grad[i * num_classes + label_idx] -= 1.0f;
@@ -34,23 +34,23 @@ sparse_categorical_crossentropy_loss_backward(float *logit_grad,
 }
 
 __global__ void categorical_crossentropy_loss_backward(float *logit_grad,
-                                                       const float *logit,
-                                                       const float *label,
+                                                       float const *logit,
+                                                       float const *label,
                                                        coord_t num_elements) {
   CUDA_KERNEL_LOOP(i, num_elements) { logit_grad[i] = logit[i] - label[i]; }
 }
 
 __global__ void mean_squared_error_avg_loss_backward(float *logit_grad,
-                                                     const float *logit,
-                                                     const float *label,
+                                                     float const *logit,
+                                                     float const *label,
                                                      coord_t num_elements) {
   CUDA_KERNEL_LOOP(i, num_elements) { logit_grad[i] = logit[i] - label[i]; }
 }
 
 void Loss::sparse_categorical_crossentropy_loss_backward_kernel_wrapper(
     float *logit_grad_ptr,
-    const float *logit_ptr,
-    const int *label_ptr,
+    float const *logit_ptr,
+    int const *label_ptr,
     size_t logit_volume,
     size_t logit_grad_volume,
     int num_samples,
@@ -87,8 +87,8 @@ void Loss::sparse_categorical_crossentropy_loss_backward_kernel_wrapper(
 
 void Loss::categorical_crossentropy_loss_backward_kernel_wrapper(
     float *logit_grad_ptr,
-    const float *logit_ptr,
-    const float *label_ptr,
+    float const *logit_ptr,
+    float const *label_ptr,
     size_t logit_volume,
     size_t logit_grad_volume,
     float scale_factor) {
@@ -117,8 +117,8 @@ void Loss::categorical_crossentropy_loss_backward_kernel_wrapper(
 
 void Loss::mean_squared_error_avg_loss_backward_kernel_wrapper(
     float *logit_grad_ptr,
-    const float *logit_ptr,
-    const float *label_ptr,
+    float const *logit_ptr,
+    float const *label_ptr,
     size_t logit_volume,
     size_t logit_grad_volume,
     float scale_factor) {

--- a/src/loss_functions/loss_functions.cu
+++ b/src/loss_functions/loss_functions.cu
@@ -22,10 +22,10 @@ using namespace Legion;
 
 __global__ void
 sparse_categorical_crossentropy_loss_backward(float *logit_grad,
-                                              const int *label,
+                                              int const *label,
                                               coord_t num_samples,
                                               coord_t num_classes,
-                                              const int k) {
+                                              int const k) {
   CUDA_KERNEL_LOOP(i, num_samples) {
     int label_idx = label[i / k];
     logit_grad[i * num_classes + label_idx] -= 1.0f;
@@ -33,23 +33,23 @@ sparse_categorical_crossentropy_loss_backward(float *logit_grad,
 }
 
 __global__ void categorical_crossentropy_loss_backward(float *logit_grad,
-                                                       const float *logit,
-                                                       const float *label,
+                                                       float const *logit,
+                                                       float const *label,
                                                        coord_t num_elements) {
   CUDA_KERNEL_LOOP(i, num_elements) { logit_grad[i] = logit[i] - label[i]; }
 }
 
 __global__ void mean_squared_error_avg_loss_backward(float *logit_grad,
-                                                     const float *logit,
-                                                     const float *label,
+                                                     float const *logit,
+                                                     float const *label,
                                                      coord_t num_elements) {
   CUDA_KERNEL_LOOP(i, num_elements) { logit_grad[i] = logit[i] - label[i]; }
 }
 
 void Loss::sparse_categorical_crossentropy_loss_backward_kernel_wrapper(
     float *logit_grad_ptr,
-    const float *logit_ptr,
-    const int *label_ptr,
+    float const *logit_ptr,
+    int const *label_ptr,
     size_t logit_volume,
     size_t logit_grad_volume,
     int num_samples,
@@ -74,8 +74,8 @@ void Loss::sparse_categorical_crossentropy_loss_backward_kernel_wrapper(
 
 void Loss::categorical_crossentropy_loss_backward_kernel_wrapper(
     float *logit_grad_ptr,
-    const float *logit_ptr,
-    const float *label_ptr,
+    float const *logit_ptr,
+    float const *label_ptr,
     size_t logit_volume,
     size_t logit_grad_volume,
     float scale_factor) {
@@ -93,8 +93,8 @@ void Loss::categorical_crossentropy_loss_backward_kernel_wrapper(
 
 void Loss::mean_squared_error_avg_loss_backward_kernel_wrapper(
     float *logit_grad_ptr,
-    const float *logit_ptr,
-    const float *label_ptr,
+    float const *logit_ptr,
+    float const *label_ptr,
     size_t logit_volume,
     size_t logit_grad_volume,
     float scale_factor) {

--- a/src/metrics_functions/metrics_functions.cc
+++ b/src/metrics_functions/metrics_functions.cc
@@ -32,7 +32,7 @@ using Legion::Task;
 using Legion::TaskArgument;
 using Legion::TaskLauncher;
 
-Metrics::Metrics(LossType _loss_type, const std::vector<MetricsType> &metrics)
+Metrics::Metrics(LossType _loss_type, std::vector<MetricsType> const &metrics)
     : loss_type(_loss_type), measure_accuracy(false),
       measure_categorical_crossentropy(false),
       measure_sparse_categorical_crossentropy(false),
@@ -107,8 +107,8 @@ void Metrics::compute(FFModel *model,
   model->current_metrics = runtime->execute_task(ctx, metrics_task);
 }
 
-PerfMetrics Metrics::compute_task(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+PerfMetrics Metrics::compute_task(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime) {
   Domain domain = runtime->get_index_space_domain(
@@ -128,13 +128,13 @@ PerfMetrics Metrics::compute_task(const Task *task,
 
 template <int NDIM>
 PerfMetrics
-Metrics::compute_task_with_dim(const Task *task,
-                               const std::vector<PhysicalRegion> &regions,
+Metrics::compute_task_with_dim(Task const *task,
+                               std::vector<PhysicalRegion> const &regions,
                                Context ctx,
                                Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
-  const Metrics *me = (Metrics *)task->args;
+  Metrics const *me = (Metrics *)task->args;
   PerfMetrics perf_zc;
 
   if (me->loss_type == LOSS_SPARSE_CATEGORICAL_CROSSENTROPY) {
@@ -187,7 +187,7 @@ PerfMetrics::PerfMetrics(void)
   start_time = Realm::Clock::current_time_in_microseconds();
 }
 
-void PerfMetrics::update(const PerfMetrics &one) {
+void PerfMetrics::update(PerfMetrics const &one) {
   train_all += one.train_all;
   train_correct += one.train_correct;
   cce_loss += one.cce_loss;
@@ -205,7 +205,7 @@ void PerfMetrics::apply_scale(float scale) {
   mae_loss *= scale;
 }
 
-void PerfMetrics::print(const Metrics *m) {
+void PerfMetrics::print(Metrics const *m) {
   std::string output = "[Metrics]";
   if (train_all == 0) {
     double current_time = Realm::Clock::current_time_in_microseconds();

--- a/src/metrics_functions/metrics_functions.cpp
+++ b/src/metrics_functions/metrics_functions.cpp
@@ -19,10 +19,10 @@
 
 namespace FlexFlow {
 
-const float LOG_MIN_VALUE = 0.00000001f;
+float const LOG_MIN_VALUE = 0.00000001f;
 
-__global__ void update_metrics_sparse_label_kernel(const float *logits,
-                                                   const int *labels,
+__global__ void update_metrics_sparse_label_kernel(float const *logits,
+                                                   int const *labels,
                                                    PerfMetrics *perf,
                                                    const Metrics metrics,
                                                    int num_samples,
@@ -67,8 +67,8 @@ __global__ void update_metrics_sparse_label_kernel(const float *logits,
   }
 }
 
-__global__ void update_metrics_label_kernel(const float *logits,
-                                            const float *labels,
+__global__ void update_metrics_label_kernel(float const *logits,
+                                            float const *labels,
                                             PerfMetrics *perf,
                                             const Metrics metrics,
                                             int num_samples,
@@ -130,9 +130,9 @@ __global__ void update_metrics_label_kernel(const float *logits,
 }
 
 void Metrics::update_metrics_sparse_label_kernel_wrapper(
-    const float *logit_ptr,
-    const int *label_ptr,
-    const Metrics *me,
+    float const *logit_ptr,
+    int const *label_ptr,
+    Metrics const *me,
     int num_effective_samples,
     int num_classes,
     PerfMetrics &perf_zc) {
@@ -160,9 +160,9 @@ void Metrics::update_metrics_sparse_label_kernel_wrapper(
   checkCUDA(hipFree(perf));
 }
 
-void Metrics::update_metrics_label_kernel_wrapper(const float *logit_ptr,
-                                                  const float *label_ptr,
-                                                  const Metrics *me,
+void Metrics::update_metrics_label_kernel_wrapper(float const *logit_ptr,
+                                                  float const *label_ptr,
+                                                  Metrics const *me,
                                                   int num_samples,
                                                   int num_classes,
                                                   PerfMetrics &perf_zc) {

--- a/src/metrics_functions/metrics_functions.cu
+++ b/src/metrics_functions/metrics_functions.cu
@@ -18,10 +18,10 @@
 
 namespace FlexFlow {
 
-const float LOG_MIN_VALUE = 0.00000001f;
+float const LOG_MIN_VALUE = 0.00000001f;
 
-__global__ void update_metrics_sparse_label_kernel(const float *logits,
-                                                   const int *labels,
+__global__ void update_metrics_sparse_label_kernel(float const *logits,
+                                                   int const *labels,
                                                    PerfMetrics *perf,
                                                    const Metrics metrics,
                                                    int num_samples,
@@ -66,8 +66,8 @@ __global__ void update_metrics_sparse_label_kernel(const float *logits,
   }
 }
 
-__global__ void update_metrics_label_kernel(const float *logits,
-                                            const float *labels,
+__global__ void update_metrics_label_kernel(float const *logits,
+                                            float const *labels,
                                             PerfMetrics *perf,
                                             const Metrics metrics,
                                             int num_samples,
@@ -129,9 +129,9 @@ __global__ void update_metrics_label_kernel(const float *logits,
 }
 
 void Metrics::update_metrics_sparse_label_kernel_wrapper(
-    const float *logit_ptr,
-    const int *label_ptr,
-    const Metrics *me,
+    float const *logit_ptr,
+    int const *label_ptr,
+    Metrics const *me,
     int num_effective_samples,
     int num_classes,
     PerfMetrics &perf_zc) {
@@ -153,9 +153,9 @@ void Metrics::update_metrics_sparse_label_kernel_wrapper(
   checkCUDA(cudaFree(perf));
 }
 
-void Metrics::update_metrics_label_kernel_wrapper(const float *logit_ptr,
-                                                  const float *label_ptr,
-                                                  const Metrics *me,
+void Metrics::update_metrics_label_kernel_wrapper(float const *logit_ptr,
+                                                  float const *label_ptr,
+                                                  Metrics const *me,
                                                   int num_samples,
                                                   int num_classes,
                                                   PerfMetrics &perf_zc) {

--- a/src/ops/aggregate.cpp
+++ b/src/ops/aggregate.cpp
@@ -20,13 +20,13 @@
 namespace FlexFlow {
 
 __global__ void agg_forward_kernel(float **exp_preds,
-                                   const int *exp_assign,
-                                   const float *gate_net_preds,
+                                   int const *exp_assign,
+                                   float const *gate_net_preds,
                                    float *output,
                                    int n,
-                                   const int k,     // num chosen experts
+                                   int const k,     // num chosen experts
                                    int exp_samples, // max samples per expert
-                                   const int batch_size,
+                                   int const batch_size,
                                    int out_dim) {
   __shared__ float
       *chosen_exp_preds[AGGREGATE_MAX_K * AGGREGATE_MAX_BATCH_SIZE];
@@ -66,11 +66,11 @@ __global__ void agg_forward_kernel(float **exp_preds,
   }
 }
 
-__device__ void agg_backward_kernel_gate(const float *output_grad,
+__device__ void agg_backward_kernel_gate(float const *output_grad,
                                          float *full_gate_grads,
                                          float **exp_preds,
-                                         const int *expert_assign,
-                                         const bool *cache_corr,
+                                         int const *expert_assign,
+                                         bool const *cache_corr,
                                          int *expert_bal,
                                          float lambda_bal,
                                          int batch_size,
@@ -107,8 +107,8 @@ __device__ void agg_backward_kernel_gate(const float *output_grad,
   }
 }
 
-__device__ void agg_backward_kernel_exp(const float *output_grad,
-                                        const float *gate_preds,
+__device__ void agg_backward_kernel_exp(float const *output_grad,
+                                        float const *gate_preds,
                                         float **exp_grads,
                                         int batch_size,
                                         int k,
@@ -125,11 +125,11 @@ __device__ void agg_backward_kernel_exp(const float *output_grad,
 
 __global__ void agg_backward_kernel(float **exp_preds,
                                     float **exp_grads,
-                                    const int *exp_assign,
-                                    const int *true_exp_assign,
-                                    const float *gating_net_preds,
+                                    int const *exp_assign,
+                                    int const *true_exp_assign,
+                                    float const *gating_net_preds,
                                     float *full_gating_grads,
-                                    const float *output_grads,
+                                    float const *output_grads,
                                     int n,           // num experts
                                     int k,           // num chosen experts
                                     int exp_samples, // max samples per expert
@@ -195,15 +195,15 @@ __global__ void agg_backward_kernel(float **exp_preds,
 }
 
 /*static*/
-void Aggregate::forward_kernel_wrapper(const AggregateMeta *m,
+void Aggregate::forward_kernel_wrapper(AggregateMeta const *m,
                                        float **exp_preds,
-                                       const int *acc_gate_assign_ptr,
-                                       const float *acc_gate_pred_ptr,
+                                       int const *acc_gate_assign_ptr,
+                                       float const *acc_gate_pred_ptr,
                                        float *acc_output_ptr,
                                        int n,
-                                       const int k,
+                                       int const k,
                                        int rows,
-                                       const int batch_size,
+                                       int const batch_size,
                                        int out_dim) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -231,19 +231,19 @@ void Aggregate::forward_kernel_wrapper(const AggregateMeta *m,
 }
 
 /*static*/
-void Aggregate::backward_kernel_wrapper(const AggregateMeta *m,
+void Aggregate::backward_kernel_wrapper(AggregateMeta const *m,
                                         float **exp_preds,
                                         float **exp_grads,
-                                        const int *acc_gate_assign_ptr,
-                                        const int *acc_true_gate_assign_ptr,
-                                        const float *acc_gate_pred_ptr,
+                                        int const *acc_gate_assign_ptr,
+                                        int const *acc_true_gate_assign_ptr,
+                                        float const *acc_gate_pred_ptr,
                                         float *full_acc_gate_grad_ptr,
-                                        const float *acc_output_grad_ptr,
+                                        float const *acc_output_grad_ptr,
                                         int n,
-                                        const int k,
+                                        int const k,
                                         int rows,
                                         float lambda_bal,
-                                        const int batch_size,
+                                        int const batch_size,
                                         int out_dim) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));

--- a/src/ops/aggregate.cu
+++ b/src/ops/aggregate.cu
@@ -19,13 +19,13 @@
 namespace FlexFlow {
 
 __global__ void agg_forward_kernel(float **exp_preds,
-                                   const int *exp_assign,
-                                   const float *gate_net_preds,
+                                   int const *exp_assign,
+                                   float const *gate_net_preds,
                                    float *output,
                                    int n,
-                                   const int k,     // num chosen experts
+                                   int const k,     // num chosen experts
                                    int exp_samples, // max samples per expert
-                                   const int batch_size,
+                                   int const batch_size,
                                    int out_dim) {
   __shared__ float
       *chosen_exp_preds[AGGREGATE_MAX_K * AGGREGATE_MAX_BATCH_SIZE];
@@ -65,11 +65,11 @@ __global__ void agg_forward_kernel(float **exp_preds,
   }
 }
 
-__device__ void agg_backward_kernel_gate(const float *output_grad,
+__device__ void agg_backward_kernel_gate(float const *output_grad,
                                          float *full_gate_grads,
                                          float **exp_preds,
-                                         const int *expert_assign,
-                                         const bool *cache_corr,
+                                         int const *expert_assign,
+                                         bool const *cache_corr,
                                          int *expert_bal,
                                          float lambda_bal,
                                          int batch_size,
@@ -106,8 +106,8 @@ __device__ void agg_backward_kernel_gate(const float *output_grad,
   }
 }
 
-__device__ void agg_backward_kernel_exp(const float *output_grad,
-                                        const float *gate_preds,
+__device__ void agg_backward_kernel_exp(float const *output_grad,
+                                        float const *gate_preds,
                                         float **exp_grads,
                                         int batch_size,
                                         int k,
@@ -124,11 +124,11 @@ __device__ void agg_backward_kernel_exp(const float *output_grad,
 
 __global__ void agg_backward_kernel(float **exp_preds,
                                     float **exp_grads,
-                                    const int *exp_assign,
-                                    const int *true_exp_assign,
-                                    const float *gating_net_preds,
+                                    int const *exp_assign,
+                                    int const *true_exp_assign,
+                                    float const *gating_net_preds,
                                     float *full_gating_grads,
-                                    const float *output_grads,
+                                    float const *output_grads,
                                     int n,           // num experts
                                     int k,           // num chosen experts
                                     int exp_samples, // max samples per expert
@@ -194,15 +194,15 @@ __global__ void agg_backward_kernel(float **exp_preds,
 }
 
 /*static*/
-void Aggregate::forward_kernel_wrapper(const AggregateMeta *m,
+void Aggregate::forward_kernel_wrapper(AggregateMeta const *m,
                                        float **exp_preds,
-                                       const int *acc_gate_assign_ptr,
-                                       const float *acc_gate_pred_ptr,
+                                       int const *acc_gate_assign_ptr,
+                                       float const *acc_gate_pred_ptr,
                                        float *acc_output_ptr,
                                        int n,
-                                       const int k,
+                                       int const k,
                                        int rows,
-                                       const int batch_size,
+                                       int const batch_size,
                                        int out_dim) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -228,19 +228,19 @@ void Aggregate::forward_kernel_wrapper(const AggregateMeta *m,
 }
 
 /*static*/
-void Aggregate::backward_kernel_wrapper(const AggregateMeta *m,
+void Aggregate::backward_kernel_wrapper(AggregateMeta const *m,
                                         float **exp_preds,
                                         float **exp_grads,
-                                        const int *acc_gate_assign_ptr,
-                                        const int *acc_true_gate_assign_ptr,
-                                        const float *acc_gate_pred_ptr,
+                                        int const *acc_gate_assign_ptr,
+                                        int const *acc_true_gate_assign_ptr,
+                                        float const *acc_gate_pred_ptr,
                                         float *full_acc_gate_grad_ptr,
-                                        const float *acc_output_grad_ptr,
+                                        float const *acc_output_grad_ptr,
                                         int n,
-                                        const int k,
+                                        int const k,
                                         int rows,
                                         float lambda_bal,
-                                        const int batch_size,
+                                        int const batch_size,
                                         int out_dim) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));

--- a/src/ops/aggregate_spec.cpp
+++ b/src/ops/aggregate_spec.cpp
@@ -21,12 +21,12 @@ namespace FlexFlow {
 
 __global__ void
 aggspec_forward_kernel(float **exp_preds,
-                       const int *exp_assign,
+                       int const *exp_assign,
                        float *output,
                        int n,           // num experts
-                       const int k,     // num chosen experts
+                       int const k,     // num chosen experts
                        int exp_samples, // max samples per expert
-                       const int batch_size,
+                       int const batch_size,
                        int out_dim) {
   __shared__ float
       *chosen_exp_preds[AGGREGATE_SPEC_MAX_K * AGGREGATE_SPEC_MAX_BATCH_SIZE];
@@ -62,11 +62,11 @@ aggspec_forward_kernel(float **exp_preds,
   }
 }
 
-__device__ void aggspec_backward_kernel_gate(const float *output_grad,
+__device__ void aggspec_backward_kernel_gate(float const *output_grad,
                                              float *full_gate_grads,
-                                             const int *expert_assign,
-                                             const bool *cache_corr,
-                                             const float *gate_pred,
+                                             int const *expert_assign,
+                                             bool const *cache_corr,
+                                             float const *gate_pred,
                                              int *expert_bal,
                                              float lambda_bal,
                                              int batch_size,
@@ -124,8 +124,8 @@ __device__ void aggspec_backward_kernel_gate(const float *output_grad,
   }
 }
 
-__device__ void aggspec_backward_kernel_exp(const float *output_grad,
-                                            const float *gate_preds,
+__device__ void aggspec_backward_kernel_exp(float const *output_grad,
+                                            float const *gate_preds,
                                             float **exp_grads,
                                             int batch_size,
                                             int k,
@@ -141,11 +141,11 @@ __device__ void aggspec_backward_kernel_exp(const float *output_grad,
 
 __global__ void
 aggspec_backward_kernel(float **exp_grads,
-                        const int *exp_assign,
-                        const int *true_exp_assign,
-                        const float *gating_net_preds,
+                        int const *exp_assign,
+                        int const *true_exp_assign,
+                        float const *gating_net_preds,
                         float *full_gating_grads,
-                        const float *output_grads,
+                        float const *output_grads,
                         int n,           // num experts
                         int k,           // num chosen experts
                         int exp_samples, // max samples per expert
@@ -206,14 +206,14 @@ aggspec_backward_kernel(float **exp_grads,
 }
 
 /*static*/
-void AggregateSpec::forward_kernel_wrapper(const AggregateSpecMeta *m,
+void AggregateSpec::forward_kernel_wrapper(AggregateSpecMeta const *m,
                                            float **exp_preds,
-                                           const int *acc_gate_assign_ptr,
+                                           int const *acc_gate_assign_ptr,
                                            float *acc_output_ptr,
                                            int n,
-                                           const int k,
+                                           int const k,
                                            int rows,
-                                           const int batch_size,
+                                           int const batch_size,
                                            int out_dim) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -242,18 +242,18 @@ void AggregateSpec::forward_kernel_wrapper(const AggregateSpecMeta *m,
 }
 
 /*static*/
-void AggregateSpec::backward_kernel_wrapper(const AggregateSpecMeta *m,
+void AggregateSpec::backward_kernel_wrapper(AggregateSpecMeta const *m,
                                             float **exp_grads,
-                                            const int *acc_gate_assign_ptr,
-                                            const int *acc_true_gate_assign_ptr,
-                                            const float *acc_gate_pred_ptr,
+                                            int const *acc_gate_assign_ptr,
+                                            int const *acc_true_gate_assign_ptr,
+                                            float const *acc_gate_pred_ptr,
                                             float *acc_full_gate_grad_ptr,
-                                            const float *acc_output_grad_ptr,
+                                            float const *acc_output_grad_ptr,
                                             int n,
-                                            const int k,
+                                            int const k,
                                             int rows,
                                             float lambda_bal,
-                                            const int batch_size,
+                                            int const batch_size,
                                             int out_dim) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));

--- a/src/ops/aggregate_spec.cu
+++ b/src/ops/aggregate_spec.cu
@@ -20,12 +20,12 @@ namespace FlexFlow {
 
 __global__ void
 aggspec_forward_kernel(float **exp_preds,
-                       const int *exp_assign,
+                       int const *exp_assign,
                        float *output,
                        int n,           // num experts
-                       const int k,     // num chosen experts
+                       int const k,     // num chosen experts
                        int exp_samples, // max samples per expert
-                       const int batch_size,
+                       int const batch_size,
                        int out_dim) {
   __shared__ float
       *chosen_exp_preds[AGGREGATE_SPEC_MAX_K * AGGREGATE_SPEC_MAX_BATCH_SIZE];
@@ -61,11 +61,11 @@ aggspec_forward_kernel(float **exp_preds,
   }
 }
 
-__device__ void aggspec_backward_kernel_gate(const float *output_grad,
+__device__ void aggspec_backward_kernel_gate(float const *output_grad,
                                              float *full_gate_grads,
-                                             const int *expert_assign,
-                                             const bool *cache_corr,
-                                             const float *gate_pred,
+                                             int const *expert_assign,
+                                             bool const *cache_corr,
+                                             float const *gate_pred,
                                              int *expert_bal,
                                              float lambda_bal,
                                              int batch_size,
@@ -123,8 +123,8 @@ __device__ void aggspec_backward_kernel_gate(const float *output_grad,
   }
 }
 
-__device__ void aggspec_backward_kernel_exp(const float *output_grad,
-                                            const float *gate_preds,
+__device__ void aggspec_backward_kernel_exp(float const *output_grad,
+                                            float const *gate_preds,
                                             float **exp_grads,
                                             int batch_size,
                                             int k,
@@ -140,11 +140,11 @@ __device__ void aggspec_backward_kernel_exp(const float *output_grad,
 
 __global__ void
 aggspec_backward_kernel(float **exp_grads,
-                        const int *exp_assign,
-                        const int *true_exp_assign,
-                        const float *gating_net_preds,
+                        int const *exp_assign,
+                        int const *true_exp_assign,
+                        float const *gating_net_preds,
                         float *full_gating_grads,
-                        const float *output_grads,
+                        float const *output_grads,
                         int n,           // num experts
                         int k,           // num chosen experts
                         int exp_samples, // max samples per expert
@@ -205,14 +205,14 @@ aggspec_backward_kernel(float **exp_grads,
 }
 
 /*static*/
-void AggregateSpec::forward_kernel_wrapper(const AggregateSpecMeta *m,
+void AggregateSpec::forward_kernel_wrapper(AggregateSpecMeta const *m,
                                            float **exp_preds,
-                                           const int *acc_gate_assign_ptr,
+                                           int const *acc_gate_assign_ptr,
                                            float *acc_output_ptr,
                                            int n,
-                                           const int k,
+                                           int const k,
                                            int rows,
-                                           const int batch_size,
+                                           int const batch_size,
                                            int out_dim) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -240,18 +240,18 @@ void AggregateSpec::forward_kernel_wrapper(const AggregateSpecMeta *m,
 }
 
 /*static*/
-void AggregateSpec::backward_kernel_wrapper(const AggregateSpecMeta *m,
+void AggregateSpec::backward_kernel_wrapper(AggregateSpecMeta const *m,
                                             float **exp_grads,
-                                            const int *acc_gate_assign_ptr,
-                                            const int *acc_true_gate_assign_ptr,
-                                            const float *acc_gate_pred_ptr,
+                                            int const *acc_gate_assign_ptr,
+                                            int const *acc_true_gate_assign_ptr,
+                                            float const *acc_gate_pred_ptr,
                                             float *acc_full_gate_grad_ptr,
-                                            const float *acc_output_grad_ptr,
+                                            float const *acc_output_grad_ptr,
                                             int n,
-                                            const int k,
+                                            int const k,
                                             int rows,
                                             float lambda_bal,
-                                            const int batch_size,
+                                            int const batch_size,
                                             int out_dim) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));

--- a/src/ops/attention.cpp
+++ b/src/ops/attention.cpp
@@ -24,11 +24,11 @@ using Legion::coord_t;
 using Legion::Memory;
 
 /*static*/
-void MultiHeadAttention::forward_kernel(const MultiHeadAttentionMeta *m,
-                                        const float *query_ptr,
-                                        const float *key_ptr,
-                                        const float *value_ptr,
-                                        const float *weight_ptr,
+void MultiHeadAttention::forward_kernel(MultiHeadAttentionMeta const *m,
+                                        float const *query_ptr,
+                                        float const *key_ptr,
+                                        float const *value_ptr,
+                                        float const *weight_ptr,
                                         float *output_ptr,
                                         hipStream_t stream) {
 #if 0
@@ -45,11 +45,11 @@ void MultiHeadAttention::forward_kernel(const MultiHeadAttentionMeta *m,
 }
 
 /*static*/
-void MultiHeadAttention::forward_kernel_wrapper(const MultiHeadAttentionMeta *m,
-                                                const float *query_ptr,
-                                                const float *key_ptr,
-                                                const float *value_ptr,
-                                                const float *weight_ptr,
+void MultiHeadAttention::forward_kernel_wrapper(MultiHeadAttentionMeta const *m,
+                                                float const *query_ptr,
+                                                float const *key_ptr,
+                                                float const *value_ptr,
+                                                float const *weight_ptr,
                                                 float *output_ptr) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -77,16 +77,16 @@ void MultiHeadAttention::forward_kernel_wrapper(const MultiHeadAttentionMeta *m,
 }
 
 /*static*/
-void MultiHeadAttention::backward_kernel(const MultiHeadAttentionMeta *m,
-                                         const float *query_ptr,
+void MultiHeadAttention::backward_kernel(MultiHeadAttentionMeta const *m,
+                                         float const *query_ptr,
                                          float *query_grad_ptr,
-                                         const float *key_ptr,
+                                         float const *key_ptr,
                                          float *key_grad_ptr,
-                                         const float *value_ptr,
+                                         float const *value_ptr,
                                          float *value_grad_ptr,
-                                         const float *weight_ptr,
+                                         float const *weight_ptr,
                                          float *weight_grad_ptr,
-                                         const float *output_grad_ptr,
+                                         float const *output_grad_ptr,
                                          hipStream_t stream) {
   checkCUDNN(miopenSetStream(m->handle.dnn, stream));
 
@@ -109,16 +109,16 @@ void MultiHeadAttention::backward_kernel(const MultiHeadAttentionMeta *m,
 
 /*static*/
 void MultiHeadAttention::backward_kernel_wrapper(
-    const MultiHeadAttentionMeta *m,
-    const float *query_ptr,
+    MultiHeadAttentionMeta const *m,
+    float const *query_ptr,
     float *query_grad_ptr,
-    const float *key_ptr,
+    float const *key_ptr,
     float *key_grad_ptr,
-    const float *value_ptr,
+    float const *value_ptr,
     float *value_grad_ptr,
-    const float *weight_ptr,
+    float const *weight_ptr,
     float *weight_grad_ptr,
-    const float *output_grad_ptr) {
+    float const *output_grad_ptr) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
 
@@ -152,7 +152,7 @@ void MultiHeadAttention::backward_kernel_wrapper(
 }
 
 MultiHeadAttentionMeta::MultiHeadAttentionMeta(FFHandler handler,
-                                               const MultiHeadAttention *attn,
+                                               MultiHeadAttention const *attn,
                                                Memory gpu_mem,
                                                int num_samples,
                                                int num_heads)

--- a/src/ops/attention.cu
+++ b/src/ops/attention.cu
@@ -23,11 +23,11 @@ using Legion::coord_t;
 using Legion::Memory;
 
 /*static*/
-void MultiHeadAttention::forward_kernel(const MultiHeadAttentionMeta *m,
-                                        const float *query_ptr,
-                                        const float *key_ptr,
-                                        const float *value_ptr,
-                                        const float *weight_ptr,
+void MultiHeadAttention::forward_kernel(MultiHeadAttentionMeta const *m,
+                                        float const *query_ptr,
+                                        float const *key_ptr,
+                                        float const *value_ptr,
+                                        float const *weight_ptr,
                                         float *output_ptr,
                                         cudaStream_t stream) {
   checkCUDNN(cudnnSetStream(m->handle.dnn, stream));
@@ -57,11 +57,11 @@ void MultiHeadAttention::forward_kernel(const MultiHeadAttentionMeta *m,
 }
 
 /*static*/
-void MultiHeadAttention::forward_kernel_wrapper(const MultiHeadAttentionMeta *m,
-                                                const float *query_ptr,
-                                                const float *key_ptr,
-                                                const float *value_ptr,
-                                                const float *weight_ptr,
+void MultiHeadAttention::forward_kernel_wrapper(MultiHeadAttentionMeta const *m,
+                                                float const *query_ptr,
+                                                float const *key_ptr,
+                                                float const *value_ptr,
+                                                float const *weight_ptr,
                                                 float *output_ptr) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -89,16 +89,16 @@ void MultiHeadAttention::forward_kernel_wrapper(const MultiHeadAttentionMeta *m,
 }
 
 /*static*/
-void MultiHeadAttention::backward_kernel(const MultiHeadAttentionMeta *m,
-                                         const float *query_ptr,
+void MultiHeadAttention::backward_kernel(MultiHeadAttentionMeta const *m,
+                                         float const *query_ptr,
                                          float *query_grad_ptr,
-                                         const float *key_ptr,
+                                         float const *key_ptr,
                                          float *key_grad_ptr,
-                                         const float *value_ptr,
+                                         float const *value_ptr,
                                          float *value_grad_ptr,
-                                         const float *weight_ptr,
+                                         float const *weight_ptr,
                                          float *weight_grad_ptr,
-                                         const float *output_grad_ptr,
+                                         float const *output_grad_ptr,
                                          cudaStream_t stream) {
   checkCUDNN(cudnnSetStream(m->handle.dnn, stream));
 
@@ -147,16 +147,16 @@ void MultiHeadAttention::backward_kernel(const MultiHeadAttentionMeta *m,
 
 /*static*/
 void MultiHeadAttention::backward_kernel_wrapper(
-    const MultiHeadAttentionMeta *m,
-    const float *query_ptr,
+    MultiHeadAttentionMeta const *m,
+    float const *query_ptr,
     float *query_grad_ptr,
-    const float *key_ptr,
+    float const *key_ptr,
     float *key_grad_ptr,
-    const float *value_ptr,
+    float const *value_ptr,
     float *value_grad_ptr,
-    const float *weight_ptr,
+    float const *weight_ptr,
     float *weight_grad_ptr,
-    const float *output_grad_ptr) {
+    float const *output_grad_ptr) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
 
@@ -190,7 +190,7 @@ void MultiHeadAttention::backward_kernel_wrapper(
 }
 
 MultiHeadAttentionMeta::MultiHeadAttentionMeta(FFHandler handler,
-                                               const MultiHeadAttention *attn,
+                                               MultiHeadAttention const *attn,
                                                Memory gpu_mem,
                                                int num_samples,
                                                int num_heads)

--- a/src/ops/batch_matmul.cpp
+++ b/src/ops/batch_matmul.cpp
@@ -25,11 +25,11 @@ B: (batch, k, m)
 O: (batch, n, m)
 O = A * B
 */
-void BatchMatmul::forward_kernel(const BatchMatmulMeta *meta,
+void BatchMatmul::forward_kernel(BatchMatmulMeta const *meta,
                                  float *o_ptr,
-                                 const float *a_ptr,
-                                 const float *b_ptr,
-                                 const float *c_ptr,
+                                 float const *a_ptr,
+                                 float const *b_ptr,
+                                 float const *c_ptr,
                                  int m,
                                  int n,
                                  int k,
@@ -96,11 +96,11 @@ void BatchMatmul::forward_kernel(const BatchMatmulMeta *meta,
 }
 
 /*static*/
-void BatchMatmul::forward_kernel_wrapper(const BatchMatmulMeta *meta,
+void BatchMatmul::forward_kernel_wrapper(BatchMatmulMeta const *meta,
                                          float *o_ptr,
-                                         const float *a_ptr,
-                                         const float *b_ptr,
-                                         const float *c_ptr,
+                                         float const *a_ptr,
+                                         float const *b_ptr,
+                                         float const *c_ptr,
                                          int m,
                                          int n,
                                          int k,
@@ -148,12 +148,12 @@ O, OGrad: (batch, n, m)
 AGrad = OGrad * B^T
 BGrad = A^T * OGrad
 */
-void BatchMatmul::backward_kernel(const BatchMatmulMeta *meta,
-                                  const float *o_ptr,
-                                  const float *o_grad_ptr,
-                                  const float *a_ptr,
+void BatchMatmul::backward_kernel(BatchMatmulMeta const *meta,
+                                  float const *o_ptr,
+                                  float const *o_grad_ptr,
+                                  float const *a_ptr,
                                   float *a_grad_ptr,
-                                  const float *b_ptr,
+                                  float const *b_ptr,
                                   float *b_grad_ptr,
                                   float *c_grad_ptr,
                                   int m,
@@ -208,12 +208,12 @@ void BatchMatmul::backward_kernel(const BatchMatmulMeta *meta,
 }
 
 /*static*/
-void BatchMatmul::backward_kernel_wrapper(const BatchMatmulMeta *meta,
-                                          const float *o_ptr,
-                                          const float *o_grad_ptr,
-                                          const float *a_ptr,
+void BatchMatmul::backward_kernel_wrapper(BatchMatmulMeta const *meta,
+                                          float const *o_ptr,
+                                          float const *o_grad_ptr,
+                                          float const *a_ptr,
                                           float *a_grad_ptr,
-                                          const float *b_ptr,
+                                          float const *b_ptr,
                                           float *b_grad_ptr,
                                           float *c_grad_ptr,
                                           int m,

--- a/src/ops/batch_matmul.cu
+++ b/src/ops/batch_matmul.cu
@@ -24,11 +24,11 @@ B: (batch, k, m)
 O: (batch, n, m)
 O = A * B
 */
-void BatchMatmul::forward_kernel(const BatchMatmulMeta *meta,
+void BatchMatmul::forward_kernel(BatchMatmulMeta const *meta,
                                  float *o_ptr,
-                                 const float *a_ptr,
-                                 const float *b_ptr,
-                                 const float *c_ptr,
+                                 float const *a_ptr,
+                                 float const *b_ptr,
+                                 float const *c_ptr,
                                  int m,
                                  int n,
                                  int k,
@@ -95,11 +95,11 @@ void BatchMatmul::forward_kernel(const BatchMatmulMeta *meta,
 }
 
 /*static*/
-void BatchMatmul::forward_kernel_wrapper(const BatchMatmulMeta *meta,
+void BatchMatmul::forward_kernel_wrapper(BatchMatmulMeta const *meta,
                                          float *o_ptr,
-                                         const float *a_ptr,
-                                         const float *b_ptr,
-                                         const float *c_ptr,
+                                         float const *a_ptr,
+                                         float const *b_ptr,
+                                         float const *c_ptr,
                                          int m,
                                          int n,
                                          int k,
@@ -147,12 +147,12 @@ O, OGrad: (batch, n, m)
 AGrad = OGrad * B^T
 BGrad = A^T * OGrad
 */
-void BatchMatmul::backward_kernel(const BatchMatmulMeta *meta,
-                                  const float *o_ptr,
-                                  const float *o_grad_ptr,
-                                  const float *a_ptr,
+void BatchMatmul::backward_kernel(BatchMatmulMeta const *meta,
+                                  float const *o_ptr,
+                                  float const *o_grad_ptr,
+                                  float const *a_ptr,
                                   float *a_grad_ptr,
-                                  const float *b_ptr,
+                                  float const *b_ptr,
                                   float *b_grad_ptr,
                                   float *c_grad_ptr,
                                   int m,
@@ -207,12 +207,12 @@ void BatchMatmul::backward_kernel(const BatchMatmulMeta *meta,
 }
 
 /*static*/
-void BatchMatmul::backward_kernel_wrapper(const BatchMatmulMeta *meta,
-                                          const float *o_ptr,
-                                          const float *o_grad_ptr,
-                                          const float *a_ptr,
+void BatchMatmul::backward_kernel_wrapper(BatchMatmulMeta const *meta,
+                                          float const *o_ptr,
+                                          float const *o_grad_ptr,
+                                          float const *a_ptr,
                                           float *a_grad_ptr,
-                                          const float *b_ptr,
+                                          float const *b_ptr,
                                           float *b_grad_ptr,
                                           float *c_grad_ptr,
                                           int m,

--- a/src/ops/batch_norm.cc
+++ b/src/ops/batch_norm.cc
@@ -30,7 +30,7 @@ using Legion::Runtime;
 using Legion::TaskArgument;
 using Legion::TaskLauncher;
 
-Tensor FFModel::batch_norm(const Tensor input, bool relu, const char *name) {
+Tensor FFModel::batch_norm(const Tensor input, bool relu, char const *name) {
   assert(input->num_dims == 4); /*NCHW*/
   Layer *bm = new Layer(this,
                         OP_BATCHNORM,
@@ -56,7 +56,7 @@ BatchNorm::BatchNorm(FFModel &model,
                      const ParallelTensor _scale,
                      const ParallelTensor _bias,
                      bool _relu,
-                     const char *name)
+                     char const *name)
     : Op(model,
          OP_BATCHNORM,
          name,
@@ -77,7 +77,7 @@ BatchNorm::BatchNorm(FFModel &model,
   return;
 }
 
-void BatchNorm::init(const FFModel &ff) {
+void BatchNorm::init(FFModel const &ff) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
@@ -121,7 +121,7 @@ void BatchNorm::init(const FFModel &ff) {
   set_opmeta_from_futuremap(ff, fm);
 }
 
-void BatchNorm::forward(const FFModel &ff) {
+void BatchNorm::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -162,7 +162,7 @@ void BatchNorm::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void BatchNorm::backward(const FFModel &ff) {
+void BatchNorm::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -228,7 +228,7 @@ void BatchNorm::backward(const FFModel &ff) {
 }
 
 bool BatchNorm::measure_operator_cost(Simulator *sim,
-                                      const MachineView &mv,
+                                      MachineView const &mv,
                                       CostMetrics &cost_metrics) const {
   ParallelTensorBase sub_input, sub_output;
   if (!outputs[0]->get_sub_tensor(mv, sub_output)) {

--- a/src/ops/batch_norm.cpp
+++ b/src/ops/batch_norm.cpp
@@ -39,14 +39,14 @@ using Legion::Task;
   regions[3](I): bias
 */
 __host__ OpMeta *
-BatchNorm::init_task(const Task *task,
-                     const std::vector<PhysicalRegion> &regions,
+BatchNorm::init_task(Task const *task,
+                     std::vector<PhysicalRegion> const &regions,
                      Context ctx,
                      Runtime *runtime) {
   assert(regions.size() == 4);
   assert(task->regions.size() == 4);
-  const BatchNorm *bm = (BatchNorm *)task->args;
-  FFHandler handle = *((const FFHandler *)task->local_args);
+  BatchNorm const *bm = (BatchNorm *)task->args;
+  FFHandler handle = *((FFHandler const *)task->local_args);
   TensorAccessorR<float, 4> acc_input(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   TensorAccessorW<float, 4> acc_output(
@@ -76,15 +76,15 @@ BatchNorm::init_task(const Task *task,
   regions[1](O): bias, initilized to zeros
 */
 __host__ void
-BatchNorm::init_para_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+BatchNorm::init_para_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
   // const BatchNorm* bm = (BatchNorm*) task->args;
-  const AccessorWO<float, 1> acc_scale(regions[0], FID_DATA);
-  const AccessorWO<float, 1> acc_bias(regions[1], FID_DATA);
+  AccessorWO<float, 1> const acc_scale(regions[0], FID_DATA);
+  AccessorWO<float, 1> const acc_bias(regions[1], FID_DATA);
   Rect<1> rect_scale, rect_bias;
   rect_scale = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
@@ -182,8 +182,8 @@ void BatchNorm::forward_kernel(BatchNormMeta *m,
   regions[3](I): bias
 */
 __host__ void
-BatchNorm::forward_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+BatchNorm::forward_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {
   assert(regions.size() == 4);
@@ -282,8 +282,8 @@ void BatchNorm::backward_kernel(BatchNormMeta *m,
   regions[6](I/O): bias_grad
 */
 __host__ void
-BatchNorm::backward_task(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+BatchNorm::backward_task(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime) {
   assert(regions.size() == 7);
@@ -352,7 +352,7 @@ BatchNorm::backward_task(const Task *task,
 }
 
 BatchNormMeta::BatchNormMeta(FFHandler handler,
-                             const BatchNorm *bn,
+                             BatchNorm const *bn,
                              Memory gpu_mem,
                              int output_n,
                              int output_c,

--- a/src/ops/batch_norm.cu
+++ b/src/ops/batch_norm.cu
@@ -36,14 +36,14 @@ using Legion::Task;
   regions[3](I): bias
 */
 __host__ OpMeta *
-BatchNorm::init_task(const Task *task,
-                     const std::vector<PhysicalRegion> &regions,
+BatchNorm::init_task(Task const *task,
+                     std::vector<PhysicalRegion> const &regions,
                      Context ctx,
                      Runtime *runtime) {
   assert(regions.size() == 4);
   assert(task->regions.size() == 4);
-  const BatchNorm *bm = (BatchNorm *)task->args;
-  FFHandler handle = *((const FFHandler *)task->local_args);
+  BatchNorm const *bm = (BatchNorm *)task->args;
+  FFHandler handle = *((FFHandler const *)task->local_args);
   TensorAccessorR<float, 4> acc_input(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   TensorAccessorW<float, 4> acc_output(
@@ -73,15 +73,15 @@ BatchNorm::init_task(const Task *task,
   regions[1](O): bias, initilized to zeros
 */
 __host__ void
-BatchNorm::init_para_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+BatchNorm::init_para_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
   // const BatchNorm* bm = (BatchNorm*) task->args;
-  const AccessorWO<float, 1> acc_scale(regions[0], FID_DATA);
-  const AccessorWO<float, 1> acc_bias(regions[1], FID_DATA);
+  AccessorWO<float, 1> const acc_scale(regions[0], FID_DATA);
+  AccessorWO<float, 1> const acc_bias(regions[1], FID_DATA);
   Rect<1> rect_scale, rect_bias;
   rect_scale = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
@@ -158,8 +158,8 @@ void BatchNorm::forward_kernel(BatchNormMeta *m,
   regions[3](I): bias
 */
 __host__ void
-BatchNorm::forward_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+BatchNorm::forward_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {
   assert(regions.size() == 4);
@@ -250,8 +250,8 @@ void BatchNorm::backward_kernel(BatchNormMeta *m,
   regions[6](I/O): bias_grad
 */
 __host__ void
-BatchNorm::backward_task(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+BatchNorm::backward_task(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime) {
   assert(regions.size() == 7);
@@ -320,7 +320,7 @@ BatchNorm::backward_task(const Task *task,
 }
 
 BatchNormMeta::BatchNormMeta(FFHandler handler,
-                             const BatchNorm *bn,
+                             BatchNorm const *bn,
                              Memory gpu_mem,
                              int output_n,
                              int output_c,

--- a/src/ops/cache.cpp
+++ b/src/ops/cache.cpp
@@ -26,12 +26,12 @@ using Legion::Runtime;
 using Legion::Task;
 
 template <typename T>
-void Cache::cache_forward(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+void Cache::cache_forward(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   Cache *c = ((Arg *)(task->args))->cache;
-  const CacheMeta *m = *((CacheMeta **)task->local_args);
+  CacheMeta const *m = *((CacheMeta **)task->local_args);
   int batch_ctr = ((Arg *)(task->args))->batch_ctr;
   T **batch_ptrs = (T **)c->batch_ptrs;
   T *output_ptr = helperGetTensorPointerWO<T>(
@@ -50,8 +50,8 @@ void Cache::cache_forward(const Task *task,
 }
 
 template <typename T>
-float Cache::cache_update(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+float Cache::cache_update(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   Cache *c = ((Arg *)(task->args))->cache;
@@ -78,24 +78,24 @@ float Cache::cache_update(const Task *task,
 CacheMeta::CacheMeta(FFHandler handler) : OpMeta(handler) {}
 
 template void
-Cache::cache_forward<float>(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+Cache::cache_forward<float>(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime);
 template void
-Cache::cache_forward<int32_t>(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+Cache::cache_forward<int32_t>(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime);
 
 template float
-Cache::cache_update<float>(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+Cache::cache_update<float>(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 template float
-Cache::cache_update<int32_t>(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+Cache::cache_update<int32_t>(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              Runtime *runtime);
 

--- a/src/ops/cache.cu
+++ b/src/ops/cache.cu
@@ -25,12 +25,12 @@ using Legion::Runtime;
 using Legion::Task;
 
 template <typename T>
-void Cache::cache_forward(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+void Cache::cache_forward(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   Cache *c = ((Arg *)(task->args))->cache;
-  const CacheMeta *m = *((CacheMeta **)task->local_args);
+  CacheMeta const *m = *((CacheMeta **)task->local_args);
   int batch_ctr = ((Arg *)(task->args))->batch_ctr;
   T **batch_ptrs = (T **)c->batch_ptrs;
   T *output_ptr = helperGetTensorPointerWO<T>(
@@ -49,8 +49,8 @@ void Cache::cache_forward(const Task *task,
 }
 
 template <typename T>
-float Cache::cache_update(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+float Cache::cache_update(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   Cache *c = ((Arg *)(task->args))->cache;
@@ -77,24 +77,24 @@ float Cache::cache_update(const Task *task,
 CacheMeta::CacheMeta(FFHandler handler) : OpMeta(handler) {}
 
 template void
-Cache::cache_forward<float>(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+Cache::cache_forward<float>(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime);
 template void
-Cache::cache_forward<int32_t>(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+Cache::cache_forward<int32_t>(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime);
 
 template float
-Cache::cache_update<float>(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+Cache::cache_update<float>(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime);
 template float
-Cache::cache_update<int32_t>(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+Cache::cache_update<int32_t>(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              Runtime *runtime);
 

--- a/src/ops/cast.cpp
+++ b/src/ops/cast.cpp
@@ -85,79 +85,79 @@ void Cast::backward_kernel_wrapper(const IDT *src_ptr,
 
 CastMeta::CastMeta(FFHandler handle) : OpMeta(handle) {}
 
-template void Cast::forward_kernel_wrapper<float, float>(const float *input_ptr,
+template void Cast::forward_kernel_wrapper<float, float>(float const *input_ptr,
                                                          float *output_ptr,
                                                          size_t volume);
 template void Cast::forward_kernel_wrapper<float, double>(
-    const float *input_ptr, double *output_ptr, size_t volume);
+    float const *input_ptr, double *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<float, int32_t>(
-    const float *input_ptr, int32_t *output_ptr, size_t volume);
+    float const *input_ptr, int32_t *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<float, int64_t>(
-    const float *input_ptr, int64_t *output_ptr, size_t volume);
+    float const *input_ptr, int64_t *output_ptr, size_t volume);
 
 template void Cast::forward_kernel_wrapper<double, float>(
-    const double *input_ptr, float *output_ptr, size_t volume);
+    double const *input_ptr, float *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<double, double>(
-    const double *input_ptr, double *output_ptr, size_t volume);
+    double const *input_ptr, double *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<double, int32_t>(
-    const double *input_ptr, int32_t *output_ptr, size_t volume);
+    double const *input_ptr, int32_t *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<double, int64_t>(
-    const double *input_ptr, int64_t *output_ptr, size_t volume);
+    double const *input_ptr, int64_t *output_ptr, size_t volume);
 
 template void Cast::forward_kernel_wrapper<int32_t, float>(
-    const int32_t *input_ptr, float *output_ptr, size_t volume);
+    int32_t const *input_ptr, float *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int32_t, double>(
-    const int32_t *input_ptr, double *output_ptr, size_t volume);
+    int32_t const *input_ptr, double *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int32_t, int32_t>(
-    const int32_t *input_ptr, int32_t *output_ptr, size_t volume);
+    int32_t const *input_ptr, int32_t *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int32_t, int64_t>(
-    const int32_t *input_ptr, int64_t *output_ptr, size_t volume);
+    int32_t const *input_ptr, int64_t *output_ptr, size_t volume);
 
 template void Cast::forward_kernel_wrapper<int64_t, float>(
-    const int64_t *input_ptr, float *output_ptr, size_t volume);
+    int64_t const *input_ptr, float *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int64_t, double>(
-    const int64_t *input_ptr, double *output_ptr, size_t volume);
+    int64_t const *input_ptr, double *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int64_t, int32_t>(
-    const int64_t *input_ptr, int32_t *output_ptr, size_t volume);
+    int64_t const *input_ptr, int32_t *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int64_t, int64_t>(
-    const int64_t *input_ptr, int64_t *output_ptr, size_t volume);
+    int64_t const *input_ptr, int64_t *output_ptr, size_t volume);
 
-template void Cast::backward_kernel_wrapper<float, float>(const float *src_ptr,
+template void Cast::backward_kernel_wrapper<float, float>(float const *src_ptr,
                                                           float *dst_ptr,
                                                           size_t volume);
-template void Cast::backward_kernel_wrapper<float, double>(const float *src_ptr,
+template void Cast::backward_kernel_wrapper<float, double>(float const *src_ptr,
                                                            double *dst_ptr,
                                                            size_t volume);
 template void Cast::backward_kernel_wrapper<float, int32_t>(
-    const float *src_ptr, int32_t *dst_ptr, size_t volume);
+    float const *src_ptr, int32_t *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<float, int64_t>(
-    const float *src_ptr, int64_t *dst_ptr, size_t volume);
+    float const *src_ptr, int64_t *dst_ptr, size_t volume);
 
 template void Cast::backward_kernel_wrapper<double, float>(
-    const double *src_ptr, float *dst_ptr, size_t volume);
+    double const *src_ptr, float *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<double, double>(
-    const double *src_ptr, double *dst_ptr, size_t volume);
+    double const *src_ptr, double *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<double, int32_t>(
-    const double *src_ptr, int32_t *dst_ptr, size_t volume);
+    double const *src_ptr, int32_t *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<double, int64_t>(
-    const double *src_ptr, int64_t *dst_ptr, size_t volume);
+    double const *src_ptr, int64_t *dst_ptr, size_t volume);
 
 template void Cast::backward_kernel_wrapper<int32_t, float>(
-    const int32_t *src_ptr, float *dst_ptr, size_t volume);
+    int32_t const *src_ptr, float *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int32_t, double>(
-    const int32_t *src_ptr, double *dst_ptr, size_t volume);
+    int32_t const *src_ptr, double *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int32_t, int32_t>(
-    const int32_t *src_ptr, int32_t *dst_ptr, size_t volume);
+    int32_t const *src_ptr, int32_t *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int32_t, int64_t>(
-    const int32_t *src_ptr, int64_t *dst_ptr, size_t volume);
+    int32_t const *src_ptr, int64_t *dst_ptr, size_t volume);
 
 template void Cast::backward_kernel_wrapper<int64_t, float>(
-    const int64_t *src_ptr, float *dst_ptr, size_t volume);
+    int64_t const *src_ptr, float *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int64_t, double>(
-    const int64_t *src_ptr, double *dst_ptr, size_t volume);
+    int64_t const *src_ptr, double *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int64_t, int32_t>(
-    const int64_t *src_ptr, int32_t *dst_ptr, size_t volume);
+    int64_t const *src_ptr, int32_t *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int64_t, int64_t>(
-    const int64_t *src_ptr, int64_t *dst_ptr, size_t volume);
+    int64_t const *src_ptr, int64_t *dst_ptr, size_t volume);
 
 }; // namespace FlexFlow

--- a/src/ops/cast.cu
+++ b/src/ops/cast.cu
@@ -71,79 +71,79 @@ void Cast::backward_kernel_wrapper(const IDT *src_ptr,
 
 CastMeta::CastMeta(FFHandler handle) : OpMeta(handle) {}
 
-template void Cast::forward_kernel_wrapper<float, float>(const float *input_ptr,
+template void Cast::forward_kernel_wrapper<float, float>(float const *input_ptr,
                                                          float *output_ptr,
                                                          size_t volume);
 template void Cast::forward_kernel_wrapper<float, double>(
-    const float *input_ptr, double *output_ptr, size_t volume);
+    float const *input_ptr, double *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<float, int32_t>(
-    const float *input_ptr, int32_t *output_ptr, size_t volume);
+    float const *input_ptr, int32_t *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<float, int64_t>(
-    const float *input_ptr, int64_t *output_ptr, size_t volume);
+    float const *input_ptr, int64_t *output_ptr, size_t volume);
 
 template void Cast::forward_kernel_wrapper<double, float>(
-    const double *input_ptr, float *output_ptr, size_t volume);
+    double const *input_ptr, float *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<double, double>(
-    const double *input_ptr, double *output_ptr, size_t volume);
+    double const *input_ptr, double *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<double, int32_t>(
-    const double *input_ptr, int32_t *output_ptr, size_t volume);
+    double const *input_ptr, int32_t *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<double, int64_t>(
-    const double *input_ptr, int64_t *output_ptr, size_t volume);
+    double const *input_ptr, int64_t *output_ptr, size_t volume);
 
 template void Cast::forward_kernel_wrapper<int32_t, float>(
-    const int32_t *input_ptr, float *output_ptr, size_t volume);
+    int32_t const *input_ptr, float *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int32_t, double>(
-    const int32_t *input_ptr, double *output_ptr, size_t volume);
+    int32_t const *input_ptr, double *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int32_t, int32_t>(
-    const int32_t *input_ptr, int32_t *output_ptr, size_t volume);
+    int32_t const *input_ptr, int32_t *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int32_t, int64_t>(
-    const int32_t *input_ptr, int64_t *output_ptr, size_t volume);
+    int32_t const *input_ptr, int64_t *output_ptr, size_t volume);
 
 template void Cast::forward_kernel_wrapper<int64_t, float>(
-    const int64_t *input_ptr, float *output_ptr, size_t volume);
+    int64_t const *input_ptr, float *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int64_t, double>(
-    const int64_t *input_ptr, double *output_ptr, size_t volume);
+    int64_t const *input_ptr, double *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int64_t, int32_t>(
-    const int64_t *input_ptr, int32_t *output_ptr, size_t volume);
+    int64_t const *input_ptr, int32_t *output_ptr, size_t volume);
 template void Cast::forward_kernel_wrapper<int64_t, int64_t>(
-    const int64_t *input_ptr, int64_t *output_ptr, size_t volume);
+    int64_t const *input_ptr, int64_t *output_ptr, size_t volume);
 
-template void Cast::backward_kernel_wrapper<float, float>(const float *src_ptr,
+template void Cast::backward_kernel_wrapper<float, float>(float const *src_ptr,
                                                           float *dst_ptr,
                                                           size_t volume);
-template void Cast::backward_kernel_wrapper<float, double>(const float *src_ptr,
+template void Cast::backward_kernel_wrapper<float, double>(float const *src_ptr,
                                                            double *dst_ptr,
                                                            size_t volume);
 template void Cast::backward_kernel_wrapper<float, int32_t>(
-    const float *src_ptr, int32_t *dst_ptr, size_t volume);
+    float const *src_ptr, int32_t *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<float, int64_t>(
-    const float *src_ptr, int64_t *dst_ptr, size_t volume);
+    float const *src_ptr, int64_t *dst_ptr, size_t volume);
 
 template void Cast::backward_kernel_wrapper<double, float>(
-    const double *src_ptr, float *dst_ptr, size_t volume);
+    double const *src_ptr, float *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<double, double>(
-    const double *src_ptr, double *dst_ptr, size_t volume);
+    double const *src_ptr, double *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<double, int32_t>(
-    const double *src_ptr, int32_t *dst_ptr, size_t volume);
+    double const *src_ptr, int32_t *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<double, int64_t>(
-    const double *src_ptr, int64_t *dst_ptr, size_t volume);
+    double const *src_ptr, int64_t *dst_ptr, size_t volume);
 
 template void Cast::backward_kernel_wrapper<int32_t, float>(
-    const int32_t *src_ptr, float *dst_ptr, size_t volume);
+    int32_t const *src_ptr, float *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int32_t, double>(
-    const int32_t *src_ptr, double *dst_ptr, size_t volume);
+    int32_t const *src_ptr, double *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int32_t, int32_t>(
-    const int32_t *src_ptr, int32_t *dst_ptr, size_t volume);
+    int32_t const *src_ptr, int32_t *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int32_t, int64_t>(
-    const int32_t *src_ptr, int64_t *dst_ptr, size_t volume);
+    int32_t const *src_ptr, int64_t *dst_ptr, size_t volume);
 
 template void Cast::backward_kernel_wrapper<int64_t, float>(
-    const int64_t *src_ptr, float *dst_ptr, size_t volume);
+    int64_t const *src_ptr, float *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int64_t, double>(
-    const int64_t *src_ptr, double *dst_ptr, size_t volume);
+    int64_t const *src_ptr, double *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int64_t, int32_t>(
-    const int64_t *src_ptr, int32_t *dst_ptr, size_t volume);
+    int64_t const *src_ptr, int32_t *dst_ptr, size_t volume);
 template void Cast::backward_kernel_wrapper<int64_t, int64_t>(
-    const int64_t *src_ptr, int64_t *dst_ptr, size_t volume);
+    int64_t const *src_ptr, int64_t *dst_ptr, size_t volume);
 
 }; // namespace FlexFlow

--- a/src/ops/concat.cpp
+++ b/src/ops/concat.cpp
@@ -45,8 +45,8 @@ void Concat::forward_kernel(float *output,
                             float const *const *inputs,
                             int num_inputs,
                             int axis,
-                            const Domain &out_domain,
-                            const Domain *in_domain,
+                            Domain const &out_domain,
+                            Domain const *in_domain,
                             hipStream_t stream) {
   coord_t num_blocks = 1, output_blk_size = 1, input_blk_sizes[MAX_NUM_INPUTS];
   assert(num_inputs <= MAX_NUM_INPUTS);
@@ -89,13 +89,13 @@ void Concat::forward_kernel(float *output,
 }
 
 /*static*/
-void Concat::forward_kernel_wrapper(const ConcatMeta *m,
+void Concat::forward_kernel_wrapper(ConcatMeta const *m,
                                     float *output,
                                     float const *const *inputs,
                                     int num_inputs,
                                     int axis,
-                                    const Domain &out_domain,
-                                    const Domain *in_domain) {
+                                    Domain const &out_domain,
+                                    Domain const *in_domain) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
 
@@ -124,12 +124,12 @@ void Concat::forward_kernel_wrapper(const ConcatMeta *m,
 }
 
 /*static*/
-void Concat::backward_kernel(const float *output_grad,
+void Concat::backward_kernel(float const *output_grad,
                              float **input_grads,
                              int num_inputs,
                              int axis,
-                             const Domain &out_grad_domain,
-                             const Domain *in_grad_domain,
+                             Domain const &out_grad_domain,
+                             Domain const *in_grad_domain,
                              hipStream_t stream) {
   coord_t num_blocks = 1, output_blk_size = 1, input_blk_sizes[MAX_NUM_INPUTS];
   assert(num_inputs <= MAX_NUM_INPUTS);
@@ -175,13 +175,13 @@ void Concat::backward_kernel(const float *output_grad,
 }
 
 /*static*/
-void Concat::backward_kernel_wrapper(const ConcatMeta *m,
-                                     const float *output_grad,
+void Concat::backward_kernel_wrapper(ConcatMeta const *m,
+                                     float const *output_grad,
                                      float **input_grads,
                                      int num_inputs,
                                      int axis,
-                                     const Domain &out_grad_domain,
-                                     const Domain *in_grad_domain) {
+                                     Domain const &out_grad_domain,
+                                     Domain const *in_grad_domain) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
 

--- a/src/ops/concat.cu
+++ b/src/ops/concat.cu
@@ -44,8 +44,8 @@ void Concat::forward_kernel(float *output,
                             float const *const *inputs,
                             int num_inputs,
                             int axis,
-                            const Domain &out_domain,
-                            const Domain *in_domain,
+                            Domain const &out_domain,
+                            Domain const *in_domain,
                             cudaStream_t stream) {
   coord_t num_blocks = 1, output_blk_size = 1, input_blk_sizes[MAX_NUM_INPUTS];
   assert(num_inputs <= MAX_NUM_INPUTS);
@@ -83,13 +83,13 @@ void Concat::forward_kernel(float *output,
 }
 
 /*static*/
-void Concat::forward_kernel_wrapper(const ConcatMeta *m,
+void Concat::forward_kernel_wrapper(ConcatMeta const *m,
                                     float *output,
                                     float const *const *inputs,
                                     int num_inputs,
                                     int axis,
-                                    const Domain &out_domain,
-                                    const Domain *in_domain) {
+                                    Domain const &out_domain,
+                                    Domain const *in_domain) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
 
@@ -118,12 +118,12 @@ void Concat::forward_kernel_wrapper(const ConcatMeta *m,
 }
 
 /*static*/
-void Concat::backward_kernel(const float *output_grad,
+void Concat::backward_kernel(float const *output_grad,
                              float **input_grads,
                              int num_inputs,
                              int axis,
-                             const Domain &out_grad_domain,
-                             const Domain *in_grad_domain,
+                             Domain const &out_grad_domain,
+                             Domain const *in_grad_domain,
                              cudaStream_t stream) {
   coord_t num_blocks = 1, output_blk_size = 1, input_blk_sizes[MAX_NUM_INPUTS];
   assert(num_inputs <= MAX_NUM_INPUTS);
@@ -167,13 +167,13 @@ void Concat::backward_kernel(const float *output_grad,
 }
 
 /*static*/
-void Concat::backward_kernel_wrapper(const ConcatMeta *m,
-                                     const float *output_grad,
+void Concat::backward_kernel_wrapper(ConcatMeta const *m,
+                                     float const *output_grad,
                                      float **input_grads,
                                      int num_inputs,
                                      int axis,
-                                     const Domain &out_grad_domain,
-                                     const Domain *in_grad_domain) {
+                                     Domain const &out_grad_domain,
+                                     Domain const *in_grad_domain) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
 

--- a/src/ops/conv_2d.cpp
+++ b/src/ops/conv_2d.cpp
@@ -22,9 +22,9 @@ namespace FlexFlow {
 miopenConvFwdAlgorithm_t
 selectConvolutionForwardAlgorithm(miopenHandle_t handle,
                                   const miopenTensorDescriptor_t xDesc,
-                                  const void *x,
+                                  void const *x,
                                   const miopenTensorDescriptor_t wDesc,
-                                  const void *w,
+                                  void const *w,
                                   const miopenConvolutionDescriptor_t convDesc,
                                   void *workSpace,
                                   size_t workSpaceSize,
@@ -33,9 +33,9 @@ selectConvolutionForwardAlgorithm(miopenHandle_t handle,
 miopenConvBwdWeightsAlgorithm_t selectConvolutionBackwardFilterAlgorithm(
     miopenHandle_t handle,
     const miopenTensorDescriptor_t xDesc,
-    const void *x,
+    void const *x,
     const miopenTensorDescriptor_t dyDesc,
-    const void *dy,
+    void const *dy,
     const miopenConvolutionDescriptor_t convDesc,
     void *workSpace,
     size_t workSpaceSize,
@@ -44,9 +44,9 @@ miopenConvBwdWeightsAlgorithm_t selectConvolutionBackwardFilterAlgorithm(
 miopenConvBwdDataAlgorithm_t selectConvolutionBackwardDataAlgorithm(
     miopenHandle_t handle,
     const miopenTensorDescriptor_t wDesc,
-    const void *w,
+    void const *w,
     const miopenTensorDescriptor_t dyDesc,
-    const void *dy,
+    void const *dy,
     const miopenConvolutionDescriptor_t convDesc,
     void *workSpace,
     size_t workSpaceSize,
@@ -54,7 +54,7 @@ miopenConvBwdDataAlgorithm_t selectConvolutionBackwardDataAlgorithm(
     void *dx);
 
 /*static*/
-void Conv2D::init_kernel(const Conv2D *conv,
+void Conv2D::init_kernel(Conv2D const *conv,
                          Conv2DMeta *m,
                          int input_w,
                          int input_h,
@@ -66,9 +66,9 @@ void Conv2D::init_kernel(const Conv2D *conv,
                          int output_n,
                          int pad_h,
                          int pad_w,
-                         const float *input_ptr,
+                         float const *input_ptr,
                          float *output_ptr,
-                         const float *kernel_ptr,
+                         float const *kernel_ptr,
                          float *kernel_grad_ptr) {
   checkCUDNN(miopenSet4dTensorDescriptor(
       m->inputTensor, miopenFloat, input_n, input_c, input_h, input_w));
@@ -163,11 +163,11 @@ void Conv2D::init_kernel(const Conv2D *conv,
 }
 
 /*static*/
-void Conv2D::forward_kernel(const Conv2DMeta *m,
-                            const float *input_ptr,
+void Conv2D::forward_kernel(Conv2DMeta const *m,
+                            float const *input_ptr,
                             float *output_ptr,
-                            const float *filter_ptr,
-                            const float *bias_ptr,
+                            float const *filter_ptr,
+                            float const *bias_ptr,
                             hipStream_t stream) {
 
   checkCUDNN(miopenSetStream(m->handle.dnn, stream));
@@ -210,11 +210,11 @@ void Conv2D::forward_kernel(const Conv2DMeta *m,
 }
 
 /*static*/
-void Conv2D::forward_kernel_wrapper(const Conv2DMeta *m,
-                                    const float *input_ptr,
+void Conv2D::forward_kernel_wrapper(Conv2DMeta const *m,
+                                    float const *input_ptr,
                                     float *output_ptr,
-                                    const float *filter_ptr,
-                                    const float *bias_ptr) {
+                                    float const *filter_ptr,
+                                    float const *bias_ptr) {
   // printf("fwdAlgo(%d), bwdFilterALgo(%d), bwdDataAlgo(%d)\n",
   // (int)m->fwdAlgo,(int) m->bwdFilterAlgo,(int) m->bwdDataAlgo);
   hipStream_t stream;
@@ -245,12 +245,12 @@ void Conv2D::forward_kernel_wrapper(const Conv2DMeta *m,
 }
 
 /*static*/
-void Conv2D::backward_kernel(const Conv2DMeta *m,
-                             const float *input_ptr,
+void Conv2D::backward_kernel(Conv2DMeta const *m,
+                             float const *input_ptr,
                              float *input_grad_ptr,
-                             const float *output_ptr,
+                             float const *output_ptr,
                              float *output_grad_ptr,
-                             const float *kernel_ptr,
+                             float const *kernel_ptr,
                              float *kernel_grad_ptr,
                              float *bias_grad_ptr,
                              hipStream_t stream) {
@@ -327,12 +327,12 @@ void Conv2D::backward_kernel(const Conv2DMeta *m,
 }
 
 /*static*/
-void Conv2D::backward_kernel_wrapper(const Conv2DMeta *m,
-                                     const float *input_ptr,
+void Conv2D::backward_kernel_wrapper(Conv2DMeta const *m,
+                                     float const *input_ptr,
                                      float *input_grad_ptr,
-                                     const float *output_ptr,
+                                     float const *output_ptr,
                                      float *output_grad_ptr,
-                                     const float *kernel_ptr,
+                                     float const *kernel_ptr,
                                      float *kernel_grad_ptr,
                                      float *bias_grad_ptr) {
   hipStream_t stream;
@@ -376,15 +376,15 @@ void Conv2D::backward_kernel_wrapper(const Conv2DMeta *m,
 miopenConvFwdAlgorithm_t
 selectConvolutionForwardAlgorithm(miopenHandle_t handle,
                                   const miopenTensorDescriptor_t xDesc,
-                                  const void *x,
+                                  void const *x,
                                   const miopenTensorDescriptor_t wDesc,
-                                  const void *w,
+                                  void const *w,
                                   const miopenConvolutionDescriptor_t convDesc,
                                   void *workSpace,
                                   size_t workSpaceSize,
                                   const miopenTensorDescriptor_t yDesc,
                                   void *y) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   miopenConvAlgoPerf_t perfResults[reqAlgCnt];
   checkCUDNN(miopenFindConvolutionForwardAlgorithm(handle,
@@ -412,15 +412,15 @@ selectConvolutionForwardAlgorithm(miopenHandle_t handle,
 miopenConvBwdWeightsAlgorithm_t selectConvolutionBackwardFilterAlgorithm(
     miopenHandle_t handle,
     const miopenTensorDescriptor_t xDesc,
-    const void *x,
+    void const *x,
     const miopenTensorDescriptor_t dyDesc,
-    const void *dy,
+    void const *dy,
     const miopenConvolutionDescriptor_t convDesc,
     void *workSpace,
     size_t workSpaceSize,
     const miopenTensorDescriptor_t dwDesc,
     void *dw) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   miopenConvAlgoPerf_t perfResults[reqAlgCnt];
   checkCUDNN(miopenFindConvolutionBackwardWeightsAlgorithm(handle,
@@ -448,15 +448,15 @@ miopenConvBwdWeightsAlgorithm_t selectConvolutionBackwardFilterAlgorithm(
 miopenConvBwdDataAlgorithm_t selectConvolutionBackwardDataAlgorithm(
     miopenHandle_t handle,
     const miopenTensorDescriptor_t wDesc,
-    const void *w,
+    void const *w,
     const miopenTensorDescriptor_t dyDesc,
-    const void *dy,
+    void const *dy,
     const miopenConvolutionDescriptor_t convDesc,
     void *workSpace,
     size_t workSpaceSize,
     const miopenTensorDescriptor_t dxDesc,
     void *dx) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   miopenConvAlgoPerf_t perfResults[reqAlgCnt];
   checkCUDNN(miopenFindConvolutionBackwardDataAlgorithm(handle,
@@ -491,7 +491,7 @@ Conv2DMeta::Conv2DMeta(FFHandler handler) : OpMeta(handler) {
 }
 
 bool Conv2D::measure_operator_cost(Simulator *sim,
-                                   const MachineView &pc,
+                                   MachineView const &pc,
                                    CostMetrics &cost_metrics) const {
 #if 0
   ParallelTensorBase sub_output, sub_input;

--- a/src/ops/conv_2d.cu
+++ b/src/ops/conv_2d.cu
@@ -22,9 +22,9 @@ namespace FlexFlow {
 cudnnConvolutionFwdAlgo_t
 selectConvolutionForwardAlgorithm(cudnnHandle_t handle,
                                   const cudnnTensorDescriptor_t xDesc,
-                                  const void *x,
+                                  void const *x,
                                   const cudnnFilterDescriptor_t wDesc,
-                                  const void *w,
+                                  void const *w,
                                   const cudnnConvolutionDescriptor_t convDesc,
                                   void *workSpace,
                                   size_t workSpaceSize,
@@ -33,9 +33,9 @@ selectConvolutionForwardAlgorithm(cudnnHandle_t handle,
 cudnnConvolutionBwdFilterAlgo_t selectConvolutionBackwardFilterAlgorithm(
     cudnnHandle_t handle,
     const cudnnTensorDescriptor_t xDesc,
-    const void *x,
+    void const *x,
     const cudnnTensorDescriptor_t dyDesc,
-    const void *dy,
+    void const *dy,
     const cudnnConvolutionDescriptor_t convDesc,
     void *workSpace,
     size_t workSpaceSize,
@@ -44,9 +44,9 @@ cudnnConvolutionBwdFilterAlgo_t selectConvolutionBackwardFilterAlgorithm(
 cudnnConvolutionBwdDataAlgo_t selectConvolutionBackwardDataAlgorithm(
     cudnnHandle_t handle,
     const cudnnFilterDescriptor_t wDesc,
-    const void *w,
+    void const *w,
     const cudnnTensorDescriptor_t dyDesc,
-    const void *dy,
+    void const *dy,
     const cudnnConvolutionDescriptor_t convDesc,
     void *workSpace,
     size_t workSpaceSize,
@@ -54,7 +54,7 @@ cudnnConvolutionBwdDataAlgo_t selectConvolutionBackwardDataAlgorithm(
     void *dx);
 
 /*static*/
-void Conv2D::init_kernel(const Conv2D *conv,
+void Conv2D::init_kernel(Conv2D const *conv,
                          Conv2DMeta *m,
                          int input_w,
                          int input_h,
@@ -66,9 +66,9 @@ void Conv2D::init_kernel(const Conv2D *conv,
                          int output_n,
                          int pad_h,
                          int pad_w,
-                         const float *input_ptr,
+                         float const *input_ptr,
                          float *output_ptr,
-                         const float *kernel_ptr,
+                         float const *kernel_ptr,
                          float *kernel_grad_ptr) {
   checkCUDNN(cudnnSetTensor4dDescriptor(m->inputTensor,
                                         CUDNN_TENSOR_NCHW,
@@ -169,11 +169,11 @@ void Conv2D::init_kernel(const Conv2D *conv,
 }
 
 /*static*/
-void Conv2D::forward_kernel(const Conv2DMeta *m,
-                            const float *input_ptr,
+void Conv2D::forward_kernel(Conv2DMeta const *m,
+                            float const *input_ptr,
                             float *output_ptr,
-                            const float *filter_ptr,
-                            const float *bias_ptr,
+                            float const *filter_ptr,
+                            float const *bias_ptr,
                             cudaStream_t stream) {
   checkCUDNN(cudnnSetStream(m->handle.dnn, stream));
 
@@ -215,11 +215,11 @@ void Conv2D::forward_kernel(const Conv2DMeta *m,
 }
 
 /*static*/
-void Conv2D::forward_kernel_wrapper(const Conv2DMeta *m,
-                                    const float *input_ptr,
+void Conv2D::forward_kernel_wrapper(Conv2DMeta const *m,
+                                    float const *input_ptr,
                                     float *output_ptr,
-                                    const float *filter_ptr,
-                                    const float *bias_ptr) {
+                                    float const *filter_ptr,
+                                    float const *bias_ptr) {
   // printf("fwdAlgo(%d), bwdFilterALgo(%d), bwdDataAlgo(%d)\n",
   // (int)m->fwdAlgo,(int) m->bwdFilterAlgo,(int) m->bwdDataAlgo);
   cudaStream_t stream;
@@ -250,12 +250,12 @@ void Conv2D::forward_kernel_wrapper(const Conv2DMeta *m,
 }
 
 /*static*/
-void Conv2D::backward_kernel(const Conv2DMeta *m,
-                             const float *input_ptr,
+void Conv2D::backward_kernel(Conv2DMeta const *m,
+                             float const *input_ptr,
                              float *input_grad_ptr,
-                             const float *output_ptr,
+                             float const *output_ptr,
                              float *output_grad_ptr,
-                             const float *kernel_ptr,
+                             float const *kernel_ptr,
                              float *kernel_grad_ptr,
                              float *bias_grad_ptr,
                              cudaStream_t stream) {
@@ -325,12 +325,12 @@ void Conv2D::backward_kernel(const Conv2DMeta *m,
 }
 
 /*static*/
-void Conv2D::backward_kernel_wrapper(const Conv2DMeta *m,
-                                     const float *input_ptr,
+void Conv2D::backward_kernel_wrapper(Conv2DMeta const *m,
+                                     float const *input_ptr,
                                      float *input_grad_ptr,
-                                     const float *output_ptr,
+                                     float const *output_ptr,
                                      float *output_grad_ptr,
-                                     const float *kernel_ptr,
+                                     float const *kernel_ptr,
                                      float *kernel_grad_ptr,
                                      float *bias_grad_ptr) {
   cudaStream_t stream;
@@ -374,15 +374,15 @@ void Conv2D::backward_kernel_wrapper(const Conv2DMeta *m,
 cudnnConvolutionFwdAlgo_t
 selectConvolutionForwardAlgorithm(cudnnHandle_t handle,
                                   const cudnnTensorDescriptor_t xDesc,
-                                  const void *x,
+                                  void const *x,
                                   const cudnnFilterDescriptor_t wDesc,
-                                  const void *w,
+                                  void const *w,
                                   const cudnnConvolutionDescriptor_t convDesc,
                                   void *workSpace,
                                   size_t workSpaceSize,
                                   const cudnnTensorDescriptor_t yDesc,
                                   void *y) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   cudnnConvolutionFwdAlgoPerf_t perfResults[reqAlgCnt];
   checkCUDNN(cudnnFindConvolutionForwardAlgorithmEx(handle,
@@ -409,15 +409,15 @@ selectConvolutionForwardAlgorithm(cudnnHandle_t handle,
 cudnnConvolutionBwdFilterAlgo_t selectConvolutionBackwardFilterAlgorithm(
     cudnnHandle_t handle,
     const cudnnTensorDescriptor_t xDesc,
-    const void *x,
+    void const *x,
     const cudnnTensorDescriptor_t dyDesc,
-    const void *dy,
+    void const *dy,
     const cudnnConvolutionDescriptor_t convDesc,
     void *workSpace,
     size_t workSpaceSize,
     const cudnnFilterDescriptor_t dwDesc,
     void *dw) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   cudnnConvolutionBwdFilterAlgoPerf_t perfResults[reqAlgCnt];
   checkCUDNN(cudnnFindConvolutionBackwardFilterAlgorithmEx(handle,
@@ -444,15 +444,15 @@ cudnnConvolutionBwdFilterAlgo_t selectConvolutionBackwardFilterAlgorithm(
 cudnnConvolutionBwdDataAlgo_t selectConvolutionBackwardDataAlgorithm(
     cudnnHandle_t handle,
     const cudnnFilterDescriptor_t wDesc,
-    const void *w,
+    void const *w,
     const cudnnTensorDescriptor_t dyDesc,
-    const void *dy,
+    void const *dy,
     const cudnnConvolutionDescriptor_t convDesc,
     void *workSpace,
     size_t workSpaceSize,
     const cudnnTensorDescriptor_t dxDesc,
     void *dx) {
-  const int reqAlgCnt = 8;
+  int const reqAlgCnt = 8;
   int cnt = 0;
   cudnnConvolutionBwdDataAlgoPerf_t perfResults[reqAlgCnt];
   checkCUDNN(cudnnFindConvolutionBackwardDataAlgorithmEx(handle,
@@ -487,7 +487,7 @@ Conv2DMeta::Conv2DMeta(FFHandler handler) : OpMeta(handler) {
 
 // TODO: refactor it
 bool Conv2D::measure_operator_cost(Simulator *sim,
-                                   const MachineView &mv,
+                                   MachineView const &mv,
                                    CostMetrics &cost_metrics) const {
   ParallelTensorBase sub_output, sub_input;
   if (!outputs[0]->get_sub_tensor(mv, sub_output))
@@ -574,7 +574,7 @@ bool Conv2D::measure_operator_cost(Simulator *sim,
 
   // select forward algorithm
   {
-    const int reqAlgCnt = 8;
+    int const reqAlgCnt = 8;
     int cnt = 0;
     cudnnConvolutionFwdAlgoPerf_t perfResults[reqAlgCnt];
     checkCUDNN(cudnnFindConvolutionForwardAlgorithmEx(m->handle.dnn,
@@ -599,7 +599,7 @@ bool Conv2D::measure_operator_cost(Simulator *sim,
   }
   // select backward algorithm
   {
-    const int reqAlgCnt = 8;
+    int const reqAlgCnt = 8;
     int cnt = 0;
     cudnnConvolutionBwdFilterAlgoPerf_t perfResults[reqAlgCnt];
     checkCUDNN(
@@ -624,7 +624,7 @@ bool Conv2D::measure_operator_cost(Simulator *sim,
     //   perfResults[i].algo, perfResults[i].time);
   }
   if (trainableInputs[0]) {
-    const int reqAlgCnt = 8;
+    int const reqAlgCnt = 8;
     int cnt = 0;
     cudnnConvolutionBwdDataAlgoPerf_t perfResults[reqAlgCnt];
     checkCUDNN(

--- a/src/ops/dropout.cpp
+++ b/src/ops/dropout.cpp
@@ -77,9 +77,9 @@ void Dropout::backward_kernel_wrapper(DropoutMeta *m,
 }
 
 DropoutMeta::DropoutMeta(FFHandler handler,
-                         const Dropout *dropout,
+                         Dropout const *dropout,
                          Memory gpu_mem,
-                         const Domain &output_domain)
+                         Domain const &output_domain)
     : OpMeta(handler) {
   profiling = dropout->profiling;
   checkCUDNN(miopenCreateTensorDescriptor(&inputTensor));

--- a/src/ops/dropout.cu
+++ b/src/ops/dropout.cu
@@ -74,9 +74,9 @@ void Dropout::backward_kernel_wrapper(DropoutMeta *m,
 }
 
 DropoutMeta::DropoutMeta(FFHandler handler,
-                         const Dropout *dropout,
+                         Dropout const *dropout,
                          Memory gpu_mem,
-                         const Domain &output_domain)
+                         Domain const &output_domain)
     : OpMeta(handler) {
   profiling = dropout->profiling;
   checkCUDNN(cudnnCreateTensorDescriptor(&inputTensor));

--- a/src/ops/element_binary.cpp
+++ b/src/ops/element_binary.cpp
@@ -24,9 +24,9 @@ using Legion::Domain;
 
 /*static*/
 void ElementBinary::init_kernel(ElementBinaryMeta *m,
-                                const Domain &input1_domain,
-                                const Domain &input2_domain,
-                                const Domain &output_domain) {
+                                Domain const &input1_domain,
+                                Domain const &input2_domain,
+                                Domain const &output_domain) {
   miopenTensorOp_t mode;
   switch (m->op_type) {
   case OP_EW_ADD:
@@ -55,11 +55,11 @@ void ElementBinary::init_kernel(ElementBinaryMeta *m,
 }
 
 __global__ void elewise_binary_forward_kernel(coord_t volume,
-                                              const float alpha,
-                                              const float beta,
+                                              float const alpha,
+                                              float const beta,
                                               OperatorType type,
-                                              const float *in1,
-                                              const float *in2,
+                                              float const *in1,
+                                              float const *in2,
                                               float *out) {
   switch (type) {
   case OP_EW_ADD: {
@@ -92,9 +92,9 @@ __global__ void elewise_binary_forward_kernel(coord_t volume,
 }
 
 /*static*/
-void ElementBinary::forward_kernel(const ElementBinaryMeta *m,
-                                   const float *in1_ptr,
-                                   const float *in2_ptr,
+void ElementBinary::forward_kernel(ElementBinaryMeta const *m,
+                                   float const *in1_ptr,
+                                   float const *in2_ptr,
                                    float *out_ptr,
                                    hipStream_t stream) {
   checkCUDA(hipblasSetStream(m->handle.blas, stream));
@@ -154,9 +154,9 @@ void ElementBinary::forward_kernel(const ElementBinaryMeta *m,
 }
 
 /*static*/
-void ElementBinary::forward_kernel_wrapper(const ElementBinaryMeta *m,
-                                           const float *in1_ptr,
-                                           const float *in2_ptr,
+void ElementBinary::forward_kernel_wrapper(ElementBinaryMeta const *m,
+                                           float const *in1_ptr,
+                                           float const *in2_ptr,
                                            float *out_ptr) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -200,12 +200,12 @@ void ElementBinary::forward_kernel_wrapper(const ElementBinaryMeta *m,
 }
 
 __global__ void elewise_binary_backward_kernel(coord_t volume,
-                                               const float alpha,
-                                               const float beta,
+                                               float const alpha,
+                                               float const beta,
                                                OperatorType type,
-                                               const float *out_grad,
-                                               const float *in1,
-                                               const float *in2,
+                                               float const *out_grad,
+                                               float const *in1,
+                                               float const *in2,
                                                float *in1_grad,
                                                float *in2_grad) {
   CUDA_KERNEL_LOOP(i, volume) {
@@ -238,10 +238,10 @@ __global__ void elewise_binary_backward_kernel(coord_t volume,
 }
 
 /*static*/
-void ElementBinary::backward_kernel(const ElementBinaryMeta *m,
-                                    const float *out_grad_ptr,
-                                    const float *in1_ptr,
-                                    const float *in2_ptr,
+void ElementBinary::backward_kernel(ElementBinaryMeta const *m,
+                                    float const *out_grad_ptr,
+                                    float const *in1_ptr,
+                                    float const *in2_ptr,
                                     float *in1_grad_ptr,
                                     float *in2_grad_ptr,
                                     hipStream_t stream) {
@@ -342,10 +342,10 @@ void ElementBinary::backward_kernel(const ElementBinaryMeta *m,
 }
 
 /*static*/
-void ElementBinary::backward_kernel_wrapper(const ElementBinaryMeta *m,
-                                            const float *out_grad_ptr,
-                                            const float *in1_ptr,
-                                            const float *in2_ptr,
+void ElementBinary::backward_kernel_wrapper(ElementBinaryMeta const *m,
+                                            float const *out_grad_ptr,
+                                            float const *in1_ptr,
+                                            float const *in2_ptr,
                                             float *in1_grad_ptr,
                                             float *in2_grad_ptr) {
   hipStream_t stream;

--- a/src/ops/element_binary.cu
+++ b/src/ops/element_binary.cu
@@ -23,9 +23,9 @@ using Legion::Domain;
 
 /*static*/
 void ElementBinary::init_kernel(ElementBinaryMeta *m,
-                                const Domain &input1_domain,
-                                const Domain &input2_domain,
-                                const Domain &output_domain) {
+                                Domain const &input1_domain,
+                                Domain const &input2_domain,
+                                Domain const &output_domain) {
   cudnnOpTensorOp_t mode;
   switch (m->op_type) {
   case OP_EW_ADD:
@@ -55,11 +55,11 @@ void ElementBinary::init_kernel(ElementBinaryMeta *m,
 }
 
 __global__ void elewise_binary_forward_kernel(coord_t volume,
-                                              const float alpha,
-                                              const float beta,
+                                              float const alpha,
+                                              float const beta,
                                               OperatorType type,
-                                              const float *in1,
-                                              const float *in2,
+                                              float const *in1,
+                                              float const *in2,
                                               float *out) {
   switch (type) {
   case OP_EW_ADD: {
@@ -92,9 +92,9 @@ __global__ void elewise_binary_forward_kernel(coord_t volume,
 }
 
 /*static*/
-void ElementBinary::forward_kernel(const ElementBinaryMeta *m,
-                                   const float *in1_ptr,
-                                   const float *in2_ptr,
+void ElementBinary::forward_kernel(ElementBinaryMeta const *m,
+                                   float const *in1_ptr,
+                                   float const *in2_ptr,
                                    float *out_ptr,
                                    cudaStream_t stream) {
   checkCUDA(cublasSetStream(m->handle.blas, stream));
@@ -153,9 +153,9 @@ void ElementBinary::forward_kernel(const ElementBinaryMeta *m,
 }
 
 /*static*/
-void ElementBinary::forward_kernel_wrapper(const ElementBinaryMeta *m,
-                                           const float *in1_ptr,
-                                           const float *in2_ptr,
+void ElementBinary::forward_kernel_wrapper(ElementBinaryMeta const *m,
+                                           float const *in1_ptr,
+                                           float const *in2_ptr,
                                            float *out_ptr) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -199,12 +199,12 @@ void ElementBinary::forward_kernel_wrapper(const ElementBinaryMeta *m,
 }
 
 __global__ void elewise_binary_backward_kernel(coord_t volume,
-                                               const float alpha,
-                                               const float beta,
+                                               float const alpha,
+                                               float const beta,
                                                OperatorType type,
-                                               const float *out_grad,
-                                               const float *in1,
-                                               const float *in2,
+                                               float const *out_grad,
+                                               float const *in1,
+                                               float const *in2,
                                                float *in1_grad,
                                                float *in2_grad) {
   CUDA_KERNEL_LOOP(i, volume) {
@@ -237,10 +237,10 @@ __global__ void elewise_binary_backward_kernel(coord_t volume,
 }
 
 /*static*/
-void ElementBinary::backward_kernel(const ElementBinaryMeta *m,
-                                    const float *out_grad_ptr,
-                                    const float *in1_ptr,
-                                    const float *in2_ptr,
+void ElementBinary::backward_kernel(ElementBinaryMeta const *m,
+                                    float const *out_grad_ptr,
+                                    float const *in1_ptr,
+                                    float const *in2_ptr,
                                     float *in1_grad_ptr,
                                     float *in2_grad_ptr,
                                     cudaStream_t stream) {
@@ -333,10 +333,10 @@ void ElementBinary::backward_kernel(const ElementBinaryMeta *m,
 }
 
 /*static*/
-void ElementBinary::backward_kernel_wrapper(const ElementBinaryMeta *m,
-                                            const float *out_grad_ptr,
-                                            const float *in1_ptr,
-                                            const float *in2_ptr,
+void ElementBinary::backward_kernel_wrapper(ElementBinaryMeta const *m,
+                                            float const *out_grad_ptr,
+                                            float const *in1_ptr,
+                                            float const *in2_ptr,
                                             float *in1_grad_ptr,
                                             float *in2_grad_ptr) {
   cudaStream_t stream;

--- a/src/ops/element_unary.cc
+++ b/src/ops/element_unary.cc
@@ -24,7 +24,7 @@ using Legion::TaskLauncher;
 Tensor FFModel::unary(OperatorType op,
                       const Tensor x,
                       bool inplace,
-                      const char *name,
+                      char const *name,
                       float scalar) {
   Layer *ele =
       new Layer(this, op, name, 1 /*inputs*/, 0 /*weights*/, 1 /*outputs*/, x);
@@ -42,8 +42,8 @@ Tensor FFModel::unary(OperatorType op,
 
 Op *ElementUnary::create_operator_from_layer(
     FFModel &model,
-    const Layer *layer,
-    const std::vector<ParallelTensor> &inputs) {
+    Layer const *layer,
+    std::vector<ParallelTensor> const &inputs) {
   long long value;
   layer->get_int_property("inplace", value);
   bool inplace = (bool)value;
@@ -74,81 +74,81 @@ Node FFModel::get_or_create_element_unary_node(const ParallelTensor input,
   return get_or_create_node<ElementUnary>(input, params);
 }
 
-Tensor FFModel::exp(const Tensor x, const char *name) {
+Tensor FFModel::exp(const Tensor x, char const *name) {
   return this->unary(OP_EXP, x, false /*inplace*/, name);
 }
 
 Tensor FFModel::scalar_multiply(const Tensor x,
-                                const float scalar,
+                                float const scalar,
                                 bool inplace,
-                                const char *name) {
+                                char const *name) {
   return this->unary(OP_SCALAR_MULTIPLY, x, inplace, name, scalar);
 }
 
 Tensor FFModel::scalar_add(const Tensor x,
-                           const float scalar,
+                           float const scalar,
                            bool inplace,
-                           const char *name) {
+                           char const *name) {
   return this->unary(OP_SCALAR_ADD, x, inplace, name, scalar);
 }
 
 Tensor FFModel::scalar_sub(const Tensor x,
-                           const float scalar,
+                           float const scalar,
                            bool inplace,
-                           const char *name) {
+                           char const *name) {
   return this->unary(OP_SCALAR_SUB, x, inplace, name, scalar);
 }
 
 Tensor FFModel::scalar_truediv(const Tensor x,
-                               const float scalar,
+                               float const scalar,
                                bool inplace,
-                               const char *name) {
+                               char const *name) {
   return this->unary(OP_SCALAR_TRUE_DIV, x, inplace, name, scalar);
 }
 
-Tensor FFModel::relu(const Tensor x, bool inplace, const char *name) {
+Tensor FFModel::relu(const Tensor x, bool inplace, char const *name) {
   return this->unary(OP_RELU, x, inplace, name);
 }
 
-Tensor FFModel::sigmoid(const Tensor x, const char *name) {
+Tensor FFModel::sigmoid(const Tensor x, char const *name) {
   return this->unary(OP_SIGMOID, x, false /*inplace*/, name);
 }
 
-Tensor FFModel::tanh(const Tensor x, const char *name) {
+Tensor FFModel::tanh(const Tensor x, char const *name) {
   return this->unary(OP_TANH, x, false /*inplace*/, name);
 }
 
-Tensor FFModel::identity(const Tensor x, const char *name) {
+Tensor FFModel::identity(const Tensor x, char const *name) {
   return this->unary(OP_IDENTITY, x, false /*inplace*/, name);
 }
 
-Tensor FFModel::gelu(const Tensor x, const char *name) {
+Tensor FFModel::gelu(const Tensor x, char const *name) {
   return this->unary(OP_GELU, x, false /*inplace*/, name);
 }
 
-Tensor FFModel::elu(const Tensor x, bool inplace, const char *name) {
+Tensor FFModel::elu(const Tensor x, bool inplace, char const *name) {
   // Currently assume inplace is false
   assert(!inplace);
   return this->unary(OP_ELU, x, inplace, name);
 }
 
-Tensor FFModel::rsqrt(const Tensor x, bool inplace, const char *name) {
+Tensor FFModel::rsqrt(const Tensor x, bool inplace, char const *name) {
   return this->unary(OP_RSQRT, x, inplace, name);
 }
 
 Tensor FFModel::pow(const Tensor x,
-                    const float exponent,
+                    float const exponent,
                     bool inplace,
-                    const char *name) {
+                    char const *name) {
   return this->unary(OP_POW, x, inplace, name, exponent);
 }
 
-bool ElementUnaryParams::is_valid(const ParallelTensorShape &input) const {
+bool ElementUnaryParams::is_valid(ParallelTensorShape const &input) const {
   // TODO: more check on the input shape
   return input.is_valid();
 }
 
-bool operator==(const ElementUnaryParams &lhs, const ElementUnaryParams &rhs) {
+bool operator==(ElementUnaryParams const &lhs, ElementUnaryParams const &rhs) {
   return lhs.op_type == rhs.op_type && lhs.scalar == rhs.scalar &&
          lhs.inplace == rhs.inplace;
 }
@@ -157,7 +157,7 @@ ElementUnary::ElementUnary(FFModel &model,
                            OperatorType _op_type,
                            const ParallelTensor x,
                            bool _inplace,
-                           const char *name,
+                           char const *name,
                            float _scalar)
     : Op(model, _op_type, name, 1 /*inputs*/, 0 /*weights*/, 1 /*outputs*/, x),
       inplace(_inplace), scalar(_scalar) {
@@ -172,9 +172,9 @@ ElementUnary::ElementUnary(FFModel &model,
 }
 
 ElementUnary::ElementUnary(FFModel &model,
-                           const ElementUnaryParams &params,
+                           ElementUnaryParams const &params,
                            const ParallelTensor input,
-                           const char *name)
+                           char const *name)
     : ElementUnary(
           model, params.op_type, input, params.inplace, name, params.scalar) {}
 
@@ -196,7 +196,7 @@ bool ElementUnary::use_cudnn(OperatorType type) {
   return false;
 }
 
-void ElementUnary::init(const FFModel &ff) {
+void ElementUnary::init(FFModel const &ff) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
@@ -231,8 +231,8 @@ void ElementUnary::init(const FFModel &ff) {
   set_opmeta_from_futuremap(ff, fm);
 }
 
-OpMeta *ElementUnary::init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+OpMeta *ElementUnary::init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   ElementUnary *eu = (ElementUnary *)task->args;
@@ -261,7 +261,7 @@ OpMeta *ElementUnary::init_task(const Task *task,
   return m;
 }
 
-void ElementUnary::forward(const FFModel &ff) {
+void ElementUnary::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -300,11 +300,11 @@ void ElementUnary::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void ElementUnary::forward_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+void ElementUnary::forward_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
-  const ElementUnaryMeta *m = *((ElementUnaryMeta **)task->local_args);
+  ElementUnaryMeta const *m = *((ElementUnaryMeta **)task->local_args);
   if (m->data_type == DT_FLOAT) {
     forward_task_with_type<float>(task, regions, ctx, runtime);
   } else if (m->data_type == DT_DOUBLE) {
@@ -324,12 +324,12 @@ void ElementUnary::forward_task(const Task *task,
 */
 template <typename DT>
 void ElementUnary::forward_task_with_type(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   // const ElementUnary* ele = (const ElementUnary*) task->args;
-  const ElementUnaryMeta *m = *((ElementUnaryMeta **)task->local_args);
+  ElementUnaryMeta const *m = *((ElementUnaryMeta **)task->local_args);
   Domain input_domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   const DT *input_ptr = NULL;
@@ -356,7 +356,7 @@ void ElementUnary::forward_task_with_type(
       m, input_ptr, output_ptr, input_domain.get_volume());
 }
 
-void ElementUnary::backward(const FFModel &ff) {
+void ElementUnary::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -419,11 +419,11 @@ void ElementUnary::backward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void ElementUnary::backward_task(const Task *task,
-                                 const std::vector<PhysicalRegion> &regions,
+void ElementUnary::backward_task(Task const *task,
+                                 std::vector<PhysicalRegion> const &regions,
                                  Context ctx,
                                  Runtime *runtime) {
-  const ElementUnaryMeta *m = *((ElementUnaryMeta **)task->local_args);
+  ElementUnaryMeta const *m = *((ElementUnaryMeta **)task->local_args);
   if (m->data_type == DT_FLOAT) {
     backward_task_with_type<float>(task, regions, ctx, runtime);
   } else if (m->data_type == DT_DOUBLE) {
@@ -445,12 +445,12 @@ void ElementUnary::backward_task(const Task *task,
 */
 template <typename DT>
 void ElementUnary::backward_task_with_type(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   // const ElementUnary* ele = (const ElementUnary*) task->args;
-  const ElementUnaryMeta *m = *((ElementUnaryMeta **)task->local_args);
+  ElementUnaryMeta const *m = *((ElementUnaryMeta **)task->local_args);
   const DT *input_ptr = NULL, *output_ptr = NULL, *output_grad_ptr = NULL;
   DT *input_grad_ptr = NULL;
   Domain input_domain = runtime->get_index_space_domain(
@@ -506,7 +506,7 @@ void ElementUnary::serialize(Legion::Serializer &sez) const {
 }
 
 bool ElementUnary::measure_operator_cost(Simulator *sim,
-                                         const MachineView &mv,
+                                         MachineView const &mv,
                                          CostMetrics &cost_metrics) const {
   ParallelTensorBase sub_output, sub_input;
   if (!outputs[0]->get_sub_tensor(mv, sub_output))
@@ -620,7 +620,7 @@ Op *ElementUnary::materialize(FFModel &ff,
 
 namespace std {
 size_t hash<FlexFlow::ElementUnaryParams>::operator()(
-    const FlexFlow::ElementUnaryParams &params) const {
+    FlexFlow::ElementUnaryParams const &params) const {
   size_t key = 0;
   hash_combine(key, params.op_type);
   hash_combine(key, params.scalar);

--- a/src/ops/element_unary.cpp
+++ b/src/ops/element_unary.cpp
@@ -25,8 +25,8 @@ using Legion::Domain;
 
 /*static*/
 void ElementUnary::init_kernel(ElementUnaryMeta *m,
-                               const Domain &input_domain,
-                               const Domain &output_domain) {
+                               Domain const &input_domain,
+                               Domain const &output_domain) {
   miopenActivationMode_t mode;
   switch (m->op_type) {
   case OP_SIGMOID:
@@ -100,7 +100,7 @@ __global__ void elewise_unary_forward_kernel(
 
 /*static*/
 template <typename T>
-void ElementUnary::forward_kernel(const ElementUnaryMeta *m,
+void ElementUnary::forward_kernel(ElementUnaryMeta const *m,
                                   const T *input_ptr,
                                   T *output_ptr,
                                   size_t num_elements,
@@ -133,7 +133,7 @@ void ElementUnary::forward_kernel(const ElementUnaryMeta *m,
 
 /*static*/
 template <typename T>
-void ElementUnary::forward_kernel_wrapper(const ElementUnaryMeta *m,
+void ElementUnary::forward_kernel_wrapper(ElementUnaryMeta const *m,
                                           const T *input_ptr,
                                           T *output_ptr,
                                           size_t num_elements) {
@@ -202,7 +202,7 @@ __global__ void elewise_unary_backward_kernel(coord_t volume,
 
 /*static*/
 template <typename T>
-void ElementUnary::backward_kernel(const ElementUnaryMeta *m,
+void ElementUnary::backward_kernel(ElementUnaryMeta const *m,
                                    const T *input_ptr,
                                    T *input_grad_ptr,
                                    const T *output_ptr,
@@ -244,7 +244,7 @@ void ElementUnary::backward_kernel(const ElementUnaryMeta *m,
 
 /*static*/
 template <typename T>
-void ElementUnary::backward_kernel_wrapper(const ElementUnaryMeta *m,
+void ElementUnary::backward_kernel_wrapper(ElementUnaryMeta const *m,
                                            const T *input_ptr,
                                            T *input_grad_ptr,
                                            const T *output_ptr,
@@ -268,53 +268,53 @@ ElementUnaryMeta::ElementUnaryMeta(FFHandler handler) : OpMeta(handler) {
 }
 
 template void
-ElementUnary::forward_kernel_wrapper<float>(const ElementUnaryMeta *m,
-                                            const float *input_ptr,
+ElementUnary::forward_kernel_wrapper<float>(ElementUnaryMeta const *m,
+                                            float const *input_ptr,
                                             float *output_ptr,
                                             size_t num_elements);
 template void
-ElementUnary::forward_kernel_wrapper<double>(const ElementUnaryMeta *m,
-                                             const double *input_ptr,
+ElementUnary::forward_kernel_wrapper<double>(ElementUnaryMeta const *m,
+                                             double const *input_ptr,
                                              double *output_ptr,
                                              size_t num_elements);
 template void
-ElementUnary::forward_kernel_wrapper<int32_t>(const ElementUnaryMeta *m,
-                                              const int32_t *input_ptr,
+ElementUnary::forward_kernel_wrapper<int32_t>(ElementUnaryMeta const *m,
+                                              int32_t const *input_ptr,
                                               int32_t *output_ptr,
                                               size_t num_elements);
 template void
-ElementUnary::forward_kernel_wrapper<int64_t>(const ElementUnaryMeta *m,
-                                              const int64_t *input_ptr,
+ElementUnary::forward_kernel_wrapper<int64_t>(ElementUnaryMeta const *m,
+                                              int64_t const *input_ptr,
                                               int64_t *output_ptr,
                                               size_t num_elements);
 
 template void
-ElementUnary::backward_kernel_wrapper<float>(const ElementUnaryMeta *m,
-                                             const float *input_ptr,
+ElementUnary::backward_kernel_wrapper<float>(ElementUnaryMeta const *m,
+                                             float const *input_ptr,
                                              float *input_grad_ptr,
-                                             const float *output_ptr,
-                                             const float *output_grad_ptr,
+                                             float const *output_ptr,
+                                             float const *output_grad_ptr,
                                              size_t num_elements);
 template void
-ElementUnary::backward_kernel_wrapper<double>(const ElementUnaryMeta *m,
-                                              const double *input_ptr,
+ElementUnary::backward_kernel_wrapper<double>(ElementUnaryMeta const *m,
+                                              double const *input_ptr,
                                               double *input_grad_ptr,
-                                              const double *output_ptr,
-                                              const double *output_grad_ptr,
+                                              double const *output_ptr,
+                                              double const *output_grad_ptr,
                                               size_t num_elements);
 template void
-ElementUnary::backward_kernel_wrapper<int32_t>(const ElementUnaryMeta *m,
-                                               const int32_t *input_ptr,
+ElementUnary::backward_kernel_wrapper<int32_t>(ElementUnaryMeta const *m,
+                                               int32_t const *input_ptr,
                                                int32_t *input_grad_ptr,
-                                               const int32_t *output_ptr,
-                                               const int32_t *output_grad_ptr,
+                                               int32_t const *output_ptr,
+                                               int32_t const *output_grad_ptr,
                                                size_t num_elements);
 template void
-ElementUnary::backward_kernel_wrapper<int64_t>(const ElementUnaryMeta *m,
-                                               const int64_t *input_ptr,
+ElementUnary::backward_kernel_wrapper<int64_t>(ElementUnaryMeta const *m,
+                                               int64_t const *input_ptr,
                                                int64_t *input_grad_ptr,
-                                               const int64_t *output_ptr,
-                                               const int64_t *output_grad_ptr,
+                                               int64_t const *output_ptr,
+                                               int64_t const *output_grad_ptr,
                                                size_t num_elements);
 
 }; // namespace FlexFlow

--- a/src/ops/element_unary.cu
+++ b/src/ops/element_unary.cu
@@ -24,8 +24,8 @@ using Legion::Domain;
 
 /*static*/
 void ElementUnary::init_kernel(ElementUnaryMeta *m,
-                               const Domain &input_domain,
-                               const Domain &output_domain) {
+                               Domain const &input_domain,
+                               Domain const &output_domain) {
   cudnnActivationMode_t mode;
   switch (m->op_type) {
   case OP_SIGMOID:
@@ -100,7 +100,7 @@ __global__ void elewise_unary_forward_kernel(
 
 /*static*/
 template <typename T>
-void ElementUnary::forward_kernel(const ElementUnaryMeta *m,
+void ElementUnary::forward_kernel(ElementUnaryMeta const *m,
                                   const T *input_ptr,
                                   T *output_ptr,
                                   size_t num_elements,
@@ -128,7 +128,7 @@ void ElementUnary::forward_kernel(const ElementUnaryMeta *m,
 
 /*static*/
 template <typename T>
-void ElementUnary::forward_kernel_wrapper(const ElementUnaryMeta *m,
+void ElementUnary::forward_kernel_wrapper(ElementUnaryMeta const *m,
                                           const T *input_ptr,
                                           T *output_ptr,
                                           size_t num_elements) {
@@ -197,7 +197,7 @@ __global__ void elewise_unary_backward_kernel(coord_t volume,
 
 /*static*/
 template <typename T>
-void ElementUnary::backward_kernel(const ElementUnaryMeta *m,
+void ElementUnary::backward_kernel(ElementUnaryMeta const *m,
                                    const T *input_ptr,
                                    T *input_grad_ptr,
                                    const T *output_ptr,
@@ -235,7 +235,7 @@ void ElementUnary::backward_kernel(const ElementUnaryMeta *m,
 
 /*static*/
 template <typename T>
-void ElementUnary::backward_kernel_wrapper(const ElementUnaryMeta *m,
+void ElementUnary::backward_kernel_wrapper(ElementUnaryMeta const *m,
                                            const T *input_ptr,
                                            T *input_grad_ptr,
                                            const T *output_ptr,
@@ -259,53 +259,53 @@ ElementUnaryMeta::ElementUnaryMeta(FFHandler handler) : OpMeta(handler) {
 }
 
 template void
-ElementUnary::forward_kernel_wrapper<float>(const ElementUnaryMeta *m,
-                                            const float *input_ptr,
+ElementUnary::forward_kernel_wrapper<float>(ElementUnaryMeta const *m,
+                                            float const *input_ptr,
                                             float *output_ptr,
                                             size_t num_elements);
 template void
-ElementUnary::forward_kernel_wrapper<double>(const ElementUnaryMeta *m,
-                                             const double *input_ptr,
+ElementUnary::forward_kernel_wrapper<double>(ElementUnaryMeta const *m,
+                                             double const *input_ptr,
                                              double *output_ptr,
                                              size_t num_elements);
 template void
-ElementUnary::forward_kernel_wrapper<int32_t>(const ElementUnaryMeta *m,
-                                              const int32_t *input_ptr,
+ElementUnary::forward_kernel_wrapper<int32_t>(ElementUnaryMeta const *m,
+                                              int32_t const *input_ptr,
                                               int32_t *output_ptr,
                                               size_t num_elements);
 template void
-ElementUnary::forward_kernel_wrapper<int64_t>(const ElementUnaryMeta *m,
-                                              const int64_t *input_ptr,
+ElementUnary::forward_kernel_wrapper<int64_t>(ElementUnaryMeta const *m,
+                                              int64_t const *input_ptr,
                                               int64_t *output_ptr,
                                               size_t num_elements);
 
 template void
-ElementUnary::backward_kernel_wrapper<float>(const ElementUnaryMeta *m,
-                                             const float *input_ptr,
+ElementUnary::backward_kernel_wrapper<float>(ElementUnaryMeta const *m,
+                                             float const *input_ptr,
                                              float *input_grad_ptr,
-                                             const float *output_ptr,
-                                             const float *output_grad_ptr,
+                                             float const *output_ptr,
+                                             float const *output_grad_ptr,
                                              size_t num_elements);
 template void
-ElementUnary::backward_kernel_wrapper<double>(const ElementUnaryMeta *m,
-                                              const double *input_ptr,
+ElementUnary::backward_kernel_wrapper<double>(ElementUnaryMeta const *m,
+                                              double const *input_ptr,
                                               double *input_grad_ptr,
-                                              const double *output_ptr,
-                                              const double *output_grad_ptr,
+                                              double const *output_ptr,
+                                              double const *output_grad_ptr,
                                               size_t num_elements);
 template void
-ElementUnary::backward_kernel_wrapper<int32_t>(const ElementUnaryMeta *m,
-                                               const int32_t *input_ptr,
+ElementUnary::backward_kernel_wrapper<int32_t>(ElementUnaryMeta const *m,
+                                               int32_t const *input_ptr,
                                                int32_t *input_grad_ptr,
-                                               const int32_t *output_ptr,
-                                               const int32_t *output_grad_ptr,
+                                               int32_t const *output_ptr,
+                                               int32_t const *output_grad_ptr,
                                                size_t num_elements);
 template void
-ElementUnary::backward_kernel_wrapper<int64_t>(const ElementUnaryMeta *m,
-                                               const int64_t *input_ptr,
+ElementUnary::backward_kernel_wrapper<int64_t>(ElementUnaryMeta const *m,
+                                               int64_t const *input_ptr,
                                                int64_t *input_grad_ptr,
-                                               const int64_t *output_ptr,
-                                               const int64_t *output_grad_ptr,
+                                               int64_t const *output_ptr,
+                                               int64_t const *output_grad_ptr,
                                                size_t num_elements);
 
 }; // namespace FlexFlow

--- a/src/ops/embedding.cpp
+++ b/src/ops/embedding.cpp
@@ -30,7 +30,7 @@ using Legion::Task;
 template <typename TI>
 __global__ void embed_forward_no_aggr(const TI *input,
                                       float *output,
-                                      const float *embed,
+                                      float const *embed,
                                       int out_dim,
                                       int batch_size) {
   CUDA_KERNEL_LOOP(i, batch_size * out_dim) {
@@ -45,7 +45,7 @@ __global__ void embed_forward_no_aggr(const TI *input,
 template <typename TI>
 __global__ void embed_forward_with_aggr(const TI *input,
                                         float *output,
-                                        const float *embed,
+                                        float const *embed,
                                         int out_dim,
                                         int in_dim,
                                         int batch_size,
@@ -68,7 +68,7 @@ __global__ void embed_forward_with_aggr(const TI *input,
 
 template <typename TI>
 __global__ void embed_backward_no_aggr(const TI *input,
-                                       const float *output,
+                                       float const *output,
                                        float *embed,
                                        int out_dim,
                                        int batch_size) {
@@ -82,7 +82,7 @@ __global__ void embed_backward_no_aggr(const TI *input,
 
 template <typename TI>
 __global__ void embed_backward_with_aggr(const TI *input,
-                                         const float *output,
+                                         float const *output,
                                          float *embed,
                                          int out_dim,
                                          int in_dim,
@@ -145,7 +145,7 @@ void Embedding::forward_kernel(const TI *input_ptr,
 
 /*static*/
 template <typename TI>
-void Embedding::forward_kernel_wrapper(const EmbeddingMeta *m,
+void Embedding::forward_kernel_wrapper(EmbeddingMeta const *m,
                                        const TI *input_ptr,
                                        float *output_ptr,
                                        float const *weight_ptr,
@@ -216,7 +216,7 @@ void Embedding::backward_kernel(const TI *input_ptr,
 
 /*static*/
 template <typename TI>
-void Embedding::backward_kernel_wrapper(const EmbeddingMeta *m,
+void Embedding::backward_kernel_wrapper(EmbeddingMeta const *m,
                                         const TI *input_ptr,
                                         float const *output_ptr,
                                         float *weight_grad_ptr,
@@ -268,8 +268,8 @@ void Embedding::rand_generate_int64_wrapper(int64_t *ptr,
 }
 
 template void
-Embedding::forward_kernel_wrapper<int32_t>(const EmbeddingMeta *m,
-                                           const int32_t *input_ptr,
+Embedding::forward_kernel_wrapper<int32_t>(EmbeddingMeta const *m,
+                                           int32_t const *input_ptr,
                                            float *output_ptr,
                                            float const *weight_ptr,
                                            int in_dim,
@@ -278,8 +278,8 @@ Embedding::forward_kernel_wrapper<int32_t>(const EmbeddingMeta *m,
                                            AggrMode aggr,
                                            int outputSize);
 template void
-Embedding::forward_kernel_wrapper<int64_t>(const EmbeddingMeta *m,
-                                           const int64_t *input_ptr,
+Embedding::forward_kernel_wrapper<int64_t>(EmbeddingMeta const *m,
+                                           int64_t const *input_ptr,
                                            float *output_ptr,
                                            float const *weight_ptr,
                                            int in_dim,
@@ -289,8 +289,8 @@ Embedding::forward_kernel_wrapper<int64_t>(const EmbeddingMeta *m,
                                            int outputSize);
 
 template void
-Embedding::backward_kernel_wrapper<int32_t>(const EmbeddingMeta *m,
-                                            const int32_t *input_ptr,
+Embedding::backward_kernel_wrapper<int32_t>(EmbeddingMeta const *m,
+                                            int32_t const *input_ptr,
                                             float const *output_ptr,
                                             float *weight_grad_ptr,
                                             int in_dim,
@@ -299,8 +299,8 @@ Embedding::backward_kernel_wrapper<int32_t>(const EmbeddingMeta *m,
                                             AggrMode aggr,
                                             int outputSize);
 template void
-Embedding::backward_kernel_wrapper<int64_t>(const EmbeddingMeta *m,
-                                            const int64_t *input_ptr,
+Embedding::backward_kernel_wrapper<int64_t>(EmbeddingMeta const *m,
+                                            int64_t const *input_ptr,
                                             float const *output_ptr,
                                             float *weight_grad_ptr,
                                             int in_dim,

--- a/src/ops/embedding.cu
+++ b/src/ops/embedding.cu
@@ -29,7 +29,7 @@ using Legion::Task;
 template <typename TI>
 __global__ void embed_forward_no_aggr(const TI *input,
                                       float *output,
-                                      const float *embed,
+                                      float const *embed,
                                       int out_dim,
                                       int batch_size) {
   CUDA_KERNEL_LOOP(i, batch_size * out_dim) {
@@ -44,7 +44,7 @@ __global__ void embed_forward_no_aggr(const TI *input,
 template <typename TI>
 __global__ void embed_forward_with_aggr(const TI *input,
                                         float *output,
-                                        const float *embed,
+                                        float const *embed,
                                         int out_dim,
                                         int in_dim,
                                         int batch_size,
@@ -67,7 +67,7 @@ __global__ void embed_forward_with_aggr(const TI *input,
 
 template <typename TI>
 __global__ void embed_backward_no_aggr(const TI *input,
-                                       const float *output,
+                                       float const *output,
                                        float *embed,
                                        int out_dim,
                                        int batch_size) {
@@ -81,7 +81,7 @@ __global__ void embed_backward_no_aggr(const TI *input,
 
 template <typename TI>
 __global__ void embed_backward_with_aggr(const TI *input,
-                                         const float *output,
+                                         float const *output,
                                          float *embed,
                                          int out_dim,
                                          int in_dim,
@@ -133,7 +133,7 @@ void Embedding::forward_kernel(const TI *input_ptr,
 
 /*static*/
 template <typename TI>
-void Embedding::forward_kernel_wrapper(const EmbeddingMeta *m,
+void Embedding::forward_kernel_wrapper(EmbeddingMeta const *m,
                                        const TI *input_ptr,
                                        float *output_ptr,
                                        float const *weight_ptr,
@@ -194,7 +194,7 @@ void Embedding::backward_kernel(const TI *input_ptr,
 
 /*static*/
 template <typename TI>
-void Embedding::backward_kernel_wrapper(const EmbeddingMeta *m,
+void Embedding::backward_kernel_wrapper(EmbeddingMeta const *m,
                                         const TI *input_ptr,
                                         float const *output_ptr,
                                         float *weight_grad_ptr,
@@ -240,8 +240,8 @@ void Embedding::rand_generate_int64_wrapper(int64_t *ptr,
 }
 
 template void
-Embedding::forward_kernel_wrapper<int32_t>(const EmbeddingMeta *m,
-                                           const int32_t *input_ptr,
+Embedding::forward_kernel_wrapper<int32_t>(EmbeddingMeta const *m,
+                                           int32_t const *input_ptr,
                                            float *output_ptr,
                                            float const *weight_ptr,
                                            int in_dim,
@@ -250,8 +250,8 @@ Embedding::forward_kernel_wrapper<int32_t>(const EmbeddingMeta *m,
                                            AggrMode aggr,
                                            int outputSize);
 template void
-Embedding::forward_kernel_wrapper<int64_t>(const EmbeddingMeta *m,
-                                           const int64_t *input_ptr,
+Embedding::forward_kernel_wrapper<int64_t>(EmbeddingMeta const *m,
+                                           int64_t const *input_ptr,
                                            float *output_ptr,
                                            float const *weight_ptr,
                                            int in_dim,
@@ -261,8 +261,8 @@ Embedding::forward_kernel_wrapper<int64_t>(const EmbeddingMeta *m,
                                            int outputSize);
 
 template void
-Embedding::backward_kernel_wrapper<int32_t>(const EmbeddingMeta *m,
-                                            const int32_t *input_ptr,
+Embedding::backward_kernel_wrapper<int32_t>(EmbeddingMeta const *m,
+                                            int32_t const *input_ptr,
                                             float const *output_ptr,
                                             float *weight_grad_ptr,
                                             int in_dim,
@@ -271,8 +271,8 @@ Embedding::backward_kernel_wrapper<int32_t>(const EmbeddingMeta *m,
                                             AggrMode aggr,
                                             int outputSize);
 template void
-Embedding::backward_kernel_wrapper<int64_t>(const EmbeddingMeta *m,
-                                            const int64_t *input_ptr,
+Embedding::backward_kernel_wrapper<int64_t>(EmbeddingMeta const *m,
+                                            int64_t const *input_ptr,
                                             float const *output_ptr,
                                             float *weight_grad_ptr,
                                             int in_dim,

--- a/src/ops/flat.cc
+++ b/src/ops/flat.cc
@@ -18,7 +18,7 @@ using Legion::Task;
 using Legion::TaskArgument;
 using Legion::TaskLauncher;
 
-Tensor FFModel::flat(const Tensor input, const char *name) {
+Tensor FFModel::flat(const Tensor input, char const *name) {
   assert(input->num_dims == 4);
   Layer *flat = new Layer(
       this, OP_FLAT, name, 1 /*inputs*/, 0 /*weights*/, 1 /*outputs*/, input);
@@ -40,8 +40,8 @@ Tensor FFModel::flat(const Tensor input, const char *name) {
 
 Op *Flat::create_operator_from_layer(
     FFModel &model,
-    const Layer *layer,
-    const std::vector<ParallelTensor> &inputs) {
+    Layer const *layer,
+    std::vector<ParallelTensor> const &inputs) {
   return new Flat(model, inputs[0], layer->name);
 }
 
@@ -101,7 +101,7 @@ Node FFModel::get_or_create_flat_node(const ParallelTensor input) {
 
   Flat *flat;
 
-  const auto &it = this->cached_flat_ops.find(hash);
+  auto const &it = this->cached_flat_ops.find(hash);
   if (it != cached_flat_ops.end()) {
     flat = it->second;
   } else {
@@ -122,7 +122,7 @@ void Flat::construct_output_mappings(
        {Input::CHANNEL, MappingOperation::PARTITION, Output::CHANNEL}});
 }
 
-Flat::Flat(FFModel &model, const ParallelTensor _input, const char *name)
+Flat::Flat(FFModel &model, const ParallelTensor _input, char const *name)
     : Op(model,
          OP_FLAT,
          name,
@@ -144,7 +144,7 @@ Flat::Flat(FFModel &model, const ParallelTensor _input, const char *name)
   assert(check_output_input_weight_parallel_dims());
 }
 
-void Flat::init(const FFModel &ff) {
+void Flat::init(FFModel const &ff) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
@@ -176,16 +176,16 @@ void Flat::init(const FFModel &ff) {
   set_opmeta_from_futuremap(ff, fm);
 }
 
-OpMeta *Flat::init_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+OpMeta *Flat::init_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {
-  FFHandler handler = *((const FFHandler *)task->local_args);
+  FFHandler handler = *((FFHandler const *)task->local_args);
   FlatMeta *m = new FlatMeta(handler);
   return m;
 }
 
-void Flat::forward(const FFModel &ff) {
+void Flat::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -217,8 +217,8 @@ void Flat::forward(const FFModel &ff) {
   regions[0](I): input
   regions[1](O): output
 */
-void Flat::forward_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+void Flat::forward_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {
   assert(regions.size() == 2);
@@ -238,7 +238,7 @@ void Flat::forward_task(const Task *task,
   // checkCUDA(cudaDeviceSynchronize());
 }
 
-void Flat::backward(const FFModel &ff) {
+void Flat::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -270,8 +270,8 @@ void Flat::backward(const FFModel &ff) {
   regions[0](I/O) : input_grad
   regions[1](I) : output_grad
 */
-void Flat::backward_task(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+void Flat::backward_task(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime) {
   assert(regions.size() == 2);
@@ -290,7 +290,7 @@ void Flat::backward_task(const Task *task,
       acc_input_grad.ptr, acc_output_grad.ptr, acc_input_grad.rect.volume());
 }
 
-Domain Flat::get_input_tensor_shape(const ParallelConfig &pc,
+Domain Flat::get_input_tensor_shape(ParallelConfig const &pc,
                                     int input_idx,
                                     int part_idx) const {
   assert(input_idx < numInputs);
@@ -314,7 +314,7 @@ Domain Flat::get_input_tensor_shape(const ParallelConfig &pc,
 void Flat::serialize(Legion::Serializer &sez) const { return; }
 
 bool Flat::measure_operator_cost(Simulator *sim,
-                                 const MachineView &mv,
+                                 MachineView const &mv,
                                  CostMetrics &cost_metrics) const {
   ParallelTensorBase sub_input, sub_output;
   if (!outputs[0]->get_sub_tensor(mv, sub_output)) {

--- a/src/ops/flat.cpp
+++ b/src/ops/flat.cpp
@@ -20,7 +20,7 @@
 namespace FlexFlow {
 
 /*static*/
-void Flat::forward_kernel(const float *input_ptr,
+void Flat::forward_kernel(float const *input_ptr,
                           float *output_ptr,
                           size_t num_elements,
                           hipStream_t stream) {
@@ -32,7 +32,7 @@ void Flat::forward_kernel(const float *input_ptr,
 }
 
 /*static*/
-void Flat::forward_kernel_wrapper(const float *input_ptr,
+void Flat::forward_kernel_wrapper(float const *input_ptr,
                                   float *output_ptr,
                                   size_t num_elements) {
   hipStream_t stream;
@@ -42,7 +42,7 @@ void Flat::forward_kernel_wrapper(const float *input_ptr,
 }
 
 void Flat::backward_kernel(float *input_grad_ptr,
-                           const float *output_grad_ptr,
+                           float const *output_grad_ptr,
                            size_t num_elements,
                            hipStream_t stream) {
   float alpha = 1.0f;
@@ -58,7 +58,7 @@ void Flat::backward_kernel(float *input_grad_ptr,
 }
 
 void Flat::backward_kernel_wrapper(float *input_grad_ptr,
-                                   const float *output_grad_ptr,
+                                   float const *output_grad_ptr,
                                    size_t num_elements) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));

--- a/src/ops/flat.cu
+++ b/src/ops/flat.cu
@@ -19,7 +19,7 @@
 namespace FlexFlow {
 
 /*static*/
-void Flat::forward_kernel(const float *input_ptr,
+void Flat::forward_kernel(float const *input_ptr,
                           float *output_ptr,
                           size_t num_elements,
                           cudaStream_t stream) {
@@ -31,7 +31,7 @@ void Flat::forward_kernel(const float *input_ptr,
 }
 
 /*static*/
-void Flat::forward_kernel_wrapper(const float *input_ptr,
+void Flat::forward_kernel_wrapper(float const *input_ptr,
                                   float *output_ptr,
                                   size_t num_elements) {
   cudaStream_t stream;
@@ -41,7 +41,7 @@ void Flat::forward_kernel_wrapper(const float *input_ptr,
 }
 
 void Flat::backward_kernel(float *input_grad_ptr,
-                           const float *output_grad_ptr,
+                           float const *output_grad_ptr,
                            size_t num_elements,
                            cudaStream_t stream) {
   float alpha = 1.0f;
@@ -51,7 +51,7 @@ void Flat::backward_kernel(float *input_grad_ptr,
 }
 
 void Flat::backward_kernel_wrapper(float *input_grad_ptr,
-                                   const float *output_grad_ptr,
+                                   float const *output_grad_ptr,
                                    size_t num_elements) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));

--- a/src/ops/fused.cc
+++ b/src/ops/fused.cc
@@ -246,7 +246,7 @@ void FusedOp::map_output_tensors(FFModel &model) {
 }
 #endif
 
-void FusedOp::init(const FFModel &ff) {
+void FusedOp::init(FFModel const &ff) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
@@ -304,7 +304,7 @@ void FusedOp::init(const FFModel &ff) {
   }
 }
 
-void FusedOp::forward(const FFModel &ff) {
+void FusedOp::forward(FFModel const &ff) {
   // Set iter_config
   iter_config = ff.iter_config;
   ArgumentMap argmap;
@@ -353,7 +353,7 @@ void FusedOp::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void FusedOp::backward(const FFModel &ff) {
+void FusedOp::backward(FFModel const &ff) {
   // Set iter_config
   iter_config = ff.iter_config;
   ArgumentMap argmap;
@@ -421,7 +421,7 @@ void FusedOp::backward(const FFModel &ff) {
 }
 
 bool FusedOp::measure_operator_cost(Simulator *sim,
-                                    const MachineView &mv,
+                                    MachineView const &mv,
                                     CostMetrics &cost_metrics) const {
   // The search should happen before fusion
   assert(false);

--- a/src/ops/fused.cpp
+++ b/src/ops/fused.cpp
@@ -43,17 +43,17 @@ using Legion::Rect;
 using Legion::Runtime;
 using Legion::Task;
 
-OpMeta *FusedOp::init_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+OpMeta *FusedOp::init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
-  const FusedOp *fused = (FusedOp *)task->args;
-  const FusedOpMeta *metas = (FusedOpMeta *)task->local_args;
+  FusedOp const *fused = (FusedOp *)task->args;
+  FusedOpMeta const *metas = (FusedOpMeta *)task->local_args;
   FusedOpMeta *local_meta = new FusedOpMeta();
   memcpy(local_meta, metas, sizeof(FusedOpMeta));
   local_meta->fused_op = (FusedOp *)malloc(sizeof(FusedOp));
   memcpy(static_cast<void *>(local_meta->fused_op),
-         static_cast<const void *>(fused),
+         static_cast<void const *>(fused),
          sizeof(FusedOp));
   return ((OpMeta *)local_meta);
 }
@@ -63,13 +63,13 @@ OpMeta *FusedOp::init_task(const Task *task,
   regions[...](I): weights
   regions[...](I): outputs
 */
-__host__ void FusedOp::forward_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+__host__ void FusedOp::forward_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
   // const FusedOp* fused = (FusedOp*) task->args;
-  const FusedOpMeta *metas = *((FusedOpMeta **)task->local_args);
-  const FusedOp *fused = metas->fused_op;
+  FusedOpMeta const *metas = *((FusedOpMeta **)task->local_args);
+  FusedOp const *fused = metas->fused_op;
   assert(metas->numOperators == fused->numOperators);
   assert(regions.size() == task->regions.size());
   assert((int)regions.size() ==
@@ -77,8 +77,8 @@ __host__ void FusedOp::forward_task(const Task *task,
   Domain input_domain[MAX_NUM_INPUTS];
   Domain weight_domain[MAX_NUM_WEIGHTS];
   Domain output_domain[MAX_NUM_OUTPUTS];
-  const float *input_ptr[MAX_NUM_INPUTS];
-  const float *weight_ptr[MAX_NUM_WEIGHTS];
+  float const *input_ptr[MAX_NUM_INPUTS];
+  float const *weight_ptr[MAX_NUM_WEIGHTS];
   float *output_ptr[MAX_NUM_OUTPUTS];
   assert(fused->numInputs <= MAX_NUM_INPUTS);
   for (int i = 0; i < fused->numInputs; i++) {
@@ -124,8 +124,8 @@ __host__ void FusedOp::forward_task(const Task *task,
     Domain my_id[MAX_NUM_INPUTS];
     Domain my_wd[MAX_NUM_WEIGHTS];
     Domain my_od[MAX_NUM_OUTPUTS];
-    const float *my_ip[MAX_NUM_INPUTS];
-    const float *my_wp[MAX_NUM_WEIGHTS];
+    float const *my_ip[MAX_NUM_INPUTS];
+    float const *my_wp[MAX_NUM_WEIGHTS];
     float *my_op[MAX_NUM_OUTPUTS];
     for (int i = 0; i < fused->op_num_inputs[op]; i++) {
       int my_off = fused->op_input_idx[i + ioff];
@@ -335,13 +335,13 @@ __host__ void FusedOp::forward_task(const Task *task,
   regions[...](I/O): output_grad
 */
 
-__host__ void FusedOp::backward_task(const Task *task,
-                                     const std::vector<PhysicalRegion> &regions,
+__host__ void FusedOp::backward_task(Task const *task,
+                                     std::vector<PhysicalRegion> const &regions,
                                      Context ctx,
                                      Runtime *runtime) {
   // const FusedOp* fused = (FusedOp*) task->args;
-  const FusedOpMeta *metas = *((FusedOpMeta **)task->local_args);
-  const FusedOp *fused = metas->fused_op;
+  FusedOpMeta const *metas = *((FusedOpMeta **)task->local_args);
+  FusedOp const *fused = metas->fused_op;
 
   assert(metas->numOperators == fused->numOperators);
   assert(regions.size() == task->regions.size());
@@ -352,11 +352,11 @@ __host__ void FusedOp::backward_task(const Task *task,
   Domain input_domain[MAX_NUM_INPUTS], input_grad_domain[MAX_NUM_INPUTS];
   Domain weight_domain[MAX_NUM_WEIGHTS], weight_grad_domain[MAX_NUM_WEIGHTS];
   Domain output_domain[MAX_NUM_OUTPUTS], output_grad_domain[MAX_NUM_OUTPUTS];
-  const float *input_ptr[MAX_NUM_INPUTS];
+  float const *input_ptr[MAX_NUM_INPUTS];
   float *input_grad_ptr[MAX_NUM_INPUTS];
-  const float *weight_ptr[MAX_NUM_WEIGHTS];
+  float const *weight_ptr[MAX_NUM_WEIGHTS];
   float *weight_grad_ptr[MAX_NUM_WEIGHTS];
-  const float *output_ptr[MAX_NUM_OUTPUTS];
+  float const *output_ptr[MAX_NUM_OUTPUTS];
   float *output_grad_ptr[MAX_NUM_OUTPUTS];
   int roff = 0;
   assert(fused->numInputs <= MAX_NUM_INPUTS);
@@ -425,9 +425,9 @@ __host__ void FusedOp::backward_task(const Task *task,
   Domain my_id[MAX_NUM_INPUTS], my_grad_id[MAX_NUM_INPUTS];
   Domain my_wd[MAX_NUM_WEIGHTS], my_grad_wd[MAX_NUM_WEIGHTS];
   Domain my_od[MAX_NUM_OUTPUTS], my_grad_od[MAX_NUM_OUTPUTS];
-  const float *my_ip[MAX_NUM_INPUTS];
-  const float *my_wp[MAX_NUM_WEIGHTS];
-  const float *my_op[MAX_NUM_OUTPUTS];
+  float const *my_ip[MAX_NUM_INPUTS];
+  float const *my_wp[MAX_NUM_WEIGHTS];
+  float const *my_op[MAX_NUM_OUTPUTS];
   float *my_grad_ip[MAX_NUM_INPUTS];
   float *my_grad_wp[MAX_NUM_WEIGHTS];
   float *my_grad_op[MAX_NUM_OUTPUTS];

--- a/src/ops/fused.cu
+++ b/src/ops/fused.cu
@@ -42,17 +42,17 @@ using Legion::Rect;
 using Legion::Runtime;
 using Legion::Task;
 
-OpMeta *FusedOp::init_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+OpMeta *FusedOp::init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
-  const FusedOp *fused = (FusedOp *)task->args;
-  const FusedOpMeta *metas = (FusedOpMeta *)task->local_args;
+  FusedOp const *fused = (FusedOp *)task->args;
+  FusedOpMeta const *metas = (FusedOpMeta *)task->local_args;
   FusedOpMeta *local_meta = new FusedOpMeta();
   memcpy(local_meta, metas, sizeof(FusedOpMeta));
   local_meta->fused_op = (FusedOp *)malloc(sizeof(FusedOp));
   memcpy(static_cast<void *>(local_meta->fused_op),
-         static_cast<const void *>(fused),
+         static_cast<void const *>(fused),
          sizeof(FusedOp));
   return ((OpMeta *)local_meta);
 }
@@ -62,13 +62,13 @@ OpMeta *FusedOp::init_task(const Task *task,
   regions[...](I): weights
   regions[...](I): outputs
 */
-__host__ void FusedOp::forward_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+__host__ void FusedOp::forward_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
   // const FusedOp* fused = (FusedOp*) task->args;
-  const FusedOpMeta *metas = *((FusedOpMeta **)task->local_args);
-  const FusedOp *fused = metas->fused_op;
+  FusedOpMeta const *metas = *((FusedOpMeta **)task->local_args);
+  FusedOp const *fused = metas->fused_op;
   assert(metas->numOperators == fused->numOperators);
   assert(regions.size() == task->regions.size());
   assert((int)regions.size() ==
@@ -76,8 +76,8 @@ __host__ void FusedOp::forward_task(const Task *task,
   Domain input_domain[MAX_NUM_INPUTS];
   Domain weight_domain[MAX_NUM_WEIGHTS];
   Domain output_domain[MAX_NUM_OUTPUTS];
-  const float *input_ptr[MAX_NUM_INPUTS];
-  const float *weight_ptr[MAX_NUM_WEIGHTS];
+  float const *input_ptr[MAX_NUM_INPUTS];
+  float const *weight_ptr[MAX_NUM_WEIGHTS];
   float *output_ptr[MAX_NUM_OUTPUTS];
   assert(fused->numInputs <= MAX_NUM_INPUTS);
   for (int i = 0; i < fused->numInputs; i++) {
@@ -123,8 +123,8 @@ __host__ void FusedOp::forward_task(const Task *task,
     Domain my_id[MAX_NUM_INPUTS];
     Domain my_wd[MAX_NUM_WEIGHTS];
     Domain my_od[MAX_NUM_OUTPUTS];
-    const float *my_ip[MAX_NUM_INPUTS];
-    const float *my_wp[MAX_NUM_WEIGHTS];
+    float const *my_ip[MAX_NUM_INPUTS];
+    float const *my_wp[MAX_NUM_WEIGHTS];
     float *my_op[MAX_NUM_OUTPUTS];
     for (int i = 0; i < fused->op_num_inputs[op]; i++) {
       int my_off = fused->op_input_idx[i + ioff];
@@ -334,13 +334,13 @@ __host__ void FusedOp::forward_task(const Task *task,
   regions[...](I/O): output_grad
 */
 
-__host__ void FusedOp::backward_task(const Task *task,
-                                     const std::vector<PhysicalRegion> &regions,
+__host__ void FusedOp::backward_task(Task const *task,
+                                     std::vector<PhysicalRegion> const &regions,
                                      Context ctx,
                                      Runtime *runtime) {
   // const FusedOp* fused = (FusedOp*) task->args;
-  const FusedOpMeta *metas = *((FusedOpMeta **)task->local_args);
-  const FusedOp *fused = metas->fused_op;
+  FusedOpMeta const *metas = *((FusedOpMeta **)task->local_args);
+  FusedOp const *fused = metas->fused_op;
 
   assert(metas->numOperators == fused->numOperators);
   assert(regions.size() == task->regions.size());
@@ -351,11 +351,11 @@ __host__ void FusedOp::backward_task(const Task *task,
   Domain input_domain[MAX_NUM_INPUTS], input_grad_domain[MAX_NUM_INPUTS];
   Domain weight_domain[MAX_NUM_WEIGHTS], weight_grad_domain[MAX_NUM_WEIGHTS];
   Domain output_domain[MAX_NUM_OUTPUTS], output_grad_domain[MAX_NUM_OUTPUTS];
-  const float *input_ptr[MAX_NUM_INPUTS];
+  float const *input_ptr[MAX_NUM_INPUTS];
   float *input_grad_ptr[MAX_NUM_INPUTS];
-  const float *weight_ptr[MAX_NUM_WEIGHTS];
+  float const *weight_ptr[MAX_NUM_WEIGHTS];
   float *weight_grad_ptr[MAX_NUM_WEIGHTS];
-  const float *output_ptr[MAX_NUM_OUTPUTS];
+  float const *output_ptr[MAX_NUM_OUTPUTS];
   float *output_grad_ptr[MAX_NUM_OUTPUTS];
   int roff = 0;
   assert(fused->numInputs <= MAX_NUM_INPUTS);
@@ -424,9 +424,9 @@ __host__ void FusedOp::backward_task(const Task *task,
   Domain my_id[MAX_NUM_INPUTS], my_grad_id[MAX_NUM_INPUTS];
   Domain my_wd[MAX_NUM_WEIGHTS], my_grad_wd[MAX_NUM_WEIGHTS];
   Domain my_od[MAX_NUM_OUTPUTS], my_grad_od[MAX_NUM_OUTPUTS];
-  const float *my_ip[MAX_NUM_INPUTS];
-  const float *my_wp[MAX_NUM_WEIGHTS];
-  const float *my_op[MAX_NUM_OUTPUTS];
+  float const *my_ip[MAX_NUM_INPUTS];
+  float const *my_wp[MAX_NUM_WEIGHTS];
+  float const *my_op[MAX_NUM_OUTPUTS];
   float *my_grad_ip[MAX_NUM_INPUTS];
   float *my_grad_wp[MAX_NUM_WEIGHTS];
   float *my_grad_op[MAX_NUM_OUTPUTS];

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -39,7 +39,7 @@ void FFModel::group_by(const Tensor input,
                        Tensor *outputs,
                        int n,
                        float alpha,
-                       const char *name) {
+                       char const *name) {
   assert(false);
 #ifdef DEADCODE
   Group_by *group_by = new Group_by(*this, input, assign, n, alpha, name);
@@ -54,7 +54,7 @@ Group_by::Group_by(FFModel &model,
                    const ParallelTensor _assign,
                    int _n,
                    float _alpha,
-                   const char *name)
+                   char const *name)
     : Op(model,
          OP_GROUP_BY,
          name,
@@ -82,7 +82,7 @@ Group_by::Group_by(FFModel &model,
   numWeights = 0;
 }
 
-void Group_by::init(const FFModel &ff) {
+void Group_by::init(FFModel const &ff) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
@@ -123,8 +123,8 @@ void Group_by::init(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-OpMeta *Group_by::init_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+OpMeta *Group_by::init_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   Group_by *gb = (Group_by *)task->args;
@@ -134,7 +134,7 @@ OpMeta *Group_by::init_task(const Task *task,
   return m;
 }
 
-void Group_by::forward(const FFModel &ff) {
+void Group_by::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -175,23 +175,23 @@ void Group_by::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Group_by::forward_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void Group_by::forward_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   // Get n, alpha
-  const Group_by *gb = (Group_by *)task->args;
+  Group_by const *gb = (Group_by *)task->args;
   int n = gb->n;
   float alpha = gb->alpha;
 
   assert((int)regions.size() == n + 2);
   assert((int)task->regions.size() == n + 2);
 
-  const GroupByMeta *m = *((GroupByMeta **)task->local_args);
+  GroupByMeta const *m = *((GroupByMeta **)task->local_args);
 
   // get input and assign regions
-  const AccessorRO<float, 2> acc_input(regions[0], FID_DATA);
-  const AccessorRO<int, 2> acc_assign(regions[1], FID_DATA);
+  AccessorRO<float, 2> const acc_input(regions[0], FID_DATA);
+  AccessorRO<int, 2> const acc_assign(regions[1], FID_DATA);
 
   Rect<2> rect_input = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
@@ -231,7 +231,7 @@ void Group_by::forward_task(const Task *task,
                                    data_dim);
 }
 
-void Group_by::backward(const FFModel &ff) {
+void Group_by::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -273,13 +273,13 @@ void Group_by::backward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Group_by::backward_task(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+void Group_by::backward_task(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              Runtime *runtime) {
   // Get n, alpha
-  const GroupByMeta *m = *((GroupByMeta **)task->local_args);
-  const Group_by *gb = (Group_by *)task->args;
+  GroupByMeta const *m = *((GroupByMeta **)task->local_args);
+  Group_by const *gb = (Group_by *)task->args;
   int n = gb->n;
   float alpha = gb->alpha;
 
@@ -287,8 +287,8 @@ void Group_by::backward_task(const Task *task,
   assert((int)task->regions.size() == n + 2);
 
   // get input and assign regions
-  const AccessorWO<float, 2> acc_input_grad(regions[0], FID_DATA);
-  const AccessorRO<int, 2> acc_assign(regions[1], FID_DATA);
+  AccessorWO<float, 2> const acc_input_grad(regions[0], FID_DATA);
+  AccessorRO<int, 2> const acc_assign(regions[1], FID_DATA);
 
   Rect<2> rect_input_grad = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
@@ -329,7 +329,7 @@ void Group_by::backward_task(const Task *task,
 }
 
 bool Group_by::measure_operator_cost(Simulator *sim,
-                                     const MachineView &mv,
+                                     MachineView const &mv,
                                      CostMetrics &cost_metrics) const {
   // TODO: implement
   cost_metrics.forward_time = 0.0f;

--- a/src/ops/group_by.cpp
+++ b/src/ops/group_by.cpp
@@ -26,8 +26,8 @@
 namespace FlexFlow {
 
 __global__ void
-gb_forward_kernel(const float *input,
-                  const int *exp_assign,
+gb_forward_kernel(float const *input,
+                  int const *exp_assign,
                   float **outputs,
                   int n,       // num experts
                   int k,       // chosen experts
@@ -66,7 +66,7 @@ gb_forward_kernel(const float *input,
 
 __global__ void
 gb_backward_kernel(float *input_grad,
-                   const int *exp_assign,
+                   int const *exp_assign,
                    float **output_grads,
                    int n,       // num experts
                    int k,       // chosen experts
@@ -106,9 +106,9 @@ gb_backward_kernel(float *input_grad,
 
 /*static*/
 void Group_by::forward_kernel_wrapper(
-    const GroupByMeta *m,
-    const float *input,
-    const int *exp_assign,
+    GroupByMeta const *m,
+    float const *input,
+    int const *exp_assign,
     float **outputs,
     int n,       // num experts
     int k,       // chosen experts
@@ -139,9 +139,9 @@ void Group_by::forward_kernel_wrapper(
 }
 
 void Group_by::backward_kernel_wrapper(
-    const GroupByMeta *m,
+    GroupByMeta const *m,
     float *input_grad,
-    const int *exp_assign,
+    int const *exp_assign,
     float **output_grads,
     int n,       // num experts
     int k,       // chosen experts

--- a/src/ops/group_by.cu
+++ b/src/ops/group_by.cu
@@ -25,8 +25,8 @@
 namespace FlexFlow {
 
 __global__ void
-gb_forward_kernel(const float *input,
-                  const int *exp_assign,
+gb_forward_kernel(float const *input,
+                  int const *exp_assign,
                   float **outputs,
                   int n,       // num experts
                   int k,       // chosen experts
@@ -65,7 +65,7 @@ gb_forward_kernel(const float *input,
 
 __global__ void
 gb_backward_kernel(float *input_grad,
-                   const int *exp_assign,
+                   int const *exp_assign,
                    float **output_grads,
                    int n,       // num experts
                    int k,       // chosen experts
@@ -105,9 +105,9 @@ gb_backward_kernel(float *input_grad,
 
 /*static*/
 void Group_by::forward_kernel_wrapper(
-    const GroupByMeta *m,
-    const float *input,
-    const int *exp_assign,
+    GroupByMeta const *m,
+    float const *input,
+    int const *exp_assign,
     float **outputs,
     int n,       // num experts
     int k,       // chosen experts
@@ -130,9 +130,9 @@ void Group_by::forward_kernel_wrapper(
 }
 
 void Group_by::backward_kernel_wrapper(
-    const GroupByMeta *m,
+    GroupByMeta const *m,
     float *input_grad,
-    const int *exp_assign,
+    int const *exp_assign,
     float **output_grads,
     int n,       // num experts
     int k,       // chosen experts

--- a/src/ops/layer_norm.cpp
+++ b/src/ops/layer_norm.cpp
@@ -24,7 +24,7 @@ constexpr int kCUDABlockReduceNumThreads = 512;
 constexpr int kCUDANumThreads = 256;
 constexpr int kColwiseReduceTileSize = 32;
 
-LayerNormMeta::LayerNormMeta(FFHandler handle, const LayerNorm *ln)
+LayerNormMeta::LayerNormMeta(FFHandler handle, LayerNorm const *ln)
     : OpMeta(handle) {
   elementwise_affine = ln->elementwise_affine;
   effective_batch_size = ln->effective_batch_size;
@@ -61,8 +61,8 @@ template <typename T> __inline__ __device__ T WarpReduceSum(T val) {
 }
 
 template <typename T> __inline__ __device__ T BlockReduceSum(T val, T *shared) {
-  const int lid = threadIdx.x % C10_WARP_SIZE;
-  const int wid = threadIdx.x / C10_WARP_SIZE;
+  int const lid = threadIdx.x % C10_WARP_SIZE;
+  int const wid = threadIdx.x / C10_WARP_SIZE;
   val = WarpReduceSum(val);
   __syncthreads();
   if (lid == 0) {
@@ -124,7 +124,7 @@ __global__ void LayerNormForwardCUDAKernel(int64_t N,
 
 /*static*/
 template <typename T>
-void LayerNorm::forward_kernel(const LayerNormMeta *m,
+void LayerNorm::forward_kernel(LayerNormMeta const *m,
                                const T *in_ptr,
                                T *out_ptr,
                                T *gamma_ptr,
@@ -156,7 +156,7 @@ void LayerNorm::forward_kernel(const LayerNormMeta *m,
 
 /*static*/
 template <typename T>
-void LayerNorm::forward_kernel_wrapper(const LayerNormMeta *m,
+void LayerNorm::forward_kernel_wrapper(LayerNormMeta const *m,
                                        const T *in_ptr,
                                        T *out_ptr,
                                        T *gamma_ptr,
@@ -346,7 +346,7 @@ __global__ void GammaBetaBackwardCUDAKernel(int64_t M,
 
 /*static*/
 template <typename T>
-void LayerNorm::backward_kernel(const LayerNormMeta *m,
+void LayerNorm::backward_kernel(LayerNormMeta const *m,
                                 const T *output_grad_ptr,
                                 const T *input_ptr,
                                 T *input_grad_ptr,
@@ -422,7 +422,7 @@ void LayerNorm::backward_kernel(const LayerNormMeta *m,
 
 /*static*/
 template <typename T>
-void LayerNorm::backward_kernel_wrapper(const LayerNormMeta *m,
+void LayerNorm::backward_kernel_wrapper(LayerNormMeta const *m,
                                         const T *output_grad_ptr,
                                         const T *input_ptr,
                                         T *input_grad_ptr,
@@ -441,17 +441,17 @@ void LayerNorm::backward_kernel_wrapper(const LayerNormMeta *m,
                                     stream);
 }
 
-template void LayerNorm::forward_kernel_wrapper<float>(const LayerNormMeta *m,
-                                                       const float *in_ptr,
+template void LayerNorm::forward_kernel_wrapper<float>(LayerNormMeta const *m,
+                                                       float const *in_ptr,
                                                        float *out_ptr,
                                                        float *gamma_ptr,
                                                        float *beta_ptr);
 template void
-LayerNorm::backward_kernel_wrapper<float>(const LayerNormMeta *m,
-                                          const float *output_grad_ptr,
-                                          const float *input_ptr,
+LayerNorm::backward_kernel_wrapper<float>(LayerNormMeta const *m,
+                                          float const *output_grad_ptr,
+                                          float const *input_ptr,
                                           float *input_grad_ptr,
-                                          const float *gamma_ptr,
+                                          float const *gamma_ptr,
                                           float *gamma_grad_ptr,
                                           float *beta_grad_ptr);
 

--- a/src/ops/layer_norm.cu
+++ b/src/ops/layer_norm.cu
@@ -23,7 +23,7 @@ constexpr int kCUDABlockReduceNumThreads = 512;
 constexpr int kCUDANumThreads = 256;
 constexpr int kColwiseReduceTileSize = 32;
 
-LayerNormMeta::LayerNormMeta(FFHandler handle, const LayerNorm *ln)
+LayerNormMeta::LayerNormMeta(FFHandler handle, LayerNorm const *ln)
     : OpMeta(handle) {
   elementwise_affine = ln->elementwise_affine;
   effective_batch_size = ln->effective_batch_size;
@@ -58,8 +58,8 @@ template <typename T> __inline__ __device__ T WarpReduceSum(T val) {
 }
 
 template <typename T> __inline__ __device__ T BlockReduceSum(T val, T *shared) {
-  const int lid = threadIdx.x % C10_WARP_SIZE;
-  const int wid = threadIdx.x / C10_WARP_SIZE;
+  int const lid = threadIdx.x % C10_WARP_SIZE;
+  int const wid = threadIdx.x / C10_WARP_SIZE;
   val = WarpReduceSum(val);
   __syncthreads();
   if (lid == 0) {
@@ -121,7 +121,7 @@ __global__ void LayerNormForwardCUDAKernel(int64_t N,
 
 /*static*/
 template <typename T>
-void LayerNorm::forward_kernel(const LayerNormMeta *m,
+void LayerNorm::forward_kernel(LayerNormMeta const *m,
                                const T *in_ptr,
                                T *out_ptr,
                                T *gamma_ptr,
@@ -143,7 +143,7 @@ void LayerNorm::forward_kernel(const LayerNormMeta *m,
 
 /*static*/
 template <typename T>
-void LayerNorm::forward_kernel_wrapper(const LayerNormMeta *m,
+void LayerNorm::forward_kernel_wrapper(LayerNormMeta const *m,
                                        const T *in_ptr,
                                        T *out_ptr,
                                        T *gamma_ptr,
@@ -333,7 +333,7 @@ __global__ void GammaBetaBackwardCUDAKernel(int64_t M,
 
 /*static*/
 template <typename T>
-void LayerNorm::backward_kernel(const LayerNormMeta *m,
+void LayerNorm::backward_kernel(LayerNormMeta const *m,
                                 const T *output_grad_ptr,
                                 const T *input_ptr,
                                 T *input_grad_ptr,
@@ -389,7 +389,7 @@ void LayerNorm::backward_kernel(const LayerNormMeta *m,
 
 /*static*/
 template <typename T>
-void LayerNorm::backward_kernel_wrapper(const LayerNormMeta *m,
+void LayerNorm::backward_kernel_wrapper(LayerNormMeta const *m,
                                         const T *output_grad_ptr,
                                         const T *input_ptr,
                                         T *input_grad_ptr,
@@ -408,17 +408,17 @@ void LayerNorm::backward_kernel_wrapper(const LayerNormMeta *m,
                                     stream);
 }
 
-template void LayerNorm::forward_kernel_wrapper<float>(const LayerNormMeta *m,
-                                                       const float *in_ptr,
+template void LayerNorm::forward_kernel_wrapper<float>(LayerNormMeta const *m,
+                                                       float const *in_ptr,
                                                        float *out_ptr,
                                                        float *gamma_ptr,
                                                        float *beta_ptr);
 template void
-LayerNorm::backward_kernel_wrapper<float>(const LayerNormMeta *m,
-                                          const float *output_grad_ptr,
-                                          const float *input_ptr,
+LayerNorm::backward_kernel_wrapper<float>(LayerNormMeta const *m,
+                                          float const *output_grad_ptr,
+                                          float const *input_ptr,
                                           float *input_grad_ptr,
-                                          const float *gamma_ptr,
+                                          float const *gamma_ptr,
                                           float *gamma_grad_ptr,
                                           float *beta_grad_ptr);
 

--- a/src/ops/linear.cpp
+++ b/src/ops/linear.cpp
@@ -45,11 +45,11 @@ void Linear::init_kernel(LinearMeta *m, int batch_size, int channel) {
 }
 
 /*static*/
-void Linear::forward_kernel(const LinearMeta *m,
-                            const void *input_ptr,
+void Linear::forward_kernel(LinearMeta const *m,
+                            void const *input_ptr,
                             void *output_ptr,
-                            const void *weight_ptr,
-                            const void *bias_ptr,
+                            void const *weight_ptr,
+                            void const *bias_ptr,
                             int in_dim,
                             int out_dim,
                             int batch_size,
@@ -137,11 +137,11 @@ void Linear::forward_kernel(const LinearMeta *m,
 }
 
 /*static*/
-void Linear::forward_kernel_wrapper(const LinearMeta *m,
-                                    const void *input_ptr,
+void Linear::forward_kernel_wrapper(LinearMeta const *m,
+                                    void const *input_ptr,
                                     void *output_ptr,
-                                    const void *weight_ptr,
-                                    const void *bias_ptr,
+                                    void const *weight_ptr,
+                                    void const *bias_ptr,
                                     int in_dim,
                                     int out_dim,
                                     int batch_size) {
@@ -182,12 +182,12 @@ void Linear::forward_kernel_wrapper(const LinearMeta *m,
 }
 
 /*static*/
-void Linear::backward_kernel(const LinearMeta *m,
-                             const void *input_ptr,
+void Linear::backward_kernel(LinearMeta const *m,
+                             void const *input_ptr,
                              void *input_grad_ptr,
-                             const void *output_ptr,
+                             void const *output_ptr,
                              void *output_grad_ptr,
-                             const void *kernel_ptr,
+                             void const *kernel_ptr,
                              void *kernel_grad_ptr,
                              void *bias_grad_ptr,
                              int in_dim,
@@ -289,12 +289,12 @@ void Linear::backward_kernel(const LinearMeta *m,
 }
 
 /*static*/
-void Linear::backward_kernel_wrapper(const LinearMeta *m,
-                                     const void *input_ptr,
+void Linear::backward_kernel_wrapper(LinearMeta const *m,
+                                     void const *input_ptr,
                                      void *input_grad_ptr,
-                                     const void *output_ptr,
+                                     void const *output_ptr,
                                      void *output_grad_ptr,
-                                     const void *kernel_ptr,
+                                     void const *kernel_ptr,
                                      void *kernel_grad_ptr,
                                      void *bias_grad_ptr,
                                      int in_dim,
@@ -365,7 +365,7 @@ LinearMeta::LinearMeta(FFHandler handler, int batch_size) : OpMeta(handler) {
                       dram_one_ptr,
                       sizeof(float) * batch_size,
                       hipMemcpyHostToDevice));
-  one_ptr = (const float *)fb_one_ptr;
+  one_ptr = (float const *)fb_one_ptr;
   // Allocate descriptors
   checkCUDNN(miopenCreateActivationDescriptor(&actiDesc));
   checkCUDNN(miopenCreateTensorDescriptor(&outputTensor));

--- a/src/ops/linear.cu
+++ b/src/ops/linear.cu
@@ -46,11 +46,11 @@ void Linear::init_kernel(LinearMeta *m, int batch_size, int channel) {
 }
 
 /*static*/
-void Linear::forward_kernel(const LinearMeta *m,
-                            const void *input_ptr,
+void Linear::forward_kernel(LinearMeta const *m,
+                            void const *input_ptr,
                             void *output_ptr,
-                            const void *weight_ptr,
-                            const void *bias_ptr,
+                            void const *weight_ptr,
+                            void const *bias_ptr,
                             int in_dim,
                             int out_dim,
                             int batch_size,
@@ -131,11 +131,11 @@ void Linear::forward_kernel(const LinearMeta *m,
 }
 
 /*static*/
-void Linear::forward_kernel_wrapper(const LinearMeta *m,
-                                    const void *input_ptr,
+void Linear::forward_kernel_wrapper(LinearMeta const *m,
+                                    void const *input_ptr,
                                     void *output_ptr,
-                                    const void *weight_ptr,
-                                    const void *bias_ptr,
+                                    void const *weight_ptr,
+                                    void const *bias_ptr,
                                     int in_dim,
                                     int out_dim,
                                     int batch_size) {
@@ -176,12 +176,12 @@ void Linear::forward_kernel_wrapper(const LinearMeta *m,
 }
 
 /*static*/
-void Linear::backward_kernel(const LinearMeta *m,
-                             const void *input_ptr,
+void Linear::backward_kernel(LinearMeta const *m,
+                             void const *input_ptr,
                              void *input_grad_ptr,
-                             const void *output_ptr,
+                             void const *output_ptr,
                              void *output_grad_ptr,
-                             const void *kernel_ptr,
+                             void const *kernel_ptr,
                              void *kernel_grad_ptr,
                              void *bias_grad_ptr,
                              int in_dim,
@@ -283,12 +283,12 @@ void Linear::backward_kernel(const LinearMeta *m,
 }
 
 /*static*/
-void Linear::backward_kernel_wrapper(const LinearMeta *m,
-                                     const void *input_ptr,
+void Linear::backward_kernel_wrapper(LinearMeta const *m,
+                                     void const *input_ptr,
                                      void *input_grad_ptr,
-                                     const void *output_ptr,
+                                     void const *output_ptr,
                                      void *output_grad_ptr,
-                                     const void *kernel_ptr,
+                                     void const *kernel_ptr,
                                      void *kernel_grad_ptr,
                                      void *bias_grad_ptr,
                                      int in_dim,
@@ -359,7 +359,7 @@ LinearMeta::LinearMeta(FFHandler handler, int batch_size) : OpMeta(handler) {
                        dram_one_ptr,
                        sizeof(float) * batch_size,
                        cudaMemcpyHostToDevice));
-  one_ptr = (const float *)fb_one_ptr;
+  one_ptr = (float const *)fb_one_ptr;
   // Allocate descriptors
   checkCUDNN(cudnnCreateActivationDescriptor(&actiDesc));
   checkCUDNN(cudnnCreateTensorDescriptor(&outputTensor));

--- a/src/ops/mean.cc
+++ b/src/ops/mean.cc
@@ -33,9 +33,9 @@ using Legion::TaskArgument;
 using Legion::TaskLauncher;
 
 Tensor FFModel::mean(const Tensor input,
-                     const std::vector<int> &dims,
+                     std::vector<int> const &dims,
                      bool keepdims,
-                     const char *name) {
+                     char const *name) {
   assert(false);
 #ifdef DEADCODE
   Mean *mean = new Mean(*this, input, dims, keepdims, name);
@@ -46,9 +46,9 @@ Tensor FFModel::mean(const Tensor input,
 
 Mean::Mean(FFModel &model,
            const ParallelTensor input,
-           const std::vector<int> &reduce_dims,
+           std::vector<int> const &reduce_dims,
            bool keepdims,
-           const char *name)
+           char const *name)
     : Op(model,
          OP_REDUCE_MEAN,
          name,
@@ -61,7 +61,7 @@ Mean::Mean(FFModel &model,
   int num_dim = 0;
   for (int i = 0; i < inputs[0]->num_dims; i++) {
     bool reduce_this_dim = false;
-    for (const auto &dim : reduce_dims)
+    for (auto const &dim : reduce_dims)
       if (inputs[0]->num_dims - 1 - dim == i)
         reduce_this_dim = true;
     if (!reduce_this_dim) {
@@ -77,33 +77,33 @@ Mean::Mean(FFModel &model,
       num_dim, dims, input->data_type, this);
 }
 
-void Mean::init(const FFModel &ff) {}
+void Mean::init(FFModel const &ff) {}
 
-OpMeta *Mean::init_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+OpMeta *Mean::init_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {
-  FFHandler handler = *((const FFHandler *)task->local_args);
+  FFHandler handler = *((FFHandler const *)task->local_args);
   OpMeta *m = new OpMeta(handler);
   return m;
 }
 
-void Mean::forward(const FFModel &ff) {}
+void Mean::forward(FFModel const &ff) {}
 
-void Mean::forward_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+void Mean::forward_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {}
 
-void Mean::backward(const FFModel &ff) {}
+void Mean::backward(FFModel const &ff) {}
 
-void Mean::backward_task(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+void Mean::backward_task(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime) {}
 
 bool Mean::measure_operator_cost(Simulator *sim,
-                                 const MachineView &mv,
+                                 MachineView const &mv,
                                  CostMetrics &cost_metrics) const {
   return false;
 }

--- a/src/ops/noop.cc
+++ b/src/ops/noop.cc
@@ -41,7 +41,7 @@ using Legion::TaskLauncher;
 NoOp::NoOp(FFModel &model,
            OperatorType _type,
            const ParallelTensor _output,
-           const char *_name)
+           char const *_name)
     : Op(model, _type, _name, 0 /*inputs*/, 0 /*weights*/, 1 /*outputs*/),
       input_tensor_guid(0) {
   // NOOP takes one input and has one output
@@ -59,7 +59,7 @@ NoOp::NoOp(FFModel &model,
            OperatorType _type,
            size_t _input_tensor_guid,
            const ParallelTensor _output,
-           const char *_name)
+           char const *_name)
     : Op(model, _type, _name, 0 /*inputs*/, 0 /*weights*/, 1 /*outputs*/),
       input_tensor_guid(_input_tensor_guid) {
   // NOOP takes one input and has one output
@@ -73,16 +73,16 @@ NoOp::NoOp(FFModel &model,
   outputs[0]->owner_idx = 0;
 }
 
-OpMeta *NoOp::init_task(const Task *task,
-                        const std::vector<PhysicalRegion> &regions,
+OpMeta *NoOp::init_task(Task const *task,
+                        std::vector<PhysicalRegion> const &regions,
                         Context ctx,
                         Runtime *runtime) {
-  FFHandler handle = *((const FFHandler *)task->local_args);
+  FFHandler handle = *((FFHandler const *)task->local_args);
   OpMeta *m = new OpMeta(handle);
   return m;
 }
 
-void NoOp::init(const FFModel &ff) {
+void NoOp::init(FFModel const &ff) {
   parallel_is = outputs[0]->parallel_is;
   // For OP_INPUT, initialize tensor to zero
   if (op_type == OP_INPUT) {
@@ -135,12 +135,12 @@ void NoOp::init(const FFModel &ff) {
   }
 }
 
-void NoOp::forward(const FFModel &ff) {}
+void NoOp::forward(FFModel const &ff) {}
 
-void NoOp::backward(const FFModel &ff) {}
+void NoOp::backward(FFModel const &ff) {}
 
 bool NoOp::measure_operator_cost(Simulator *sim,
-                                 const MachineView &mv,
+                                 MachineView const &mv,
                                  CostMetrics &cost_metrics) const {
   cost_metrics.forward_time = 0.0f;
   cost_metrics.backward_time = 0.0f;
@@ -162,7 +162,7 @@ using PCG::Node;
 Node FFModel::get_or_create_noop_node(const ParallelTensor input) {
   size_t hash = input->get_owner_independent_hash();
   NoOp *noop = NULL;
-  const auto &it = cached_noop_ops.find(hash);
+  auto const &it = cached_noop_ops.find(hash);
   if (it != cached_noop_ops.end()) {
     noop = it->second;
   } else {
@@ -176,10 +176,10 @@ Node FFModel::get_or_create_noop_node(const ParallelTensor input) {
 }
 
 Node FFModel::get_or_create_input_node(
-    const ParallelTensorShape &output_shape) {
+    ParallelTensorShape const &output_shape) {
   size_t hash = std::hash<ParallelTensorShape>{}(output_shape);
   NoOp *input = NULL;
-  const auto &it = cached_input_ops.find(hash);
+  auto const &it = cached_input_ops.find(hash);
   if (it != cached_input_ops.end()) {
     input = it->second;
   } else {

--- a/src/ops/pool_2d.cc
+++ b/src/ops/pool_2d.cc
@@ -73,8 +73,8 @@ Tensor FFModel::pool2d(const Tensor input,
 
 Op *Pool2D::create_operator_from_layer(
     FFModel &model,
-    const Layer *layer,
-    const std::vector<ParallelTensor> &inputs) {
+    Layer const *layer,
+    std::vector<ParallelTensor> const &inputs) {
   long long value;
   layer->get_int_property("kernel_h", value);
   int kernelH = value;
@@ -133,7 +133,7 @@ bool Pool2DParams::is_valid(ParallelTensorShape const &input) const {
 }
 
 using PCG::Node;
-bool operator==(const Pool2DParams &lhs, const Pool2DParams &rhs) {
+bool operator==(Pool2DParams const &lhs, Pool2DParams const &rhs) {
   return lhs.kernel_h == rhs.kernel_h && lhs.kernel_w == rhs.kernel_w &&
          lhs.stride_h == rhs.stride_h && lhs.stride_w == rhs.stride_w &&
          lhs.padding_h == rhs.padding_h && lhs.padding_w == rhs.padding_w &&
@@ -243,7 +243,7 @@ Pool2D::Pool2D(FFModel &model,
                int _padding_w,
                PoolType _type,
                ActiMode _activation,
-               const char *name)
+               char const *name)
     : Op(model,
          OP_POOL2D,
          name,
@@ -268,9 +268,9 @@ Pool2D::Pool2D(FFModel &model,
 }
 
 Pool2D::Pool2D(FFModel &model,
-               const Pool2DParams &params,
+               Pool2DParams const &params,
                const ParallelTensor input,
-               const char *name)
+               char const *name)
     : Pool2D(model,
              input,
              params.kernel_h,
@@ -283,7 +283,7 @@ Pool2D::Pool2D(FFModel &model,
              params.activation,
              name) {}
 
-void Pool2D::init(const FFModel &ff) {
+void Pool2D::init(FFModel const &ff) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
@@ -319,14 +319,14 @@ void Pool2D::init(const FFModel &ff) {
   regions[0]: input
   regions[1]: output
 */
-OpMeta *Pool2D::init_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+OpMeta *Pool2D::init_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
-  const Pool2D *pool = (Pool2D *)task->args;
-  FFHandler handle = *((const FFHandler *)task->local_args);
+  Pool2D const *pool = (Pool2D *)task->args;
+  FFHandler handle = *((FFHandler const *)task->local_args);
   Pool2DMeta *m = new Pool2DMeta(handle);
   m->profiling = pool->profiling;
   std::strcpy(m->op_name, pool->name);
@@ -383,7 +383,7 @@ OpMeta *Pool2D::init_task(const Task *task,
   return m;
 }
 
-void Pool2D::forward(const FFModel &ff) {
+void Pool2D::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -416,14 +416,14 @@ void Pool2D::forward(const FFModel &ff) {
   regions[0](I): input
   regions[1](O): output
 */
-void Pool2D::forward_task(const Task *task,
-                          const std::vector<PhysicalRegion> &regions,
+void Pool2D::forward_task(Task const *task,
+                          std::vector<PhysicalRegion> const &regions,
                           Context ctx,
                           Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
   // const Pool2D* pool = (Pool2D*) task->args;
-  const Pool2DMeta *m = *((Pool2DMeta **)task->local_args);
+  Pool2DMeta const *m = *((Pool2DMeta **)task->local_args);
   TensorAccessorR<float, Pool2DInput::NUMDIM> acc_input(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   TensorAccessorW<float, Pool2DOutput::NUMDIM> acc_output(regions[1],
@@ -436,7 +436,7 @@ void Pool2D::forward_task(const Task *task,
   Pool2D::forward_kernel_wrapper(m, acc_input.ptr, acc_output.ptr);
 }
 
-void Pool2D::backward(const FFModel &ff) {
+void Pool2D::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -487,14 +487,14 @@ void Pool2D::backward(const FFModel &ff) {
   regions[2](I): output
   regions[3](I): output_grad
 */
-void Pool2D::backward_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+void Pool2D::backward_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
   assert(regions.size() == 4);
   assert(task->regions.size() == 4);
   // const Pool2D* pool = (Pool2D*) task->args;
-  const Pool2DMeta *m = *((Pool2DMeta **)task->local_args);
+  Pool2DMeta const *m = *((Pool2DMeta **)task->local_args);
   TensorAccessorR<float, Pool2DInput::NUMDIM> acc_input(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   TensorAccessorW<float, Pool2DInput::NUMDIM> acc_input_grad(
@@ -528,7 +528,7 @@ void Pool2D::serialize(Legion::Serializer &sez) const {
 }
 
 bool Pool2D::measure_operator_cost(Simulator *sim,
-                                   const MachineView &mv,
+                                   MachineView const &mv,
                                    CostMetrics &cost_metrics) const {
   ParallelTensorBase sub_output, sub_input;
   if (!outputs[0]->get_sub_tensor(mv, sub_output))
@@ -663,7 +663,7 @@ Node Pool2D::deserialize(FFModel &ff,
 
 namespace std {
 size_t hash<FlexFlow::Pool2DParams>::operator()(
-    const FlexFlow::Pool2DParams &params) const {
+    FlexFlow::Pool2DParams const &params) const {
   size_t key = 0;
   hash_combine(key, params.kernel_h);
   hash_combine(key, params.kernel_w);

--- a/src/ops/pool_2d.cpp
+++ b/src/ops/pool_2d.cpp
@@ -28,7 +28,7 @@ using Legion::Rect;
 using Legion::Runtime;
 using Legion::Task;
 
-void Pool2D::init_kernel(const Pool2D *pool,
+void Pool2D::init_kernel(Pool2D const *pool,
                          Pool2DMeta *m,
                          int input_w,
                          int input_h,
@@ -71,8 +71,8 @@ void Pool2D::init_kernel(const Pool2D *pool,
 }
 
 /*static*/
-void Pool2D::forward_kernel(const Pool2DMeta *m,
-                            const float *input_ptr,
+void Pool2D::forward_kernel(Pool2DMeta const *m,
+                            float const *input_ptr,
                             float *output_ptr,
                             hipStream_t stream) {
   checkCUDNN(miopenSetStream(m->handle.dnn, stream));
@@ -92,8 +92,8 @@ void Pool2D::forward_kernel(const Pool2DMeta *m,
 }
 
 /*static*/
-void Pool2D::forward_kernel_wrapper(const Pool2DMeta *m,
-                                    const float *input_ptr,
+void Pool2D::forward_kernel_wrapper(Pool2DMeta const *m,
+                                    float const *input_ptr,
                                     float *output_ptr) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -120,11 +120,11 @@ void Pool2D::forward_kernel_wrapper(const Pool2DMeta *m,
 }
 
 /*static*/
-void Pool2D::backward_kernel(const Pool2DMeta *m,
-                             const float *input_ptr,
+void Pool2D::backward_kernel(Pool2DMeta const *m,
+                             float const *input_ptr,
                              float *input_grad_ptr,
-                             const float *output_ptr,
-                             const float *output_grad_ptr,
+                             float const *output_ptr,
+                             float const *output_grad_ptr,
                              hipStream_t stream) {
   checkCUDNN(miopenSetStream(m->handle.dnn, stream));
 
@@ -146,11 +146,11 @@ void Pool2D::backward_kernel(const Pool2DMeta *m,
 }
 
 /*static*/
-void Pool2D::backward_kernel_wrapper(const Pool2DMeta *m,
-                                     const float *input_ptr,
+void Pool2D::backward_kernel_wrapper(Pool2DMeta const *m,
+                                     float const *input_ptr,
                                      float *input_grad_ptr,
-                                     const float *output_ptr,
-                                     const float *output_grad_ptr) {
+                                     float const *output_ptr,
+                                     float const *output_grad_ptr) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
 

--- a/src/ops/pool_2d.cu
+++ b/src/ops/pool_2d.cu
@@ -19,7 +19,7 @@
 namespace FlexFlow {
 
 /*static*/
-void Pool2D::init_kernel(const Pool2D *pool,
+void Pool2D::init_kernel(Pool2D const *pool,
                          Pool2DMeta *m,
                          int input_w,
                          int input_h,
@@ -68,8 +68,8 @@ void Pool2D::init_kernel(const Pool2D *pool,
 }
 
 /*static*/
-void Pool2D::forward_kernel(const Pool2DMeta *m,
-                            const float *input_ptr,
+void Pool2D::forward_kernel(Pool2DMeta const *m,
+                            float const *input_ptr,
                             float *output_ptr,
                             cudaStream_t stream) {
   checkCUDNN(cudnnSetStream(m->handle.dnn, stream));
@@ -86,8 +86,8 @@ void Pool2D::forward_kernel(const Pool2DMeta *m,
 }
 
 /*static*/
-void Pool2D::forward_kernel_wrapper(const Pool2DMeta *m,
-                                    const float *input_ptr,
+void Pool2D::forward_kernel_wrapper(Pool2DMeta const *m,
+                                    float const *input_ptr,
                                     float *output_ptr) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
@@ -114,11 +114,11 @@ void Pool2D::forward_kernel_wrapper(const Pool2DMeta *m,
 }
 
 /*static*/
-void Pool2D::backward_kernel(const Pool2DMeta *m,
-                             const float *input_ptr,
+void Pool2D::backward_kernel(Pool2DMeta const *m,
+                             float const *input_ptr,
                              float *input_grad_ptr,
-                             const float *output_ptr,
-                             const float *output_grad_ptr,
+                             float const *output_ptr,
+                             float const *output_grad_ptr,
                              cudaStream_t stream) {
   checkCUDNN(cudnnSetStream(m->handle.dnn, stream));
 
@@ -138,11 +138,11 @@ void Pool2D::backward_kernel(const Pool2DMeta *m,
 }
 
 /*static*/
-void Pool2D::backward_kernel_wrapper(const Pool2DMeta *m,
-                                     const float *input_ptr,
+void Pool2D::backward_kernel_wrapper(Pool2DMeta const *m,
+                                     float const *input_ptr,
                                      float *input_grad_ptr,
-                                     const float *output_ptr,
-                                     const float *output_grad_ptr) {
+                                     float const *output_ptr,
+                                     float const *output_grad_ptr) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
 

--- a/src/ops/reshape.cpp
+++ b/src/ops/reshape.cpp
@@ -73,61 +73,61 @@ void Reshape::backward_kernel_wrapper(T *input_grad_ptr,
       input_grad_ptr, output_grad_ptr, num_elements, stream);
 }
 
-template void Reshape::forward_kernel<float>(const float *input_ptr,
+template void Reshape::forward_kernel<float>(float const *input_ptr,
                                              float *output_ptr,
                                              size_t num_elements,
                                              hipStream_t stream);
-template void Reshape::forward_kernel<double>(const double *input_ptr,
+template void Reshape::forward_kernel<double>(double const *input_ptr,
                                               double *output_ptr,
                                               size_t num_elements,
                                               hipStream_t stream);
-template void Reshape::forward_kernel<int32_t>(const int32_t *input_ptr,
+template void Reshape::forward_kernel<int32_t>(int32_t const *input_ptr,
                                                int32_t *output_ptr,
                                                size_t num_elements,
                                                hipStream_t stream);
-template void Reshape::forward_kernel<int64_t>(const int64_t *input_ptr,
+template void Reshape::forward_kernel<int64_t>(int64_t const *input_ptr,
                                                int64_t *output_ptr,
                                                size_t num_elements,
                                                hipStream_t stream);
 
-template void Reshape::forward_kernel_wrapper<float>(const float *input_ptr,
+template void Reshape::forward_kernel_wrapper<float>(float const *input_ptr,
                                                      float *output_ptr,
                                                      size_t volume);
-template void Reshape::forward_kernel_wrapper<double>(const double *input_ptr,
+template void Reshape::forward_kernel_wrapper<double>(double const *input_ptr,
                                                       double *output_ptr,
                                                       size_t volume);
-template void Reshape::forward_kernel_wrapper<int32_t>(const int32_t *input_ptr,
+template void Reshape::forward_kernel_wrapper<int32_t>(int32_t const *input_ptr,
                                                        int32_t *output_ptr,
                                                        size_t volume);
-template void Reshape::forward_kernel_wrapper<int64_t>(const int64_t *input_ptr,
+template void Reshape::forward_kernel_wrapper<int64_t>(int64_t const *input_ptr,
                                                        int64_t *output_ptr,
                                                        size_t volume);
 
 template void Reshape::backward_kernel<float>(float *input_grad_ptr,
-                                              const float *output_grad_ptr,
+                                              float const *output_grad_ptr,
                                               size_t num_elements,
                                               hipStream_t stream);
 template void Reshape::backward_kernel<double>(double *input_grad_ptr,
-                                               const double *output_grad_ptr,
+                                               double const *output_grad_ptr,
                                                size_t num_elements,
                                                hipStream_t stream);
 template void Reshape::backward_kernel<int32_t>(int32_t *input_grad_ptr,
-                                                const int32_t *output_grad_ptr,
+                                                int32_t const *output_grad_ptr,
                                                 size_t num_elements,
                                                 hipStream_t stream);
 template void Reshape::backward_kernel<int64_t>(int64_t *input_grad_ptr,
-                                                const int64_t *output_grad_ptr,
+                                                int64_t const *output_grad_ptr,
                                                 size_t num_elements,
                                                 hipStream_t stream);
 
 template void Reshape::backward_kernel_wrapper<float>(float *in_grad_ptr,
-                                                      const float *out_grad_ptr,
+                                                      float const *out_grad_ptr,
                                                       size_t volume);
 template void Reshape::backward_kernel_wrapper<double>(
-    double *in_grad_ptr, const double *out_grad_ptr, size_t volume);
+    double *in_grad_ptr, double const *out_grad_ptr, size_t volume);
 template void Reshape::backward_kernel_wrapper<int32_t>(
-    int32_t *in_grad_ptr, const int32_t *out_grad_ptr, size_t volume);
+    int32_t *in_grad_ptr, int32_t const *out_grad_ptr, size_t volume);
 template void Reshape::backward_kernel_wrapper<int64_t>(
-    int64_t *in_grad_ptr, const int64_t *out_grad_ptr, size_t volume);
+    int64_t *in_grad_ptr, int64_t const *out_grad_ptr, size_t volume);
 
 }; // namespace FlexFlow

--- a/src/ops/reshape.cu
+++ b/src/ops/reshape.cu
@@ -66,61 +66,61 @@ void Reshape::backward_kernel_wrapper(T *input_grad_ptr,
       input_grad_ptr, output_grad_ptr, num_elements, stream);
 }
 
-template void Reshape::forward_kernel<float>(const float *input_ptr,
+template void Reshape::forward_kernel<float>(float const *input_ptr,
                                              float *output_ptr,
                                              size_t num_elements,
                                              cudaStream_t stream);
-template void Reshape::forward_kernel<double>(const double *input_ptr,
+template void Reshape::forward_kernel<double>(double const *input_ptr,
                                               double *output_ptr,
                                               size_t num_elements,
                                               cudaStream_t stream);
-template void Reshape::forward_kernel<int32_t>(const int32_t *input_ptr,
+template void Reshape::forward_kernel<int32_t>(int32_t const *input_ptr,
                                                int32_t *output_ptr,
                                                size_t num_elements,
                                                cudaStream_t stream);
-template void Reshape::forward_kernel<int64_t>(const int64_t *input_ptr,
+template void Reshape::forward_kernel<int64_t>(int64_t const *input_ptr,
                                                int64_t *output_ptr,
                                                size_t num_elements,
                                                cudaStream_t stream);
 
-template void Reshape::forward_kernel_wrapper<float>(const float *input_ptr,
+template void Reshape::forward_kernel_wrapper<float>(float const *input_ptr,
                                                      float *output_ptr,
                                                      size_t volume);
-template void Reshape::forward_kernel_wrapper<double>(const double *input_ptr,
+template void Reshape::forward_kernel_wrapper<double>(double const *input_ptr,
                                                       double *output_ptr,
                                                       size_t volume);
-template void Reshape::forward_kernel_wrapper<int32_t>(const int32_t *input_ptr,
+template void Reshape::forward_kernel_wrapper<int32_t>(int32_t const *input_ptr,
                                                        int32_t *output_ptr,
                                                        size_t volume);
-template void Reshape::forward_kernel_wrapper<int64_t>(const int64_t *input_ptr,
+template void Reshape::forward_kernel_wrapper<int64_t>(int64_t const *input_ptr,
                                                        int64_t *output_ptr,
                                                        size_t volume);
 
 template void Reshape::backward_kernel<float>(float *input_grad_ptr,
-                                              const float *output_grad_ptr,
+                                              float const *output_grad_ptr,
                                               size_t num_elements,
                                               cudaStream_t stream);
 template void Reshape::backward_kernel<double>(double *input_grad_ptr,
-                                               const double *output_grad_ptr,
+                                               double const *output_grad_ptr,
                                                size_t num_elements,
                                                cudaStream_t stream);
 template void Reshape::backward_kernel<int32_t>(int32_t *input_grad_ptr,
-                                                const int32_t *output_grad_ptr,
+                                                int32_t const *output_grad_ptr,
                                                 size_t num_elements,
                                                 cudaStream_t stream);
 template void Reshape::backward_kernel<int64_t>(int64_t *input_grad_ptr,
-                                                const int64_t *output_grad_ptr,
+                                                int64_t const *output_grad_ptr,
                                                 size_t num_elements,
                                                 cudaStream_t stream);
 
 template void Reshape::backward_kernel_wrapper<float>(float *in_grad_ptr,
-                                                      const float *out_grad_ptr,
+                                                      float const *out_grad_ptr,
                                                       size_t volume);
 template void Reshape::backward_kernel_wrapper<double>(
-    double *in_grad_ptr, const double *out_grad_ptr, size_t volume);
+    double *in_grad_ptr, double const *out_grad_ptr, size_t volume);
 template void Reshape::backward_kernel_wrapper<int32_t>(
-    int32_t *in_grad_ptr, const int32_t *out_grad_ptr, size_t volume);
+    int32_t *in_grad_ptr, int32_t const *out_grad_ptr, size_t volume);
 template void Reshape::backward_kernel_wrapper<int64_t>(
-    int64_t *in_grad_ptr, const int64_t *out_grad_ptr, size_t volume);
+    int64_t *in_grad_ptr, int64_t const *out_grad_ptr, size_t volume);
 
 }; // namespace FlexFlow

--- a/src/ops/reverse.cc
+++ b/src/ops/reverse.cc
@@ -32,7 +32,7 @@ using Legion::Task;
 using Legion::TaskArgument;
 using Legion::TaskLauncher;
 
-Tensor FFModel::reverse(const Tensor input, int axis, const char *name) {
+Tensor FFModel::reverse(const Tensor input, int axis, char const *name) {
   assert(false);
 #ifdef DEADCODE
   Reverse *reverse = new Reverse(*this, input, axis, name);
@@ -44,7 +44,7 @@ Tensor FFModel::reverse(const Tensor input, int axis, const char *name) {
 Reverse::Reverse(FFModel &model,
                  const ParallelTensor input,
                  int _axis,
-                 const char *name)
+                 char const *name)
     : Op(model,
          OP_REVERSE,
          name,
@@ -110,7 +110,7 @@ void Reverse::create_input_partition_with_dim(FFModel &model) {
 }
 #endif
 
-void Reverse::init(const FFModel &ff) {
+void Reverse::init(FFModel const &ff) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
@@ -139,14 +139,14 @@ void Reverse::init(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-OpMeta *Reverse::init_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+OpMeta *Reverse::init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
   return NULL;
 }
 
-void Reverse::forward(const FFModel &ff) {
+void Reverse::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -173,19 +173,19 @@ void Reverse::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Reverse::forward_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+void Reverse::forward_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
-  const Reverse *reverse = (const Reverse *)task->args;
+  Reverse const *reverse = (Reverse const *)task->args;
   Domain in_domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   Domain out_domain = runtime->get_index_space_domain(
       ctx, task->regions[1].region.get_index_space());
   assert(out_domain == in_domain);
-  const float *in_ptr = helperGetTensorPointerRO<float>(
+  float const *in_ptr = helperGetTensorPointerRO<float>(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   float *out_ptr = helperGetTensorPointerWO<float>(
       regions[1], task->regions[1], FID_DATA, ctx, runtime);
@@ -209,7 +209,7 @@ void Reverse::forward_task(const Task *task,
                                   output_size);
 }
 
-void Reverse::backward(const FFModel &ff) {
+void Reverse::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -238,19 +238,19 @@ void Reverse::backward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Reverse::backward_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void Reverse::backward_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
-  const Reverse *reverse = (const Reverse *)task->args;
+  Reverse const *reverse = (Reverse const *)task->args;
   Domain out_grad_domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   Domain in_grad_domain = runtime->get_index_space_domain(
       ctx, task->regions[1].region.get_index_space());
   assert(out_grad_domain == in_grad_domain);
-  const float *out_grad_ptr = helperGetTensorPointerRO<float>(
+  float const *out_grad_ptr = helperGetTensorPointerRO<float>(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   float *in_grad_ptr = helperGetTensorPointerRW<float>(
       regions[1], task->regions[1], FID_DATA, ctx, runtime);
@@ -275,7 +275,7 @@ void Reverse::backward_task(const Task *task,
 }
 
 bool Reverse::measure_operator_cost(Simulator *sim,
-                                    const MachineView &mv,
+                                    MachineView const &mv,
                                     CostMetrics &cost_metrics) const {
   ParallelTensorBase sub_input, sub_output;
   if (!outputs[0]->get_sub_tensor(mv, sub_output)) {

--- a/src/ops/reverse.cpp
+++ b/src/ops/reverse.cpp
@@ -21,7 +21,7 @@ namespace FlexFlow {
 // declare Legion names
 using Legion::coord_t;
 
-__global__ void reverse_forward_kernel(const float *in_ptr,
+__global__ void reverse_forward_kernel(float const *in_ptr,
                                        float *out_ptr,
                                        coord_t num_out_blks,
                                        coord_t reverse_dim_size,

--- a/src/ops/reverse.cu
+++ b/src/ops/reverse.cu
@@ -20,7 +20,7 @@ namespace FlexFlow {
 // declare Legion names
 using Legion::coord_t;
 
-__global__ void reverse_forward_kernel(const float *in_ptr,
+__global__ void reverse_forward_kernel(float const *in_ptr,
                                        float *out_ptr,
                                        coord_t num_out_blks,
                                        coord_t reverse_dim_size,

--- a/src/ops/softmax.cpp
+++ b/src/ops/softmax.cpp
@@ -23,8 +23,8 @@ namespace FlexFlow {
 using Legion::Domain;
 
 SoftmaxMeta::SoftmaxMeta(FFHandler handler,
-                         const Softmax *softmax,
-                         const Domain &input_domain)
+                         Softmax const *softmax,
+                         Domain const &input_domain)
     : OpMeta(handler) {
   checkCUDNN(miopenCreateTensorDescriptor(&inputTensor));
   checkCUDNN(cudnnSetTensorDescriptorFromDomain(inputTensor, input_domain));
@@ -94,7 +94,7 @@ void Softmax::backward_kernel(float *input_grad_ptr,
 }
 
 /* static */
-void Softmax::backward_kernel_wrapper(const SoftmaxMeta *m,
+void Softmax::backward_kernel_wrapper(SoftmaxMeta const *m,
                                       float *input_grad_ptr,
                                       float const *output_grad_ptr,
                                       size_t num_elements) {

--- a/src/ops/softmax.cu
+++ b/src/ops/softmax.cu
@@ -22,8 +22,8 @@ namespace FlexFlow {
 using Legion::Domain;
 
 SoftmaxMeta::SoftmaxMeta(FFHandler handler,
-                         const Softmax *softmax,
-                         const Domain &input_domain)
+                         Softmax const *softmax,
+                         Domain const &input_domain)
     : OpMeta(handler) {
   checkCUDNN(cudnnCreateTensorDescriptor(&inputTensor));
   checkCUDNN(cudnnSetTensorDescriptorFromDomain(inputTensor, input_domain));
@@ -93,7 +93,7 @@ void Softmax::backward_kernel(float *input_grad_ptr,
 }
 
 /* static */
-void Softmax::backward_kernel_wrapper(const SoftmaxMeta *m,
+void Softmax::backward_kernel_wrapper(SoftmaxMeta const *m,
                                       float *input_grad_ptr,
                                       float const *output_grad_ptr,
                                       size_t num_elements) {

--- a/src/ops/topk.cpp
+++ b/src/ops/topk.cpp
@@ -75,8 +75,8 @@ template <HeapType heapType,
           typename T>
 struct IndexedHeap {
   typedef typename Data<T>::Entry Entry;
-  const Data<T> data;
-  __device__ IndexedHeap(const Data<T> &d) : data(d) {}
+  Data<T> const data;
+  __device__ IndexedHeap(Data<T> const &d) : data(d) {}
 
   __device__ bool is_above(int left, int right) {
     T left_value = data.get_value(left);
@@ -95,7 +95,7 @@ struct IndexedHeap {
     }
   }
 
-  __device__ void assign(int i, const Entry &entry) { data[i] = entry; }
+  __device__ void assign(int i, Entry const &entry) { data[i] = entry; }
 
   __device__ void push_up(int i) {
     int child = i;
@@ -121,8 +121,8 @@ struct IndexedHeap {
   // MAX-HEAPIFY in Cormen
   __device__ void push_down(int node, int k) {
     while (true) {
-      const int left = 2 * node + 1;
-      const int right = left + 1;
+      int const left = 2 * node + 1;
+      int const right = left + 1;
       int smallest = node;
       if (left < k && is_above(left, smallest)) {
         smallest = left;
@@ -162,12 +162,12 @@ struct IndexedHeap {
     }
   }
 
-  __device__ void replace_root(const Entry &entry, int k) {
+  __device__ void replace_root(Entry const &entry, int k) {
     data[0] = entry;
     push_root_down(k);
   }
 
-  __device__ const Entry &root() { return data[0]; }
+  __device__ Entry const &root() { return data[0]; }
 };
 
 template <HeapType heapType,
@@ -246,7 +246,7 @@ __device__ void mergeShards(int num_shards,
   // of the sorted blocks.
   // If k > num_shards, we can initialize a min-heap with the top element from
   // each sorted block.
-  const int heap_size = k < num_shards ? k : num_shards;
+  int const heap_size = k < num_shards ? k : num_shards;
 
   // Min-heap part.
   {
@@ -262,8 +262,8 @@ __device__ void mergeShards(int num_shards,
 
     // Now perform top k with the remaining shards (if num_shards > heap_size).
     for (int shard = heap_size; shard < num_shards; shard++) {
-      const auto entry = entries[shard];
-      const auto root = min_heap.root();
+      auto const entry = entries[shard];
+      auto const root = min_heap.root();
       if (entry.value < root.value) {
         continue;
       }
@@ -288,9 +288,9 @@ __device__ void mergeShards(int num_shards,
 
     // Now extract the minimum k-1 times.
     // k is treated specially.
-    const int last_k = k - 1;
+    int const last_k = k - 1;
     for (int rank = 0; rank < last_k; rank++) {
-      const Entry<T> &max_element = max_heap.root();
+      Entry<T> const &max_element = max_heap.root();
       top_k_values[rank] = max_element.value;
       int shard_index = max_element.index;
       top_k_indices[rank] = entries[shard_index].index;
@@ -302,7 +302,7 @@ __device__ void mergeShards(int num_shards,
     }
 
     // rank == last_k.
-    const Entry<T> &max_element = max_heap.root();
+    Entry<T> const &max_element = max_heap.root();
     top_k_values[last_k] = max_element.value;
     int shard_index = max_element.index;
     top_k_indices[last_k] = entries[shard_index].index;
@@ -318,16 +318,16 @@ __global__ void topk_forward_kernel(const T *__restrict__ input,
                                     T *__restrict__ output,
                                     int *__restrict__ indices) {
   __shared__ char shared_memory[48 << 10];
-  const int batch_index = blockIdx.x;
+  int const batch_index = blockIdx.x;
   const T *batch_input = input + batch_index * length;
-  const int thread_index = threadIdx.x;
-  const int thread_count = blockDim.x;
+  int const thread_index = threadIdx.x;
+  int const thread_count = blockDim.x;
   Entry<T> *shared_entries = (Entry<T> *)shared_memory;
   heapTopK<T, StridedData>(
       batch_input, length, k, shared_entries, true, thread_index, thread_count);
   __syncthreads();
   if (thread_index == 0) {
-    const int offset = batch_index * k;
+    int const offset = batch_index * k;
     auto batch_output = output + offset;
     auto batch_indices = indices + offset;
     Entry<T> *top_k_heap = shared_entries + thread_count * k;
@@ -341,8 +341,8 @@ __global__ void topk_forward_kernel(const T *__restrict__ input,
 }
 
 /*static*/
-void TopK::forward_kernel(const TopKMeta *m,
-                          const float *input_ptr,
+void TopK::forward_kernel(TopKMeta const *m,
+                          float const *input_ptr,
                           float *output_ptr,
                           int *indices_ptr,
                           size_t batch_size,
@@ -355,7 +355,7 @@ void TopK::forward_kernel(const TopKMeta *m,
   int num_shards = 0;
   {
     constexpr auto shared_memory_size = 48 << 10;
-    const auto heap_size = k * sizeof(Entry<float>);
+    auto const heap_size = k * sizeof(Entry<float>);
     // shared_memory_size = (num_shards + 1) * heap_size <=>
     num_shards = shared_memory_size / heap_size - 1;
     assert(num_shards > 0);
@@ -383,8 +383,8 @@ void TopK::forward_kernel(const TopKMeta *m,
 }
 
 /*static*/
-void TopK::forward_kernel_wrapper(const TopKMeta *m,
-                                  const float *input_ptr,
+void TopK::forward_kernel_wrapper(TopKMeta const *m,
+                                  float const *input_ptr,
                                   float *output_ptr,
                                   int *indices_ptr,
                                   size_t batch_size,
@@ -423,7 +423,7 @@ void TopK::forward_kernel_wrapper(const TopKMeta *m,
 
 template <typename T>
 __global__ void topk_backward_kernel(const T *__restrict__ value_grad_ptr,
-                                     const int *__restrict__ indices_ptr,
+                                     int const *__restrict__ indices_ptr,
                                      T *__restrict__ in_grad_ptr,
                                      size_t batch_size,
                                      int length,
@@ -437,9 +437,9 @@ __global__ void topk_backward_kernel(const T *__restrict__ value_grad_ptr,
 }
 
 /*static*/
-void TopK::backward_kernel(const TopKMeta *m,
-                           const float *value_grad_ptr,
-                           const int *indices_ptr,
+void TopK::backward_kernel(TopKMeta const *m,
+                           float const *value_grad_ptr,
+                           int const *indices_ptr,
                            float *in_grad_ptr,
                            size_t batch_size,
                            int length,
@@ -459,9 +459,9 @@ void TopK::backward_kernel(const TopKMeta *m,
 }
 
 /*static*/
-void TopK::backward_kernel_wrapper(const TopKMeta *m,
-                                   const float *value_grad_ptr,
-                                   const int *indices_ptr,
+void TopK::backward_kernel_wrapper(TopKMeta const *m,
+                                   float const *value_grad_ptr,
+                                   int const *indices_ptr,
                                    float *in_grad_ptr,
                                    size_t batch_size,
                                    int length,

--- a/src/ops/transpose.cc
+++ b/src/ops/transpose.cc
@@ -33,8 +33,8 @@ using Legion::TaskArgument;
 using Legion::TaskLauncher;
 
 Tensor FFModel::transpose(const Tensor input,
-                          const std::vector<int> &perm,
-                          const char *name) {
+                          std::vector<int> const &perm,
+                          char const *name) {
   assert(false);
 #ifdef DEADCODE
   Transpose *transpose = new Transpose(*this, input, perm, name);
@@ -45,8 +45,8 @@ Tensor FFModel::transpose(const Tensor input,
 
 Transpose::Transpose(FFModel &model,
                      const ParallelTensor input,
-                     const std::vector<int> &_perm,
-                     const char *name)
+                     std::vector<int> const &_perm,
+                     char const *name)
     : Op(model,
          OP_TRANSPOSE,
          name,
@@ -66,7 +66,7 @@ Transpose::Transpose(FFModel &model,
       numdim, dims, input->data_type, this);
 }
 
-void Transpose::init(const FFModel &ff) {
+void Transpose::init(FFModel const &ff) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
@@ -110,14 +110,14 @@ void Transpose::init_meta(TransposeMeta *m,
     m->perm[i] = this->perm[i];
 }
 
-OpMeta *Transpose::init_task(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+OpMeta *Transpose::init_task(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
-  const Transpose *transpose = (const Transpose *)task->args;
-  FFHandler handle = *((const FFHandler *)task->local_args);
+  Transpose const *transpose = (Transpose const *)task->args;
+  FFHandler handle = *((FFHandler const *)task->local_args);
   Domain in_domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   Domain out_domain = runtime->get_index_space_domain(
@@ -129,7 +129,7 @@ OpMeta *Transpose::init_task(const Task *task,
   return m;
 }
 
-void Transpose::forward(const FFModel &ff) {
+void Transpose::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -157,14 +157,14 @@ void Transpose::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Transpose::forward_task(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+void Transpose::forward_task(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
   // const Transpose* transpose = (const Transpose*) task->args;
-  const TransposeMeta *m = *((TransposeMeta **)task->local_args);
+  TransposeMeta const *m = *((TransposeMeta **)task->local_args);
   Domain in_domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   Domain out_domain = runtime->get_index_space_domain(
@@ -173,7 +173,7 @@ void Transpose::forward_task(const Task *task,
     assert(out_domain.hi()[i] == in_domain.hi()[m->perm[i]]);
     assert(out_domain.lo()[i] == in_domain.lo()[m->perm[i]]);
   }
-  const float *in_ptr = helperGetTensorPointerRO<float>(
+  float const *in_ptr = helperGetTensorPointerRO<float>(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   float *out_ptr = helperGetTensorPointerWO<float>(
       regions[1], task->regions[1], FID_DATA, ctx, runtime);
@@ -181,7 +181,7 @@ void Transpose::forward_task(const Task *task,
   Transpose::forward_kernel_wrapper(m, in_ptr, out_ptr, in_domain, out_domain);
 }
 
-void Transpose::backward(const FFModel &ff) {
+void Transpose::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -211,14 +211,14 @@ void Transpose::backward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Transpose::backward_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void Transpose::backward_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
   // const Transpose* transpose = (const Transpose*) task->args;
-  const TransposeMeta *m = *((TransposeMeta **)task->local_args);
+  TransposeMeta const *m = *((TransposeMeta **)task->local_args);
   Domain out_grad_domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   Domain in_grad_domain = runtime->get_index_space_domain(
@@ -227,7 +227,7 @@ void Transpose::backward_task(const Task *task,
     assert(out_grad_domain.hi()[i] == in_grad_domain.hi()[m->perm[i]]);
     assert(out_grad_domain.lo()[i] == in_grad_domain.lo()[m->perm[i]]);
   }
-  const float *out_grad_ptr = helperGetTensorPointerRO<float>(
+  float const *out_grad_ptr = helperGetTensorPointerRO<float>(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   float *in_grad_ptr = helperGetTensorPointerRW<float>(
       regions[1], task->regions[1], FID_DATA, ctx, runtime);
@@ -237,7 +237,7 @@ void Transpose::backward_task(const Task *task,
 }
 
 bool Transpose::measure_operator_cost(Simulator *sim,
-                                      const MachineView &mv,
+                                      MachineView const &mv,
                                       CostMetrics &cost_metrics) const {
   ParallelTensorBase sub_input, sub_output;
   if (!outputs[0]->get_sub_tensor(mv, sub_output)) {

--- a/src/ops/transpose.cpp
+++ b/src/ops/transpose.cpp
@@ -29,10 +29,10 @@ struct TransposeStrides {
 };
 
 __global__ void transpose_simple_kernel(coord_t volume,
-                                        const float *in_ptr,
+                                        float const *in_ptr,
                                         float *out_ptr,
                                         const TransposeStrides info,
-                                        const float beta) {
+                                        float const beta) {
   CUDA_KERNEL_LOOP(o_idx, volume) {
     coord_t i_idx = 0;
     coord_t t = o_idx;
@@ -46,8 +46,8 @@ __global__ void transpose_simple_kernel(coord_t volume,
 }
 
 /*static*/
-void Transpose::forward_kernel(const TransposeMeta *m,
-                               const float *input_ptr,
+void Transpose::forward_kernel(TransposeMeta const *m,
+                               float const *input_ptr,
                                float *output_ptr,
                                Domain in_domain,
                                Domain out_domain,
@@ -75,8 +75,8 @@ void Transpose::forward_kernel(const TransposeMeta *m,
 }
 
 /*static*/
-void Transpose::forward_kernel_wrapper(const TransposeMeta *m,
-                                       const float *input_ptr,
+void Transpose::forward_kernel_wrapper(TransposeMeta const *m,
+                                       float const *input_ptr,
                                        float *output_ptr,
                                        Domain in_domain,
                                        Domain out_domain) {
@@ -87,9 +87,9 @@ void Transpose::forward_kernel_wrapper(const TransposeMeta *m,
 }
 
 /*static*/
-void Transpose::backward_kernel(const TransposeMeta *m,
+void Transpose::backward_kernel(TransposeMeta const *m,
                                 float *input_grad_ptr,
-                                const float *output_grad_ptr,
+                                float const *output_grad_ptr,
                                 Domain in_grad_domain,
                                 Domain out_grad_domain,
                                 hipStream_t stream) {
@@ -116,9 +116,9 @@ void Transpose::backward_kernel(const TransposeMeta *m,
 }
 
 /*static*/
-void Transpose::backward_kernel_wrapper(const TransposeMeta *m,
+void Transpose::backward_kernel_wrapper(TransposeMeta const *m,
                                         float *input_grad_ptr,
-                                        const float *output_grad_ptr,
+                                        float const *output_grad_ptr,
                                         Domain in_grad_domain,
                                         Domain out_grad_domain) {
   hipStream_t stream;

--- a/src/ops/transpose.cu
+++ b/src/ops/transpose.cu
@@ -28,10 +28,10 @@ struct TransposeStrides {
 };
 
 __global__ void transpose_simple_kernel(coord_t volume,
-                                        const float *in_ptr,
+                                        float const *in_ptr,
                                         float *out_ptr,
                                         const TransposeStrides info,
-                                        const float beta) {
+                                        float const beta) {
   CUDA_KERNEL_LOOP(o_idx, volume) {
     coord_t i_idx = 0;
     coord_t t = o_idx;
@@ -45,8 +45,8 @@ __global__ void transpose_simple_kernel(coord_t volume,
 }
 
 /*static*/
-void Transpose::forward_kernel(const TransposeMeta *m,
-                               const float *input_ptr,
+void Transpose::forward_kernel(TransposeMeta const *m,
+                               float const *input_ptr,
                                float *output_ptr,
                                Domain in_domain,
                                Domain out_domain,
@@ -69,8 +69,8 @@ void Transpose::forward_kernel(const TransposeMeta *m,
 }
 
 /*static*/
-void Transpose::forward_kernel_wrapper(const TransposeMeta *m,
-                                       const float *input_ptr,
+void Transpose::forward_kernel_wrapper(TransposeMeta const *m,
+                                       float const *input_ptr,
                                        float *output_ptr,
                                        Domain in_domain,
                                        Domain out_domain) {
@@ -81,9 +81,9 @@ void Transpose::forward_kernel_wrapper(const TransposeMeta *m,
 }
 
 /*static*/
-void Transpose::backward_kernel(const TransposeMeta *m,
+void Transpose::backward_kernel(TransposeMeta const *m,
                                 float *input_grad_ptr,
-                                const float *output_grad_ptr,
+                                float const *output_grad_ptr,
                                 Domain in_grad_domain,
                                 Domain out_grad_domain,
                                 cudaStream_t stream) {
@@ -108,9 +108,9 @@ void Transpose::backward_kernel(const TransposeMeta *m,
 }
 
 /*static*/
-void Transpose::backward_kernel_wrapper(const TransposeMeta *m,
+void Transpose::backward_kernel_wrapper(TransposeMeta const *m,
                                         float *input_grad_ptr,
-                                        const float *output_grad_ptr,
+                                        float const *output_grad_ptr,
                                         Domain in_grad_domain,
                                         Domain out_grad_domain) {
   cudaStream_t stream;

--- a/src/parallel_ops/combine.cc
+++ b/src/parallel_ops/combine.cc
@@ -40,7 +40,7 @@ using Legion::TaskLauncher;
 ParallelTensor FFModel::combine(const ParallelTensor input,
                                 int combine_legion_dim,
                                 int combine_degree,
-                                const char *name) {
+                                char const *name) {
   assert(false);
 #ifdef DEADCODE
   Combine *comb =
@@ -54,7 +54,7 @@ Combine::Combine(FFModel &model,
                  const ParallelTensor _input,
                  int _combine_legion_dim,
                  int _combine_degree,
-                 const char *name)
+                 char const *name)
     : ParallelOp(model, OP_COMBINE, name, _input),
       combine_dim(_combine_legion_dim), combine_degree(_combine_degree) {
   int numdim = _input->num_dims;
@@ -72,8 +72,8 @@ Combine::Combine(FFModel &model,
   // outputs[0]->print("Combine::output");
 }
 
-OpMeta *Combine::init_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+OpMeta *Combine::init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
   Combine *rep = (Combine *)task->args;
@@ -83,7 +83,7 @@ OpMeta *Combine::init_task(const Task *task,
   return nullptr;
 }
 
-void Combine::init(const FFModel &ff) {
+void Combine::init(FFModel const &ff) {
   parallel_is = outputs[0]->parallel_is;
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
@@ -126,7 +126,7 @@ void Combine::create_input_partition(FFModel &ff) {
                                output_grad_lp);
 }
 
-void Combine::forward(const FFModel &ff) {
+void Combine::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -154,7 +154,7 @@ void Combine::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Combine::backward(const FFModel &ff) {
+void Combine::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -186,7 +186,7 @@ void Combine::backward(const FFModel &ff) {
 }
 
 bool Combine::measure_operator_cost(Simulator *sim,
-                                    const MachineView &mv,
+                                    MachineView const &mv,
                                     CostMetrics &cost_metrics) const {
   // TODO: to be implemented
   cost_metrics.forward_time = 0.05f;
@@ -236,7 +236,7 @@ Node FFModel::get_or_create_combine_node(const ParallelTensor input,
   size_t hash = input->get_owner_independent_hash();
   hash = hash * 31 + std::hash<int>()(combine_dim);
   hash = hash * 31 + std::hash<int>()(combine_degree);
-  const auto &it = cached_combine_ops.find(hash);
+  auto const &it = cached_combine_ops.find(hash);
   Combine *combine = NULL;
   if (it != cached_combine_ops.end()) {
     combine = it->second;
@@ -266,8 +266,8 @@ tl::optional<RecordFormatter> Combine::as_dot() const {
 }
 
 /*static*/
-void Combine::forward_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+void Combine::forward_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
   assert(regions.size() == 2);
@@ -287,8 +287,8 @@ void Combine::forward_task(const Task *task,
 }
 
 template <typename DT>
-void Combine::forward_task_with_type(const Task *task,
-                                     const std::vector<PhysicalRegion> &regions,
+void Combine::forward_task_with_type(Task const *task,
+                                     std::vector<PhysicalRegion> const &regions,
                                      Context ctx,
                                      Runtime *runtime) {
   Domain input_domain = runtime->get_index_space_domain(
@@ -305,8 +305,8 @@ void Combine::forward_task_with_type(const Task *task,
   forward_kernel<DT>(input_ptr, output_ptr, output_domain.get_volume());
 }
 
-void Combine::backward_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void Combine::backward_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   assert(regions.size() == 2);
@@ -327,8 +327,8 @@ void Combine::backward_task(const Task *task,
 
 template <typename DT>
 void Combine::backward_task_with_type(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   Domain output_grad_domain = runtime->get_index_space_domain(

--- a/src/parallel_ops/combine.cpp
+++ b/src/parallel_ops/combine.cpp
@@ -50,28 +50,28 @@ void Combine::backward_kernel(const T *output_grad_ptr,
 
 CombineMeta::CombineMeta(FFHandler handler) : OpMeta(handler) {}
 
-template void Combine::forward_kernel<float>(const float *input_ptr,
+template void Combine::forward_kernel<float>(float const *input_ptr,
                                              float *output_ptr,
                                              size_t num_elements);
-template void Combine::forward_kernel<double>(const double *input_ptr,
+template void Combine::forward_kernel<double>(double const *input_ptr,
                                               double *output_ptr,
                                               size_t num_elements);
-template void Combine::forward_kernel<int32_t>(const int32_t *input_ptr,
+template void Combine::forward_kernel<int32_t>(int32_t const *input_ptr,
                                                int32_t *output_ptr,
                                                size_t num_elements);
-template void Combine::forward_kernel<int64_t>(const int64_t *input_ptr,
+template void Combine::forward_kernel<int64_t>(int64_t const *input_ptr,
                                                int64_t *output_ptr,
                                                size_t num_elements);
-template void Combine::backward_kernel<float>(const float *output_grad_ptr,
+template void Combine::backward_kernel<float>(float const *output_grad_ptr,
                                               float *input_grad_ptr,
                                               size_t num_elements);
-template void Combine::backward_kernel<double>(const double *output_grad_ptr,
+template void Combine::backward_kernel<double>(double const *output_grad_ptr,
                                                double *input_grad_ptr,
                                                size_t num_elements);
-template void Combine::backward_kernel<int32_t>(const int32_t *output_grad_ptr,
+template void Combine::backward_kernel<int32_t>(int32_t const *output_grad_ptr,
                                                 int32_t *input_grad_ptr,
                                                 size_t num_elements);
-template void Combine::backward_kernel<int64_t>(const int64_t *output_grad_ptr,
+template void Combine::backward_kernel<int64_t>(int64_t const *output_grad_ptr,
                                                 int64_t *input_grad_ptr,
                                                 size_t num_elements);
 

--- a/src/parallel_ops/combine.cu
+++ b/src/parallel_ops/combine.cu
@@ -43,28 +43,28 @@ void Combine::backward_kernel(const T *output_grad_ptr,
 
 CombineMeta::CombineMeta(FFHandler handler) : OpMeta(handler) {}
 
-template void Combine::forward_kernel<float>(const float *input_ptr,
+template void Combine::forward_kernel<float>(float const *input_ptr,
                                              float *output_ptr,
                                              size_t num_elements);
-template void Combine::forward_kernel<double>(const double *input_ptr,
+template void Combine::forward_kernel<double>(double const *input_ptr,
                                               double *output_ptr,
                                               size_t num_elements);
-template void Combine::forward_kernel<int32_t>(const int32_t *input_ptr,
+template void Combine::forward_kernel<int32_t>(int32_t const *input_ptr,
                                                int32_t *output_ptr,
                                                size_t num_elements);
-template void Combine::forward_kernel<int64_t>(const int64_t *input_ptr,
+template void Combine::forward_kernel<int64_t>(int64_t const *input_ptr,
                                                int64_t *output_ptr,
                                                size_t num_elements);
-template void Combine::backward_kernel<float>(const float *output_grad_ptr,
+template void Combine::backward_kernel<float>(float const *output_grad_ptr,
                                               float *input_grad_ptr,
                                               size_t num_elements);
-template void Combine::backward_kernel<double>(const double *output_grad_ptr,
+template void Combine::backward_kernel<double>(double const *output_grad_ptr,
                                                double *input_grad_ptr,
                                                size_t num_elements);
-template void Combine::backward_kernel<int32_t>(const int32_t *output_grad_ptr,
+template void Combine::backward_kernel<int32_t>(int32_t const *output_grad_ptr,
                                                 int32_t *input_grad_ptr,
                                                 size_t num_elements);
-template void Combine::backward_kernel<int64_t>(const int64_t *output_grad_ptr,
+template void Combine::backward_kernel<int64_t>(int64_t const *output_grad_ptr,
                                                 int64_t *input_grad_ptr,
                                                 size_t num_elements);
 

--- a/src/parallel_ops/fused_parallel_op.cc
+++ b/src/parallel_ops/fused_parallel_op.cc
@@ -40,7 +40,7 @@ using Legion::TaskLauncher;
 FusedParallelOp::FusedParallelOp(
     FFModel &model,
     const ParallelTensor _input,
-    const std::vector<ParallelOpInfo> &_parallel_ops)
+    std::vector<ParallelOpInfo> const &_parallel_ops)
     : ParallelOp(model, OP_FUSED_PARALLEL, NULL, _input), num_parallel_ops(0) {
   set_parallel_ops(_parallel_ops);
   assert(check_no_redundant_parallel_ops());
@@ -83,7 +83,7 @@ FusedParallelOp::FusedParallelOp(
 }
 
 void FusedParallelOp::set_parallel_ops(
-    const std::vector<ParallelOpInfo> &_parallel_ops) {
+    std::vector<ParallelOpInfo> const &_parallel_ops) {
   for (size_t i = 0; i < _parallel_ops.size(); i++)
     parallel_ops[num_parallel_ops++] = _parallel_ops[i];
 }
@@ -114,7 +114,7 @@ bool FusedParallelOp::check_no_redundant_parallel_ops(void) const {
   return true;
 }
 
-void FusedParallelOp::init(const FFModel &ff) {
+void FusedParallelOp::init(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -155,7 +155,7 @@ void FusedParallelOp::create_input_partition(FFModel &ff) {
                                output_grad_lp);
 }
 
-void FusedParallelOp::forward(const FFModel &ff) {
+void FusedParallelOp::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -181,7 +181,7 @@ void FusedParallelOp::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void FusedParallelOp::backward(const FFModel &ff) {
+void FusedParallelOp::backward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -212,7 +212,7 @@ void FusedParallelOp::backward(const FFModel &ff) {
 }
 
 bool FusedParallelOp::measure_operator_cost(Simulator *sim,
-                                            const MachineView &pc,
+                                            MachineView const &pc,
                                             CostMetrics &cost_metrics) const {
   cost_metrics.forward_time = 0.1f;
   cost_metrics.backward_time = 0.1f;
@@ -242,7 +242,7 @@ size_t FusedParallelOp::get_params_hash() const {
 using PCG::Node;
 Node FFModel::get_or_create_fused_parallel_node(
     const ParallelTensor input,
-    const std::vector<ParallelOpInfo> &parallel_ops) {
+    std::vector<ParallelOpInfo> const &parallel_ops) {
   // Try to combine _parallel_ops's dimensions
   if (parallel_ops.size() == 0) {
     return get_or_create_noop_node(input);
@@ -255,7 +255,7 @@ Node FFModel::get_or_create_fused_parallel_node(
     hash = hash * 31 + std::hash<int>()(parallel_ops[i].parallel_dim);
     hash = hash * 31 + std::hash<int>()(parallel_ops[i].parallel_degree);
   }
-  const auto &it = cached_fused_parallel_ops.find(hash);
+  auto const &it = cached_fused_parallel_ops.find(hash);
   FusedParallelOp *fused = NULL;
   if (it != cached_fused_parallel_ops.end()) {
     fused = it->second;
@@ -270,13 +270,13 @@ Node FFModel::get_or_create_fused_parallel_node(
   return ret;
 }
 
-void FusedParallelOp::forward_task(const Task *task,
-                                   const std::vector<PhysicalRegion> &regions,
+void FusedParallelOp::forward_task(Task const *task,
+                                   std::vector<PhysicalRegion> const &regions,
                                    Context ctx,
                                    Runtime *runtime) {}
 
-void FusedParallelOp::backward_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+void FusedParallelOp::backward_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {}
 

--- a/src/parallel_ops/partition.cc
+++ b/src/parallel_ops/partition.cc
@@ -40,7 +40,7 @@ using Legion::TaskLauncher;
 ParallelTensor FFModel::repartition(const ParallelTensor input,
                                     int repartition_legion_dim,
                                     int repartition_degree,
-                                    const char *name) {
+                                    char const *name) {
   assert(false);
 #ifdef DEADCODE
   Repartition *part = new Repartition(
@@ -54,7 +54,7 @@ Repartition::Repartition(FFModel &model,
                          const ParallelTensor _input,
                          int _repartition_legion_dim,
                          int _repartition_degree,
-                         const char *name)
+                         char const *name)
     : ParallelOp(model, OP_REPARTITION, name, _input),
       repartition_dim(_repartition_legion_dim),
       repartition_degree(_repartition_degree) {
@@ -71,14 +71,14 @@ Repartition::Repartition(FFModel &model,
   // outputs[0]->print("Repartition::output");
 }
 
-OpMeta *Repartition::init_task(const Task *task,
-                               const std::vector<PhysicalRegion> &regions,
+OpMeta *Repartition::init_task(Task const *task,
+                               std::vector<PhysicalRegion> const &regions,
                                Context ctx,
                                Runtime *runtime) {
   return nullptr;
 }
 
-void Repartition::init(const FFModel &ff) {
+void Repartition::init(FFModel const &ff) {
   ArgumentMap argmap;
   parallel_is = outputs[0]->parallel_is;
   Context ctx = ff.config.lg_ctx;
@@ -121,7 +121,7 @@ void Repartition::create_input_partition(FFModel &ff) {
                                output_grad_lp);
 }
 
-void Repartition::forward(const FFModel &ff) {
+void Repartition::forward(FFModel const &ff) {
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
@@ -149,7 +149,7 @@ void Repartition::forward(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-void Repartition::backward(const FFModel &ff) {
+void Repartition::backward(FFModel const &ff) {
   // skip backpropagation for input
   if (inputs[0]->owner_op != nullptr &&
       inputs[0]->owner_op->op_type == OP_INPUT)
@@ -186,7 +186,7 @@ void Repartition::backward(const FFModel &ff) {
 }
 
 bool Repartition::measure_operator_cost(Simulator *sim,
-                                        const MachineView &pc,
+                                        MachineView const &pc,
                                         CostMetrics &cost_metrics) const {
   cost_metrics.forward_time = 0.0f;
   cost_metrics.backward_time = 0.0f;
@@ -242,7 +242,7 @@ Node FFModel::get_or_create_repartition_node(const ParallelTensor input,
   size_t hash = input->get_owner_independent_hash();
   hash = hash * 31 + std::hash<int>()(repartition_dim);
   hash = hash * 31 + std::hash<int>()(repartition_degree);
-  const auto &it = cached_repartition_ops.find(hash);
+  auto const &it = cached_repartition_ops.find(hash);
   Repartition *repartition = NULL;
   if (it != cached_repartition_ops.end()) {
     repartition = it->second;
@@ -273,8 +273,8 @@ tl::optional<RecordFormatter> Repartition::as_dot() const {
 }
 
 /*static*/
-void Repartition::forward_task(const Task *task,
-                               const std::vector<PhysicalRegion> &regions,
+void Repartition::forward_task(Task const *task,
+                               std::vector<PhysicalRegion> const &regions,
                                Context ctx,
                                Runtime *runtime) {
   assert(regions.size() == 2);
@@ -295,8 +295,8 @@ void Repartition::forward_task(const Task *task,
 
 template <typename DT>
 void Repartition::forward_task_with_type(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   Domain input_domain = runtime->get_index_space_domain(
@@ -313,8 +313,8 @@ void Repartition::forward_task_with_type(
   forward_kernel<DT>(input_ptr, output_ptr, output_domain.get_volume());
 }
 
-void Repartition::backward_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+void Repartition::backward_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   assert(regions.size() == 2);
@@ -335,8 +335,8 @@ void Repartition::backward_task(const Task *task,
 
 template <typename DT>
 void Repartition::backward_task_with_type(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   Domain output_grad_domain = runtime->get_index_space_domain(

--- a/src/parallel_ops/partition.cpp
+++ b/src/parallel_ops/partition.cpp
@@ -50,10 +50,10 @@ void Repartition::backward_kernel(const T *output_grad_ptr,
 
 RepartitionMeta::RepartitionMeta(FFHandler handler) : OpMeta(handler) {}
 
-template void Repartition::forward_kernel<float>(const float *input_ptr,
+template void Repartition::forward_kernel<float>(float const *input_ptr,
                                                  float *output_ptr,
                                                  size_t num_elements);
-template void Repartition::backward_kernel<float>(const float *output_grad_ptr,
+template void Repartition::backward_kernel<float>(float const *output_grad_ptr,
                                                   float *input_grad_ptr,
                                                   size_t num_elements);
 

--- a/src/parallel_ops/partition.cu
+++ b/src/parallel_ops/partition.cu
@@ -43,29 +43,29 @@ void Repartition::backward_kernel(const T *output_grad_ptr,
 
 RepartitionMeta::RepartitionMeta(FFHandler handler) : OpMeta(handler) {}
 
-template void Repartition::forward_kernel<float>(const float *input_ptr,
+template void Repartition::forward_kernel<float>(float const *input_ptr,
                                                  float *output_ptr,
                                                  size_t num_elements);
-template void Repartition::forward_kernel<double>(const double *input_ptr,
+template void Repartition::forward_kernel<double>(double const *input_ptr,
                                                   double *output_ptr,
                                                   size_t num_elements);
-template void Repartition::forward_kernel<int32_t>(const int32_t *input_ptr,
+template void Repartition::forward_kernel<int32_t>(int32_t const *input_ptr,
                                                    int32_t *output_ptr,
                                                    size_t num_elements);
-template void Repartition::forward_kernel<int64_t>(const int64_t *input_ptr,
+template void Repartition::forward_kernel<int64_t>(int64_t const *input_ptr,
                                                    int64_t *output_ptr,
                                                    size_t num_elements);
-template void Repartition::backward_kernel<float>(const float *output_grad_ptr,
+template void Repartition::backward_kernel<float>(float const *output_grad_ptr,
                                                   float *input_grad_ptr,
                                                   size_t num_elements);
 template void Repartition::backward_kernel<double>(
-    const double *output_grad_ptr, double *input_grad_ptr, size_t num_elements);
+    double const *output_grad_ptr, double *input_grad_ptr, size_t num_elements);
 template void
-Repartition::backward_kernel<int32_t>(const int32_t *output_grad_ptr,
+Repartition::backward_kernel<int32_t>(int32_t const *output_grad_ptr,
                                       int32_t *input_grad_ptr,
                                       size_t num_elements);
 template void
-Repartition::backward_kernel<int64_t>(const int64_t *output_grad_ptr,
+Repartition::backward_kernel<int64_t>(int64_t const *output_grad_ptr,
                                       int64_t *input_grad_ptr,
                                       size_t num_elements);
 

--- a/src/parallel_ops/reduction.cpp
+++ b/src/parallel_ops/reduction.cpp
@@ -63,15 +63,15 @@ void Reduction::backward_kernel(const T *output_grad_ptr,
                            stream));
 }
 
-template __global__ void reduction_forward_kernel<float>(const float *input_ptr,
+template __global__ void reduction_forward_kernel<float>(float const *input_ptr,
                                                          float *output_ptr,
                                                          size_t num_elements,
                                                          size_t num_replicas);
-template void Reduction::forward_kernel<float>(const float *input_ptr,
+template void Reduction::forward_kernel<float>(float const *input_ptr,
                                                float *output_ptr,
                                                size_t num_elements,
                                                size_t num_replicas);
-template void Reduction::backward_kernel<float>(const float *output_grad_ptr,
+template void Reduction::backward_kernel<float>(float const *output_grad_ptr,
                                                 float *input_grad_ptr,
                                                 size_t num_elements);
 

--- a/src/parallel_ops/reduction.cu
+++ b/src/parallel_ops/reduction.cu
@@ -56,15 +56,15 @@ void Reduction::backward_kernel(const T *output_grad_ptr,
                             stream));
 }
 
-template __global__ void reduction_forward_kernel<float>(const float *input_ptr,
+template __global__ void reduction_forward_kernel<float>(float const *input_ptr,
                                                          float *output_ptr,
                                                          size_t num_elements,
                                                          size_t num_replicas);
-template void Reduction::forward_kernel<float>(const float *input_ptr,
+template void Reduction::forward_kernel<float>(float const *input_ptr,
                                                float *output_ptr,
                                                size_t num_elements,
                                                size_t num_replicas);
-template void Reduction::backward_kernel<float>(const float *output_grad_ptr,
+template void Reduction::backward_kernel<float>(float const *output_grad_ptr,
                                                 float *input_grad_ptr,
                                                 size_t num_elements);
 

--- a/src/parallel_ops/replicate.cpp
+++ b/src/parallel_ops/replicate.cpp
@@ -62,15 +62,15 @@ void Replicate::backward_kernel(const T *output_grad_ptr,
                      num_replicas);
 }
 
-template void Replicate::forward_kernel<float>(const float *input_ptr,
+template void Replicate::forward_kernel<float>(float const *input_ptr,
                                                float *output_ptr,
                                                size_t num_elements);
 template __global__ void
-replicate_backward_kernel<float>(const float *input_ptr,
+replicate_backward_kernel<float>(float const *input_ptr,
                                  float *output_ptr,
                                  size_t num_elements,
                                  size_t num_replicas);
-template void Replicate::backward_kernel<float>(const float *output_grad_ptr,
+template void Replicate::backward_kernel<float>(float const *output_grad_ptr,
                                                 float *input_grad_ptr,
                                                 size_t num_elements,
                                                 size_t num_replicas);

--- a/src/parallel_ops/replicate.cu
+++ b/src/parallel_ops/replicate.cu
@@ -55,15 +55,15 @@ void Replicate::backward_kernel(const T *output_grad_ptr,
           output_grad_ptr, input_grad_ptr, num_elements, num_replicas);
 }
 
-template void Replicate::forward_kernel<float>(const float *input_ptr,
+template void Replicate::forward_kernel<float>(float const *input_ptr,
                                                float *output_ptr,
                                                size_t num_elements);
 template __global__ void
-replicate_backward_kernel<float>(const float *input_ptr,
+replicate_backward_kernel<float>(float const *input_ptr,
                                  float *output_ptr,
                                  size_t num_elements,
                                  size_t num_replicas);
-template void Replicate::backward_kernel<float>(const float *output_grad_ptr,
+template void Replicate::backward_kernel<float>(float const *output_grad_ptr,
                                                 float *input_grad_ptr,
                                                 size_t num_elements,
                                                 size_t num_replicas);

--- a/src/runtime/accessor.cc
+++ b/src/runtime/accessor.cc
@@ -11,7 +11,7 @@ TensorAccessorR<DT, dim>::TensorAccessorR(PhysicalRegion region,
                                           FieldID fid,
                                           Context ctx,
                                           Runtime *runtime) {
-  const AccessorRO<DT, dim> acc(region, fid);
+  AccessorRO<DT, dim> const acc(region, fid);
   rect = runtime->get_index_space_domain(ctx, req.region.get_index_space());
   assert(acc.accessor.is_dense_arbitrary(rect));
   ptr = acc.ptr(rect);
@@ -64,11 +64,11 @@ TensorAccessorW<DT, dim>::TensorAccessorW(PhysicalRegion region,
                                           bool readOutput) {
   rect = runtime->get_index_space_domain(ctx, req.region.get_index_space());
   if (readOutput) {
-    const AccessorRW<DT, dim> acc(region, fid);
+    AccessorRW<DT, dim> const acc(region, fid);
     assert(acc.accessor.is_dense_arbitrary(rect));
     ptr = acc.ptr(rect);
   } else {
-    const AccessorWO<DT, dim> acc(region, fid);
+    AccessorWO<DT, dim> const acc(region, fid);
     assert(acc.accessor.is_dense_arbitrary(rect));
     ptr = acc.ptr(rect);
     // FIXME: currently we zero init the region if not read output
@@ -204,7 +204,7 @@ DT *helperGetTensorPointerWO(PhysicalRegion region,
 LEGION_FOREACH_N(DIMFUNC)
 #undef DIMFUNC
 
-template const float *helperGetTensorPointerRO(PhysicalRegion region,
+template float const *helperGetTensorPointerRO(PhysicalRegion region,
                                                RegionRequirement req,
                                                FieldID fid,
                                                Context ctx,
@@ -220,7 +220,7 @@ template float *helperGetTensorPointerWO(PhysicalRegion region,
                                          Context ctx,
                                          Runtime *runtime);
 
-template const double *helperGetTensorPointerRO(PhysicalRegion region,
+template double const *helperGetTensorPointerRO(PhysicalRegion region,
                                                 RegionRequirement req,
                                                 FieldID fid,
                                                 Context ctx,
@@ -236,7 +236,7 @@ template double *helperGetTensorPointerWO(PhysicalRegion region,
                                           Context ctx,
                                           Runtime *runtime);
 
-template const int32_t *helperGetTensorPointerRO(PhysicalRegion region,
+template int32_t const *helperGetTensorPointerRO(PhysicalRegion region,
                                                  RegionRequirement req,
                                                  FieldID fid,
                                                  Context ctx,
@@ -252,7 +252,7 @@ template int32_t *helperGetTensorPointerWO(PhysicalRegion region,
                                            Context ctx,
                                            Runtime *runtime);
 
-template const int64_t *helperGetTensorPointerRO(PhysicalRegion region,
+template int64_t const *helperGetTensorPointerRO(PhysicalRegion region,
                                                  RegionRequirement req,
                                                  FieldID fid,
                                                  Context ctx,

--- a/src/runtime/cuda_helper.cu
+++ b/src/runtime/cuda_helper.cu
@@ -61,17 +61,17 @@ __global__ void reluBackward(DT *grad_ptr, const DT *output, size_t n) {
 
 __host__ void relu_backward_kernel(DataType data_type,
                                    void *output_grad_ptr,
-                                   const void *output_ptr,
+                                   void const *output_ptr,
                                    size_t output_size,
                                    cudaStream_t stream) {
   if (data_type == DT_FLOAT) {
     reluBackward<float>
         <<<GET_BLOCKS(output_size), CUDA_NUM_THREADS, 0, stream>>>(
-            (float *)output_grad_ptr, (const float *)output_ptr, output_size);
+            (float *)output_grad_ptr, (float const *)output_ptr, output_size);
   } else if (data_type == DT_DOUBLE) {
     reluBackward<double>
         <<<GET_BLOCKS(output_size), CUDA_NUM_THREADS, 0, stream>>>(
-            (double *)output_grad_ptr, (const double *)output_ptr, output_size);
+            (double *)output_grad_ptr, (double const *)output_ptr, output_size);
   } else {
     assert(false && "Unsupported data type in Linear backward");
     exit(1);
@@ -88,17 +88,17 @@ sigmoid_backward_function(DT *grad_ptr, const DT *output, size_t n) {
 
 __host__ void sigmoid_backward_kernel(DataType data_type,
                                       void *output_grad_ptr,
-                                      const void *output_ptr,
+                                      void const *output_ptr,
                                       size_t output_size,
                                       cudaStream_t stream) {
   if (data_type == DT_FLOAT) {
     sigmoid_backward_function<float>
         <<<GET_BLOCKS(output_size), CUDA_NUM_THREADS, 0, stream>>>(
-            (float *)output_grad_ptr, (const float *)output_ptr, output_size);
+            (float *)output_grad_ptr, (float const *)output_ptr, output_size);
   } else if (data_type == DT_DOUBLE) {
     sigmoid_backward_function<double>
         <<<GET_BLOCKS(output_size), CUDA_NUM_THREADS, 0, stream>>>(
-            (double *)output_grad_ptr, (const double *)output_ptr, output_size);
+            (double *)output_grad_ptr, (double const *)output_ptr, output_size);
   } else {
     assert(false && "Unsupported data type in Linear backward");
     exit(1);
@@ -106,16 +106,16 @@ __host__ void sigmoid_backward_kernel(DataType data_type,
 }
 
 __global__ void
-gelu_forward_kernel(size_t size, const float B, const float C, float *input) {
+gelu_forward_kernel(size_t size, float const B, float const C, float *input) {
   CUDA_KERNEL_LOOP(i, size) {
-    const float in = input[i];
-    const float cdf = 0.5f + 0.5f * tanh(in * (C * in * in + B));
+    float const in = input[i];
+    float const cdf = 0.5f + 0.5f * tanh(in * (C * in * in + B));
     input[i] = in * cdf;
   }
 }
 
 __global__ void
-apply_add(float *data_ptr, const float *replica_ptr, size_t size) {
+apply_add(float *data_ptr, float const *replica_ptr, size_t size) {
   CUDA_KERNEL_LOOP(i, size) { data_ptr[i] += replica_ptr[i]; }
 }
 
@@ -131,7 +131,7 @@ __global__ void add_kernel(T *data_ptr, const T *grad_ptr, size_t size) {
 }
 
 __global__ void add_with_stride(float *output,
-                                const float *input,
+                                float const *input,
                                 int num_blocks,
                                 int output_blk_size,
                                 int input_blk_size) {
@@ -146,7 +146,7 @@ __global__ void add_with_stride(float *output,
 }
 
 __global__ void copy_with_stride(float *output,
-                                 const float *input,
+                                 float const *input,
                                  int num_blocks,
                                  int output_blk_size,
                                  int input_blk_size) {
@@ -161,7 +161,7 @@ __global__ void copy_with_stride(float *output,
 }
 
 __host__ void updateGAS(float *para_ptr,
-                        const float *grad_ptr,
+                        float const *grad_ptr,
                         size_t replica_size,
                         int num_replica,
                         float learning_rate) {
@@ -169,7 +169,7 @@ __host__ void updateGAS(float *para_ptr,
   checkCUDA(get_legion_stream(&stream));
   // Step 1: gater gradients to the first replica
   for (int i = 1; i < num_replica; i++) {
-    const float *replica = grad_ptr + i * replica_size;
+    float const *replica = grad_ptr + i * replica_size;
     apply_add<<<GET_BLOCKS(replica_size), CUDA_NUM_THREADS, 0, stream>>>(
         (float *)grad_ptr, replica, replica_size);
   }
@@ -184,7 +184,7 @@ __host__ void updateGAS(float *para_ptr,
 
 #ifdef DEADCODE
 template <unsigned DIM, typename T>
-__host__ void print_tensor(const T *ptr, Rect<DIM> rect, const char *prefix) {
+__host__ void print_tensor(const T *ptr, Rect<DIM> rect, char const *prefix) {
   // device synchronize to make sure the data are ready
   // checkCUDA(cudaDeviceSynchronize());
   T *host_ptr;
@@ -208,7 +208,7 @@ __host__ void print_tensor(const T *ptr, Rect<DIM> rect, const char *prefix) {
 
 template <typename T>
 __host__ void
-print_tensor(const T *ptr, size_t num_elements, const char *prefix) {
+print_tensor(const T *ptr, size_t num_elements, char const *prefix) {
   // device synchronize to make sure the data are ready
   // checkCUDA(cudaDeviceSynchronize());
   T *host_ptr;
@@ -331,41 +331,41 @@ template __global__ void
 assign_kernel<int64_t>(int64_t *ptr, coord_t size, int64_t value);
 
 template __global__ void
-add_kernel<float>(float *dst, const float *src, size_t size);
+add_kernel<float>(float *dst, float const *src, size_t size);
 template __global__ void
-add_kernel<double>(double *dst, const double *src, size_t size);
+add_kernel<double>(double *dst, double const *src, size_t size);
 template __global__ void
-add_kernel<int32_t>(int32_t *dst, const int32_t *src, size_t size);
+add_kernel<int32_t>(int32_t *dst, int32_t const *src, size_t size);
 template __global__ void
-add_kernel<int64_t>(int64_t *dst, const int64_t *src, size_t size);
+add_kernel<int64_t>(int64_t *dst, int64_t const *src, size_t size);
 
 template __global__ void
-copy_kernel<float>(float *dst, const float *src, coord_t size);
+copy_kernel<float>(float *dst, float const *src, coord_t size);
 template __global__ void
-copy_kernel<int32_t>(int32_t *dst, const int32_t *src, coord_t size);
+copy_kernel<int32_t>(int32_t *dst, int32_t const *src, coord_t size);
 template __global__ void
-copy_kernel<int64_t>(int64_t *dst, const int64_t *src, coord_t size);
+copy_kernel<int64_t>(int64_t *dst, int64_t const *src, coord_t size);
 
 template __global__ void apply_add_with_scale<float>(float *data_ptr,
-                                                     const float *grad_ptr,
+                                                     float const *grad_ptr,
                                                      size_t size,
                                                      float scale);
 template __global__ void apply_add_with_scale<double>(double *data_ptr,
-                                                      const double *grad_ptr,
+                                                      double const *grad_ptr,
                                                       size_t size,
                                                       double scale);
 template __global__ void apply_add_with_scale<int32_t>(int32_t *data_ptr,
-                                                       const int32_t *grad_ptr,
+                                                       int32_t const *grad_ptr,
                                                        size_t size,
                                                        int32_t scale);
 template __global__ void apply_add_with_scale<int64_t>(int64_t *data_ptr,
-                                                       const int64_t *grad_ptr,
+                                                       int64_t const *grad_ptr,
                                                        size_t size,
                                                        int64_t scale);
 
 template __host__ void
-print_tensor<float>(const float *ptr, size_t rect, const char *prefix);
+print_tensor<float>(float const *ptr, size_t rect, char const *prefix);
 template __host__ void
-print_tensor<int32_t>(const int32_t *ptr, size_t rect, const char *prefix);
+print_tensor<int32_t>(int32_t const *ptr, size_t rect, char const *prefix);
 template __host__ void
-print_tensor<int64_t>(const int64_t *ptr, size_t rect, const char *prefix);
+print_tensor<int64_t>(int64_t const *ptr, size_t rect, char const *prefix);

--- a/src/runtime/graph.cc
+++ b/src/runtime/graph.cc
@@ -48,7 +48,7 @@ const Node Node::INVALID_NODE = Node();
 
 Node::Node(void) : guid(0), ptr(NULL) {}
 
-std::string Node::op_to_string(const Op *op) const {
+std::string Node::op_to_string(Op const *op) const {
   return optype_to_string(op->op_type);
 }
 
@@ -56,10 +56,10 @@ Edge::Edge(void)
     : srcOp(Node::INVALID_NODE), dstOp(Node::INVALID_NODE), srcIdx(-1),
       dstIdx(-1) {}
 
-Edge::Edge(const Node &_srcOp, const Node &_dstOp, int _srcIdx, int _dstIdx)
+Edge::Edge(Node const &_srcOp, Node const &_dstOp, int _srcIdx, int _dstIdx)
     : srcOp(_srcOp), dstOp(_dstOp), srcIdx(_srcIdx), dstIdx(_dstIdx) {}
 
-bool Edge::operator==(const Edge &rhs) const {
+bool Edge::operator==(Edge const &rhs) const {
   if (srcOp != rhs.srcOp)
     return false;
   if (dstOp != rhs.dstOp)
@@ -109,8 +109,8 @@ T SearchHelper::find_optimal_sequence_graph_time(
   // this case since parallel_op does not trigger computation
   if (bn_node.ptr->is_parallel_op()) {
     bool found = false;
-    const auto &inList = g->inEdges.find(sink.node)->second;
-    for (const auto &e : inList) {
+    auto const &inList = g->inEdges.find(sink.node)->second;
+    for (auto const &e : inList) {
       if (e.srcOp == bn_node) {
         found = true;
         break;
@@ -291,8 +291,8 @@ T SearchHelper::find_optimal_nonsequence_graph_time(
 
 Graph::Graph(FFModel *_model) : model(_model), search(_model->search) {}
 
-void Graph::add_edge(const Node &srcOp,
-                     const Node &dstOp,
+void Graph::add_edge(Node const &srcOp,
+                     Node const &dstOp,
                      int srcIdx,
                      int dstIdx) {
   if (inEdges.find(dstOp) == inEdges.end()) {
@@ -308,12 +308,12 @@ void Graph::add_edge(const Node &srcOp,
   outEdges[srcOp].insert(e);
 }
 
-void Graph::add_node(const Node &node) {
+void Graph::add_node(Node const &node) {
   inEdges[node];
   outEdges[node];
 }
 
-void Graph::add_edge(const Edge &e) {
+void Graph::add_edge(Edge const &e) {
   inEdges[e.srcOp];
   outEdges[e.dstOp];
 
@@ -321,7 +321,7 @@ void Graph::add_edge(const Edge &e) {
   outEdges[e.srcOp].insert(e);
 }
 
-void Graph::remove_edge(const Edge &e, bool remove_node_if_unused) {
+void Graph::remove_edge(Edge const &e, bool remove_node_if_unused) {
   assert(outEdges[e.srcOp].find(e) != outEdges[e.srcOp].end());
   assert(inEdges[e.dstOp].find(e) != inEdges[e.dstOp].end());
   assert(outEdges[e.srcOp].erase(e) == 1);
@@ -338,15 +338,15 @@ void Graph::remove_edge(const Edge &e, bool remove_node_if_unused) {
   }
 }
 
-bool Graph::has_edge(const Node &srcOp,
-                     const Node &dstOp,
+bool Graph::has_edge(Node const &srcOp,
+                     Node const &dstOp,
                      int srcIdx,
                      int dstIdx) const {
   Edge e(srcOp, dstOp, srcIdx, dstIdx);
   return this->has_edge(e);
 }
 
-bool Graph::has_edge(const Edge &e) const {
+bool Graph::has_edge(Edge const &e) const {
   if (inEdges.find(e.dstOp) == inEdges.end()) {
     return false;
   }
@@ -358,14 +358,14 @@ bool Graph::has_edge(const Edge &e) const {
 
 void Graph::print(void) const {
   log_graph.print("Printing in-edge graph...");
-  for (const auto &it : inEdges) {
+  for (auto const &it : inEdges) {
     if (it.first.guid == 0)
       continue;
     log_graph.print("	guid(%zu) type(%s): ",
                     it.first.guid,
                     optype_to_string(it.first.ptr->op_type).data());
-    const std::unordered_set<Edge> &list = it.second;
-    for (const auto &it2 : list) {
+    std::unordered_set<Edge> const &list = it.second;
+    for (auto const &it2 : list) {
       Edge e = it2;
       log_graph.print(
           "         inEdge(guid(%zu) idx(%d))", e.srcOp.guid, e.srcIdx);
@@ -384,13 +384,13 @@ void Graph::print(void) const {
     // }
   }
   log_graph.print("Printing out-edge graph...");
-  for (const auto &it : outEdges) {
+  for (auto const &it : outEdges) {
     if (it.first.guid == 0)
       continue;
     log_graph.print(
         "	guid(%zu) type(%d): ", it.first.guid, it.first.ptr->op_type);
-    const std::unordered_set<Edge> &list = it.second;
-    for (const auto &it2 : list) {
+    std::unordered_set<Edge> const &list = it.second;
+    for (auto const &it2 : list) {
       Edge e = it2;
       log_graph.print(
           "         outEdge(guid(%zu) idx(%d))", e.dstOp.guid, e.dstIdx);
@@ -433,14 +433,14 @@ void Graph::print_dot(std::ostream &s) const {
 bool Graph::has_loop(void) {
   std::unordered_map<Node, int> todos;
   std::vector<Node> opList;
-  for (const auto &it : inEdges) {
-    const auto &inList = it.second;
+  for (auto const &it : inEdges) {
+    auto const &inList = it.second;
     todos[it.first] = (int)inList.size();
     if (todos[it.first] == 0)
       opList.push_back(it.first);
   }
 #ifdef DEADCODE
-  for (const auto &it : outEdges) {
+  for (auto const &it : outEdges) {
     if (inEdges.find(it.first) == inEdges.end()) {
       opList.push_back(it.first);
     }
@@ -449,8 +449,8 @@ bool Graph::has_loop(void) {
   size_t i = 0;
   while (i < opList.size()) {
     Node op = opList[i++];
-    const auto &outList = outEdges[op];
-    for (const auto &it2 : outList) {
+    auto const &outList = outEdges[op];
+    for (auto const &it2 : outList) {
       todos[it2.dstOp]--;
       if (todos[it2.dstOp] == 0) {
         opList.push_back(it2.dstOp);
@@ -463,7 +463,7 @@ bool Graph::has_loop(void) {
 bool Graph::check_correctness(void) {
   bool okay = true;
   for (auto it = outEdges.begin(); it != outEdges.end(); it++) {
-    const auto &list = it->second;
+    auto const &list = it->second;
     for (auto it2 = list.begin(); it2 != list.end(); it2++) {
       Edge e = *it2;
       if (!has_edge(e))
@@ -484,18 +484,18 @@ bool Graph::check_correctness(void) {
 }
 
 std::vector<MachineView> SearchHelper::get_valid_machine_views(
-    Node const &node, const MachineResource &resource, bool log) const {
+    Node const &node, MachineResource const &resource, bool log) const {
   this->logger->info() << "Getting valid machine views for "
                        << node.to_string();
   return this->get_valid_machine_views(node.ptr, resource, log);
 }
 
 std::vector<MachineView> SearchHelper::get_valid_machine_views(
-    const Op *op, const MachineResource &resource, bool log) const {
+    Op const *op, MachineResource const &resource, bool log) const {
   std::vector<MachineView> const *cached_op_views = NULL;
   std::vector<MachineView> valid_views;
 
-  const auto &iter = cached_operator_valid_views.find(op->op_guid);
+  auto const &iter = cached_operator_valid_views.find(op->op_guid);
   if (iter != cached_operator_valid_views.end()) {
     cached_op_views = iter->second.get();
   } else {
@@ -570,8 +570,8 @@ std::vector<MachineView> SearchHelper::get_valid_machine_views(
   return valid_views;
 }
 
-Node Graph::find_bottleneck_node(const Node &sink_node,
-                                 const Node &source_node) const {
+Node Graph::find_bottleneck_node(Node const &sink_node,
+                                 Node const &source_node) const {
   using FlexFlow::PCG::Utils::GraphStructure;
   using FlexFlow::PCG::Utils::imm_post_dominators;
   using FlexFlow::PCG::Utils::MultisourceGraphStructure;
@@ -597,7 +597,7 @@ Node Graph::find_bottleneck_node(const Node &sink_node,
   return bn_node;
 }
 
-void Edge::replace_node(const Node &currentOp, const Node &replaceWith) {
+void Edge::replace_node(Node const &currentOp, Node const &replaceWith) {
   if (this->srcOp == currentOp) {
     this->srcOp = replaceWith;
   }
@@ -822,7 +822,7 @@ void Graph::simplify(SimplificationSettings const &settings) {
     bool simplify = true;
     while (simplify) {
       simplify = false;
-      for (const auto &it : this->inEdges) {
+      for (auto const &it : this->inEdges) {
         if (it.first.ptr == NULL)
           continue;
         if (it.first.ptr->is_parallel_op()) {
@@ -840,7 +840,7 @@ void Graph::simplify(SimplificationSettings const &settings) {
             ((ParallelOp *)n2.ptr)->append_parallel_op_info(parallel_ops);
             Node new_node = model->get_or_create_fused_parallel_node(
                 n1.ptr->inputs[0], parallel_ops);
-            const auto &inList = this->inEdges.find(n1)->second;
+            auto const &inList = this->inEdges.find(n1)->second;
             assert(inList.size() == 1);
             Edge e1 = *inList.begin();
             // Update graph by adding edges
@@ -849,8 +849,8 @@ void Graph::simplify(SimplificationSettings const &settings) {
             this->remove_edge(e2);
             // make a copy of outList
             if (this->outEdges.find(n2) != this->outEdges.end()) {
-              const auto outList = this->outEdges.find(n2)->second;
-              for (const auto &e : outList) {
+              auto const outList = this->outEdges.find(n2)->second;
+              for (auto const &e : outList) {
                 this->add_edge(new_node, e.dstOp, 0, e.dstIdx);
                 this->remove_edge(e);
               }
@@ -867,7 +867,7 @@ void Graph::simplify(SimplificationSettings const &settings) {
   if (settings.remove_trailing_parallel_ops) {
     // Remove final parallel ops
     std::vector<Node> candidates;
-    for (const auto &it : this->outEdges) {
+    for (auto const &it : this->outEdges) {
       if (it.second.size() == 0 && it.first.ptr->op_type != OP_REDUCTION &&
           it.first.ptr->op_type != OP_FUSED_PARALLEL &&
           it.first.ptr->is_parallel_op()) {
@@ -877,7 +877,7 @@ void Graph::simplify(SimplificationSettings const &settings) {
     size_t index = 0;
     while (index < candidates.size()) {
       Node parallel_op = candidates[index++];
-      const auto &inList = this->inEdges.find(parallel_op)->second;
+      auto const &inList = this->inEdges.find(parallel_op)->second;
       assert(inList.size() == 1);
       Edge e = *inList.begin();
       this->remove_edge(e);
@@ -891,7 +891,7 @@ void Graph::simplify(SimplificationSettings const &settings) {
   if (settings.remove_noops) {
     // Remove NoOps
     std::vector<Node> noop_nodes;
-    for (const auto &it : this->inEdges) {
+    for (auto const &it : this->inEdges) {
       if (it.first.ptr == NULL)
         continue;
       if (it.first.ptr->op_type == OP_NOOP) {
@@ -901,13 +901,13 @@ void Graph::simplify(SimplificationSettings const &settings) {
     size_t index = 0;
     while (index < noop_nodes.size()) {
       Node noop = noop_nodes[index++];
-      const auto &inList = this->inEdges.find(noop)->second;
+      auto const &inList = this->inEdges.find(noop)->second;
       assert(inList.size() == 1);
       Edge in_edge = *inList.begin();
       // make a copy of outList
       if (this->outEdges.find(noop) != this->outEdges.end()) {
-        const auto outList = this->outEdges.find(noop)->second;
-        for (const auto &e : outList) {
+        auto const outList = this->outEdges.find(noop)->second;
+        for (auto const &e : outList) {
           this->add_edge(in_edge.srcOp, e.dstOp, in_edge.srcIdx, e.dstIdx);
           this->remove_edge(e);
         }
@@ -941,16 +941,16 @@ Graph::split_at_node(Node const &bottleneck) const {
     assert(used_nodes.size() < topo_sorted.size());
   }
 
-  for (const auto &it : this->inEdges) {
-    const auto &inList = it.second;
+  for (auto const &it : this->inEdges) {
+    auto const &inList = it.second;
     if (used_nodes.find(it.first) != used_nodes.end()) {
       // Add all in-edges of used_nodes in to the first_graph
-      for (const auto &it2 : inList) {
+      for (auto const &it2 : inList) {
         first_graph->add_edge(it2);
       }
     } else {
       // Add all in-edges of not_used_nodes into the second_graph
-      for (const auto &it2 : inList) {
+      for (auto const &it2 : inList) {
         second_graph->add_edge(it2);
       }
     }
@@ -1264,9 +1264,9 @@ T SearchHelper::estimate_xfer_cost(Graph const *graph,
   T result = this->empty<T>();
 
   if (source.node != Node::INVALID_NODE) {
-    const auto &inList = graph->inEdges.find(sink.node)->second;
+    auto const &inList = graph->inEdges.find(sink.node)->second;
     float op_cost = 0.0f;
-    for (const auto &it2 : inList) {
+    for (auto const &it2 : inList) {
       assert(it2.srcOp == source.node);
       assert(sink.node.ptr->inputs[it2.dstIdx]->is_valid_machine_view(
           source.view));
@@ -1312,10 +1312,10 @@ float SearchHelper::get_cost<GraphCostResult>(
 }
 
 template <typename T>
-T SearchHelper::graph_cost(const Graph *graph,
-                           const NodeAssignment &source,
-                           const NodeAssignment &sink,
-                           const MachineResource &resources,
+T SearchHelper::graph_cost(Graph const *graph,
+                           NodeAssignment const &source,
+                           NodeAssignment const &sink,
+                           MachineResource const &resources,
                            bool include_sink_compute_time) const {
   TAG_ENTER(this->logger);
   this->logger->debug() << "sink(" << sink.node.guid << ") "
@@ -1480,10 +1480,10 @@ template <typename T> T Graph::generic_optimal_cost() const {
 size_t Graph::hash(void) const {
   // Graph hash should be additive and independent to the ordering of the nodes
   size_t total_hash = 0;
-  for (const auto &it : inEdges) {
-    const auto &inList = it.second;
+  for (auto const &it : inEdges) {
+    auto const &inList = it.second;
     size_t node_hash = std::hash<size_t>()((size_t)it.first.ptr);
-    for (const auto &e : inList) {
+    for (auto const &e : inList) {
       size_t edge_hash = 17;
       edge_hash = edge_hash * 31 + std::hash<size_t>()((size_t)e.srcOp.ptr);
       edge_hash = edge_hash * 31 + std::hash<int>()(e.srcIdx);
@@ -1495,12 +1495,12 @@ size_t Graph::hash(void) const {
   return total_hash;
 }
 
-size_t dp_state_hash(const Graph *graph,
-                     const Node &sink_node,
-                     const MachineView &sink_view,
-                     const Node &source_node,
-                     const MachineView &source_view,
-                     const MachineResource &resource) {
+size_t dp_state_hash(Graph const *graph,
+                     Node const &sink_node,
+                     MachineView const &sink_view,
+                     Node const &source_node,
+                     MachineView const &source_view,
+                     MachineResource const &resource) {
   size_t key = graph->hash();
   hash_combine(key, sink_node.ptr);
   hash_combine(key, sink_view.hash());
@@ -1510,8 +1510,8 @@ size_t dp_state_hash(const Graph *graph,
 }
 
 GraphOptimalViewSerialized
-Graph::graph_optimize_task(const Task *task,
-                           const std::vector<PhysicalRegion> &regions,
+Graph::graph_optimize_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
                            Context ctx,
                            Runtime *runtime) {
   FFModel *model = *((FFModel **)task->args);
@@ -1554,14 +1554,14 @@ Graph::graph_optimize_task(const Task *task,
   std::unordered_map<Node, MachineView> optimal_views;
   if (model->config.only_data_parallel) {
     Graph *graph = new Graph(model);
-    std::unordered_map<const FlexFlow::Op *, Node> op_to_node_map;
-    for (const FlexFlow::Op *dstOp : model->operators) {
+    std::unordered_map<FlexFlow::Op const *, Node> op_to_node_map;
+    for (FlexFlow::Op const *dstOp : model->operators) {
       Node dstNode;
       dstNode.ptr = dstOp;
       dstNode.guid = model->node_global_guid++;
       op_to_node_map[dstOp] = dstNode;
       for (int j = 0; j < dstOp->numInputs; j++) {
-        const FlexFlow::Op *srcOp = dstOp->inputs[j]->owner_op;
+        FlexFlow::Op const *srcOp = dstOp->inputs[j]->owner_op;
         assert(op_to_node_map.find(srcOp) != op_to_node_map.end());
         Node srcNode = op_to_node_map[srcOp];
         graph->add_edge(srcNode, dstNode, dstOp->inputs[j]->owner_idx, j);
@@ -1575,7 +1575,7 @@ Graph::graph_optimize_task(const Task *task,
         model->config.numNodes * model->config.workersPerNode;
     data_parallel_view.stride[0] = 1;
     data_parallel_view.start_device_id = 0;
-    for (const auto &node : best_graph->inEdges) {
+    for (auto const &node : best_graph->inEdges) {
       optimal_views[node.first] = data_parallel_view;
     }
   } else {
@@ -1589,8 +1589,8 @@ Graph::graph_optimize_task(const Task *task,
   sez.serialize(best_graph->inEdges.size());
   std::unordered_map<Node, int> todos;
   std::vector<Node> opList;
-  for (const auto &it : best_graph->inEdges) {
-    const auto &inList = it.second;
+  for (auto const &it : best_graph->inEdges) {
+    auto const &inList = it.second;
     todos[it.first] = (int)inList.size();
     if (todos[it.first] == 0)
       opList.push_back(it.first);
@@ -1598,23 +1598,23 @@ Graph::graph_optimize_task(const Task *task,
   size_t node_idx = 0;
   while (node_idx < opList.size()) {
     Node cur_node = opList[node_idx++];
-    const auto &outList = best_graph->outEdges[cur_node];
-    for (const auto &e : outList) {
+    auto const &outList = best_graph->outEdges[cur_node];
+    for (auto const &e : outList) {
       todos[e.dstOp]--;
       if (todos[e.dstOp] == 0) {
         opList.push_back(e.dstOp);
       }
     }
-    const auto &inList = best_graph->inEdges[cur_node];
+    auto const &inList = best_graph->inEdges[cur_node];
     sez.serialize(inList.size());
-    for (const auto &e : inList) {
+    for (auto const &e : inList) {
       sez.serialize(e.srcOp.guid);
       assert(e.dstOp.guid == cur_node.guid);
       sez.serialize(e.srcIdx);
       sez.serialize(e.dstIdx);
     }
     sez.serialize((size_t)10101010); // safe guard for the end of inedges
-    const Op *op = cur_node.ptr;
+    Op const *op = cur_node.ptr;
     assert(op != NULL);
     sez.serialize(cur_node.guid);
     sez.serialize(op->op_type);
@@ -1719,7 +1719,7 @@ Graph::graph_optimize_task(const Task *task,
   // Second, serialize optimal machine view
   printf("opotimal_views.size = %zu\n", optimal_views.size());
   sez.serialize(optimal_views.size());
-  for (const auto &it : optimal_views) {
+  for (auto const &it : optimal_views) {
     sez.serialize((size_t)98765432); // safe guard
     sez.serialize(it.first.guid);
     sez.serialize(it.second);
@@ -1791,12 +1791,12 @@ void FFModel::register_all_machine_views(
   /* } */
 }
 
-float FFModel::graph_cost(const Graph *graph,
-                          const Node &sink_node,
-                          const MachineView &sink_view,
-                          const Node &source_node,
-                          const MachineView &source_view,
-                          const MachineResource &resources,
+float FFModel::graph_cost(Graph const *graph,
+                          Node const &sink_node,
+                          MachineView const &sink_view,
+                          Node const &source_node,
+                          MachineView const &source_view,
+                          MachineResource const &resources,
                           bool include_sink_compute_time,
                           bool constructing_optimal_view) {
   assert(!graph->inEdges.empty());
@@ -1809,12 +1809,12 @@ float FFModel::graph_cost(const Graph *graph,
 }
 
 void FFModel::construct_optimal_view(
-    const Graph *graph,
-    const Node &sink_node,
-    const MachineView &sink_view,
-    const Node &source_node,
-    const MachineView &source_view,
-    const MachineResource &resources,
+    Graph const *graph,
+    Node const &sink_node,
+    MachineView const &sink_view,
+    Node const &source_node,
+    MachineView const &source_view,
+    MachineResource const &resources,
     bool include_sink_compute_time,
     float optimal_cost,
     std::unordered_map<Node, MachineView> &optimal_views) {
@@ -2109,15 +2109,15 @@ void FFModel::deserialize_graph_optimal_view(
 #endif
   assert(dez.get_remaining_bytes() == 0);
   printf("Deserialized Views...\n");
-  for (const auto &it : optimal_views) {
+  for (auto const &it : optimal_views) {
     printf("node[%zu]: type(%s) view(%d %d %d) ",
            it.first.guid,
            it.first.to_string().c_str(),
            it.second.ndims,
            it.second.dim[0],
            it.second.start_device_id);
-    const auto &list = graph->inEdges.at(it.first);
-    for (const auto &it2 : list) {
+    auto const &list = graph->inEdges.at(it.first);
+    for (auto const &it2 : list) {
       Edge e = it2;
       printf(" inEdge(node(%zu) idx(%d))", e.srcOp.guid, e.srcIdx);
     }

--- a/src/runtime/initializer.cc
+++ b/src/runtime/initializer.cc
@@ -28,7 +28,7 @@ GlorotUniform::GlorotUniform(int _seed) : Initializer(), seed(_seed) {}
 
 GlorotUniform::~GlorotUniform(void) {}
 
-void GlorotUniform::init(const FFModel *ff, const ParallelTensor p) {
+void GlorotUniform::init(FFModel const *ff, const ParallelTensor p) {
   Context ctx = ff->config.lg_ctx;
   Runtime *runtime = ff->config.lg_hlr;
   int dim = p->num_dims - 1;
@@ -80,7 +80,7 @@ ZeroInitializer::ZeroInitializer(void) : Initializer() {}
 
 ZeroInitializer::~ZeroInitializer(void) {}
 
-void ZeroInitializer::init(const FFModel *ff, const ParallelTensor p) {
+void ZeroInitializer::init(FFModel const *ff, const ParallelTensor p) {
   Context ctx = ff->config.lg_ctx;
   Runtime *runtime = ff->config.lg_hlr;
   if (p->sync_type == ParameterSyncType::PS) {
@@ -118,8 +118,8 @@ void ZeroInitializer::init(const FFModel *ff, const ParallelTensor p) {
   }
 }
 
-void ZeroInitializer::init_task_cpu(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+void ZeroInitializer::init_task_cpu(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
   assert(regions.size() == task->regions.size());
@@ -134,7 +134,7 @@ void ZeroInitializer::init_task_cpu(const Task *task,
       break;
     }
     case 1: {
-      const AccessorWO<float, 1> accW(regions[i], FID_DATA);
+      AccessorWO<float, 1> const accW(regions[i], FID_DATA);
       Rect<1> rect = runtime->get_index_space_domain(
           ctx, task->regions[i].region.get_index_space());
       assert(accW.accessor.is_dense_arbitrary(rect));
@@ -142,7 +142,7 @@ void ZeroInitializer::init_task_cpu(const Task *task,
       break;
     }
     case 2: {
-      const AccessorWO<float, 2> accW(regions[i], FID_DATA);
+      AccessorWO<float, 2> const accW(regions[i], FID_DATA);
       Rect<2> rect = runtime->get_index_space_domain(
           ctx, task->regions[i].region.get_index_space());
       assert(accW.accessor.is_dense_arbitrary(rect));
@@ -150,7 +150,7 @@ void ZeroInitializer::init_task_cpu(const Task *task,
       break;
     }
     case 3: {
-      const AccessorWO<float, 3> accW(regions[i], FID_DATA);
+      AccessorWO<float, 3> const accW(regions[i], FID_DATA);
       Rect<3> rect = runtime->get_index_space_domain(
           ctx, task->regions[i].region.get_index_space());
       assert(accW.accessor.is_dense_arbitrary(rect));
@@ -173,7 +173,7 @@ UniformInitializer::UniformInitializer(int _seed, float _min, float _max)
 
 UniformInitializer::~UniformInitializer(void) {}
 
-void UniformInitializer::init(const FFModel *ff, const ParallelTensor p) {
+void UniformInitializer::init(FFModel const *ff, const ParallelTensor p) {
   Context ctx = ff->config.lg_ctx;
   Runtime *runtime = ff->config.lg_hlr;
   if (p->sync_type == ParameterSyncType::PS) {
@@ -210,7 +210,7 @@ NormInitializer::NormInitializer(int _seed, float _mean, float _stddev)
 
 NormInitializer::~NormInitializer(void) {}
 
-void NormInitializer::init(const FFModel *ff, const ParallelTensor p) {
+void NormInitializer::init(FFModel const *ff, const ParallelTensor p) {
   Context ctx = ff->config.lg_ctx;
   Runtime *runtime = ff->config.lg_hlr;
   if (p->sync_type == ParameterSyncType::PS) {
@@ -254,7 +254,7 @@ ConstantInitializer::ConstantInitializer(int _value)
 
 ConstantInitializer::~ConstantInitializer(void) {}
 
-void ConstantInitializer::init(const FFModel *ff, const ParallelTensor p) {
+void ConstantInitializer::init(FFModel const *ff, const ParallelTensor p) {
   Context ctx = ff->config.lg_ctx;
   Runtime *runtime = ff->config.lg_hlr;
   if (p->sync_type == ParameterSyncType::PS) {
@@ -287,8 +287,8 @@ void ConstantInitializer::init(const FFModel *ff, const ParallelTensor p) {
 }
 
 void ConstantInitializer::init_task_cpu(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
   ConstantInitializer *initializer = (ConstantInitializer *)task->args;
@@ -306,7 +306,7 @@ void ConstantInitializer::init_task_cpu(
       break;
     }
     case 1: {
-      const AccessorWO<float, 1> accW(regions[i], FID_DATA);
+      AccessorWO<float, 1> const accW(regions[i], FID_DATA);
       Rect<1> rect = runtime->get_index_space_domain(
           ctx, task->regions[i].region.get_index_space());
       assert(accW.accessor.is_dense_arbitrary(rect));
@@ -314,7 +314,7 @@ void ConstantInitializer::init_task_cpu(
       break;
     }
     case 2: {
-      const AccessorWO<float, 2> accW(regions[i], FID_DATA);
+      AccessorWO<float, 2> const accW(regions[i], FID_DATA);
       Rect<2> rect = runtime->get_index_space_domain(
           ctx, task->regions[i].region.get_index_space());
       assert(accW.accessor.is_dense_arbitrary(rect));
@@ -322,7 +322,7 @@ void ConstantInitializer::init_task_cpu(
       break;
     }
     case 3: {
-      const AccessorWO<float, 3> accW(regions[i], FID_DATA);
+      AccessorWO<float, 3> const accW(regions[i], FID_DATA);
       Rect<3> rect = runtime->get_index_space_domain(
           ctx, task->regions[i].region.get_index_space());
       assert(accW.accessor.is_dense_arbitrary(rect));

--- a/src/runtime/initializer_kernel.cpp
+++ b/src/runtime/initializer_kernel.cpp
@@ -41,8 +41,8 @@ using Legion::Runtime;
 using Legion::Task;
 using Legion::TaskArgument;
 using Legion::TaskLauncher;
-void UniformInitializer::init_task(const Task *task,
-                                   const std::vector<PhysicalRegion> &regions,
+void UniformInitializer::init_task(Task const *task,
+                                   std::vector<PhysicalRegion> const &regions,
                                    Context ctx,
                                    Runtime *runtime) {
 
@@ -100,8 +100,8 @@ void UniformInitializer::init_task(const Task *task,
 }
 
 template <int NDIM>
-void init_task_inner(const Task *task,
-                     const std::vector<PhysicalRegion> &regions,
+void init_task_inner(Task const *task,
+                     std::vector<PhysicalRegion> const &regions,
                      Context ctx,
                      Runtime *runtime,
                      Domain const &domain,
@@ -127,13 +127,13 @@ void init_task_inner(const Task *task,
   scale = sqrt(6.0 / (fan_in + fan_out));
 }
 
-void GlorotUniform::init_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void GlorotUniform::init_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   assert(regions.size() == 1);
   assert(task->regions.size() == 1);
-  const GlorotUniform *gu = (const GlorotUniform *)task->args;
+  GlorotUniform const *gu = (GlorotUniform const *)task->args;
   Domain domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   float *w = helperGetTensorPointerWO<float>(
@@ -161,8 +161,8 @@ void GlorotUniform::init_task(const Task *task,
   hiprandDestroyGenerator(gen);
 }
 
-void NormInitializer::init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+void NormInitializer::init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   assert(regions.size() == 1);
@@ -220,8 +220,8 @@ void NormInitializer::init_task(const Task *task,
   hiprandDestroyGenerator(gen);
 }
 
-void ZeroInitializer::init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+void ZeroInitializer::init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   ZeroInitMeta *meta = (ZeroInitMeta *)task->args;
@@ -272,8 +272,8 @@ void ZeroInitializer::init_task(const Task *task,
   checkCUDA(hipDeviceSynchronize());
 }
 
-void ConstantInitializer::init_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+void ConstantInitializer::init_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
   ConstantInitializer *initializer = (ConstantInitializer *)task->args;

--- a/src/runtime/initializer_kernel.cu
+++ b/src/runtime/initializer_kernel.cu
@@ -40,8 +40,8 @@ using Legion::Runtime;
 using Legion::Task;
 using Legion::TaskArgument;
 using Legion::TaskLauncher;
-void UniformInitializer::init_task(const Task *task,
-                                   const std::vector<PhysicalRegion> &regions,
+void UniformInitializer::init_task(Task const *task,
+                                   std::vector<PhysicalRegion> const &regions,
                                    Context ctx,
                                    Runtime *runtime) {
 
@@ -95,8 +95,8 @@ void UniformInitializer::init_task(const Task *task,
 }
 
 template <int NDIM>
-void init_task_inner(const Task *task,
-                     const std::vector<PhysicalRegion> &regions,
+void init_task_inner(Task const *task,
+                     std::vector<PhysicalRegion> const &regions,
                      Context ctx,
                      Runtime *runtime,
                      Domain const &domain,
@@ -122,13 +122,13 @@ void init_task_inner(const Task *task,
   scale = sqrt(6.0 / (fan_in + fan_out));
 }
 
-void GlorotUniform::init_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void GlorotUniform::init_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {
   assert(regions.size() == 1);
   assert(task->regions.size() == 1);
-  const GlorotUniform *gu = (const GlorotUniform *)task->args;
+  GlorotUniform const *gu = (GlorotUniform const *)task->args;
   Domain domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   float *w = helperGetTensorPointerWO<float>(
@@ -151,8 +151,8 @@ void GlorotUniform::init_task(const Task *task,
   curandDestroyGenerator(gen);
 }
 
-void NormInitializer::init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+void NormInitializer::init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   assert(regions.size() == 1);
@@ -212,8 +212,8 @@ void NormInitializer::init_task(const Task *task,
   curandDestroyGenerator(gen);
 }
 
-void ZeroInitializer::init_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+void ZeroInitializer::init_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   ZeroInitMeta *meta = (ZeroInitMeta *)task->args;
@@ -249,8 +249,8 @@ void ZeroInitializer::init_task(const Task *task,
   checkCUDA(cudaDeviceSynchronize());
 }
 
-void ConstantInitializer::init_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+void ConstantInitializer::init_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
   ConstantInitializer *initializer = (ConstantInitializer *)task->args;

--- a/src/runtime/layer.cc
+++ b/src/runtime/layer.cc
@@ -6,7 +6,7 @@ namespace FlexFlow {
 
 Layer::Layer(FFModel *model,
              OperatorType _type,
-             const char *_name,
+             char const *_name,
              int _numInputs,
              int _numWeights,
              int _numOutputs,
@@ -42,11 +42,11 @@ Layer::Layer(FFModel *model,
 
 Layer::Layer(FFModel *model,
              OperatorType _type,
-             const char *_name,
+             char const *_name,
              int _numInputs,
              int _numWeights,
              int _numOutputs,
-             const Tensor *_tensors)
+             Tensor const *_tensors)
     : op_type(_type), data_type(DT_FLOAT),
       layer_guid(model->layer_global_guid++), numInputs(_numInputs),
       numWeights(_numWeights), numOutputs(_numOutputs) {
@@ -68,25 +68,25 @@ Layer::Layer(FFModel *model,
   }
 }
 
-void Layer::add_int_property(const std::string &key, long long value) {
+void Layer::add_int_property(std::string const &key, long long value) {
   int_properties[key] = value;
 }
 
-void Layer::add_float_property(const std::string &key, float value) {
+void Layer::add_float_property(std::string const &key, float value) {
   float_properties[key] = value;
 }
 
-void Layer::add_int_vector_property(const std::string &key,
-                                    const std::vector<int> &value) {
+void Layer::add_int_vector_property(std::string const &key,
+                                    std::vector<int> const &value) {
   int_vector_properties[key] = value;
 }
 
-void Layer::add_initializer(const std::string &key, Initializer *initializer) {
+void Layer::add_initializer(std::string const &key, Initializer *initializer) {
   initializers[key] = initializer;
 }
 
-bool Layer::get_int_property(const std::string &key, long long &value) const {
-  const auto &it = int_properties.find(key);
+bool Layer::get_int_property(std::string const &key, long long &value) const {
+  auto const &it = int_properties.find(key);
   if (it == int_properties.end()) {
     assert(false);
     return false;
@@ -96,8 +96,8 @@ bool Layer::get_int_property(const std::string &key, long long &value) const {
   }
 }
 
-bool Layer::get_float_property(const std::string &key, float &value) const {
-  const auto &it = float_properties.find(key);
+bool Layer::get_float_property(std::string const &key, float &value) const {
+  auto const &it = float_properties.find(key);
   if (it == float_properties.end()) {
     assert(false);
     return false;
@@ -107,9 +107,9 @@ bool Layer::get_float_property(const std::string &key, float &value) const {
   }
 }
 
-bool Layer::get_int_vector_property(const std::string &key,
+bool Layer::get_int_vector_property(std::string const &key,
                                     std::vector<int> &value) const {
-  const auto &it = int_vector_properties.find(key);
+  auto const &it = int_vector_properties.find(key);
   if (it == int_vector_properties.end()) {
     assert(false);
     return false;
@@ -119,9 +119,9 @@ bool Layer::get_int_vector_property(const std::string &key,
   }
 }
 
-bool Layer::get_initializer(const std::string &key,
+bool Layer::get_initializer(std::string const &key,
                             Initializer *&initializer) const {
-  const auto &it = initializers.find(key);
+  auto const &it = initializers.find(key);
   if (it == initializers.end()) {
     assert(false);
     return false;

--- a/src/runtime/machine_model.cc
+++ b/src/runtime/machine_model.cc
@@ -957,7 +957,7 @@ NetworkedMachineModel::NetworkedMachineModel(int num_nodes,
                                              int num_gpus_per_node,
                                              int num_switches,
                                              float network_latency,
-                                             const std::vector<int> &topology,
+                                             std::vector<int> const &topology,
                                              size_t capacity,
                                              float link_bandwidth)
     : num_nodes(num_nodes), num_gpus_per_node(num_gpus_per_node),
@@ -1225,7 +1225,7 @@ CommDevice *NetworkedMachineModel::get_nominal_path(MemDevice *src_mem,
 }
 
 // TODO
-void NetworkedMachineModel::save_topology_json(const std::string &fname) const {
+void NetworkedMachineModel::save_topology_json(std::string const &fname) const {
   return;
 }
 
@@ -1233,7 +1233,7 @@ void NetworkedMachineModel::set_pcie(bool state) { pcie_on = state; }
 
 void NetworkedMachineModel::set_pipeline(bool state) { pipelined = state; }
 
-void NetworkedMachineModel::set_topology(const ConnectionMatrix &conn) {
+void NetworkedMachineModel::set_topology(ConnectionMatrix const &conn) {
   conn_matrix = conn;
   int total_devs = num_nodes + num_switches;
   for (int i = 0; i < total_devs; i++) {
@@ -1248,11 +1248,11 @@ void NetworkedMachineModel::set_topology(const ConnectionMatrix &conn) {
   update_route();
 }
 
-const ConnectionMatrix &NetworkedMachineModel::get_conn_matrix() {
+ConnectionMatrix const &NetworkedMachineModel::get_conn_matrix() {
   return conn_matrix;
 }
 
-const std::map<size_t, NominalCommDevice *> &
+std::map<size_t, NominalCommDevice *> const &
 NetworkedMachineModel::get_nomm_comm_devs() {
   return ids_to_nw_nominal_device;
 }

--- a/src/runtime/machine_view.cc
+++ b/src/runtime/machine_view.cc
@@ -58,7 +58,7 @@ size_t MachineView::hash() const {
   return ret;
 }
 
-int MachineView::get_device_id(const DomainPoint &p) const {
+int MachineView::get_device_id(DomainPoint const &p) const {
   assert(p.get_dim() == ndims);
   assert(this->get_domain().contains(p));
   int idx = this->start_device_id;
@@ -67,7 +67,7 @@ int MachineView::get_device_id(const DomainPoint &p) const {
   return idx;
 }
 
-bool MachineView::operator==(const MachineView &rhs) const {
+bool MachineView::operator==(MachineView const &rhs) const {
   if (device_type != rhs.device_type)
     return false;
   if (ndims != rhs.ndims)
@@ -83,7 +83,7 @@ bool MachineView::operator==(const MachineView &rhs) const {
   return true;
 }
 
-bool MachineView::operator!=(const MachineView &rhs) const {
+bool MachineView::operator!=(MachineView const &rhs) const {
   return !(*this == rhs);
 }
 

--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -70,7 +70,7 @@ LegionRuntime::Logger::Category log_measure("measure");
 
 Op::Op(FFModel &model,
        OperatorType op_type,
-       const char *name,
+       char const *name,
        int numInputs,
        int numWeights,
        bool allocate_weights,
@@ -92,7 +92,7 @@ Op::Op(FFModel &model,
 
 Op::Op(FFModel &model,
        OperatorType _op_type,
-       const char *_name,
+       char const *_name,
        int _numInputs,
        int _numWeights,
        int _numOutputs,
@@ -137,11 +137,11 @@ Op::Op(FFModel &model,
 
 Op::Op(FFModel &model,
        OperatorType _op_type,
-       const char *_name,
+       char const *_name,
        int _numInputs,
        int _numWeights,
        int _numOutputs,
-       const ParallelTensor *_inputs)
+       ParallelTensor const *_inputs)
     : op_type(_op_type), op_guid(model.op_global_guid++), numInputs(_numInputs),
       numWeights(_numWeights), numOutputs(_numOutputs),
       profiling(model.config.profiling) {
@@ -219,7 +219,7 @@ Op *Op::materialize(FFModel &ff,
   assert(false && "This op does not support materialization");
 }
 
-void Op::zero_grad(const FFModel &ff) {
+void Op::zero_grad(FFModel const &ff) {
   // Do nothing for input and weight
   if (op_type == OP_INPUT || op_type == OP_WEIGHT)
     return;
@@ -275,7 +275,7 @@ void Op::zero_grad(const FFModel &ff) {
   runtime->execute_index_space(ctx, launcher);
 }
 
-ParallelConfig Op::get_data_parallel_config(const FFModel &ff) const {
+ParallelConfig Op::get_data_parallel_config(FFModel const &ff) const {
   return get_basic_data_parallel_config(
       ff.config.workersPerNode * ff.config.numNodes, this->get_dimension());
 }
@@ -291,7 +291,7 @@ ParallelConfig get_basic_data_parallel_config(int num_parts, int dims) {
   return pc;
 }
 
-ParallelConfig Op::get_random_parallel_config(const FFModel &ff) const {
+ParallelConfig Op::get_random_parallel_config(FFModel const &ff) const {
   std::vector<int> candidates;
   int batch_size = outputs[0]->dims[outputs[0]->num_dims - 1].size;
   for (int i = 1; i <= ff.config.workersPerNode; i++)
@@ -356,8 +356,8 @@ bool Op::is_adoptable_parallel_config(FFModel const &ff,
   return false;
 }
 
-bool Op::is_valid_parallel_config(const FFModel &ff,
-                                  const ParallelConfig &pc) const {
+bool Op::is_valid_parallel_config(FFModel const &ff,
+                                  ParallelConfig const &pc) const {
   // By default only data parallelism is allowed
   // Check dim match
   if (pc.nDims != this->get_dimension())
@@ -368,7 +368,7 @@ bool Op::is_valid_parallel_config(const FFModel &ff,
   return true;
 }
 
-Domain Op::get_output_tensor_shape(const ParallelConfig &pc,
+Domain Op::get_output_tensor_shape(ParallelConfig const &pc,
                                    int output_idx,
                                    int part_idx) const {
   assert(output_idx < numOutputs);
@@ -388,7 +388,7 @@ Domain Op::get_output_tensor_shape(const ParallelConfig &pc,
   return d;
 }
 
-Domain Op::get_input_tensor_shape(const ParallelConfig &pc,
+Domain Op::get_input_tensor_shape(ParallelConfig const &pc,
                                   int input_idx,
                                   int part_idx) const {
   assert(input_idx < numInputs);
@@ -427,7 +427,7 @@ Domain Op::get_input_tensor_shape(const ParallelConfig &pc,
   return d;
 }
 
-Domain Op::get_weight_tensor_shape(const ParallelConfig &pc,
+Domain Op::get_weight_tensor_shape(ParallelConfig const &pc,
                                    int weight_idx,
                                    int part_idx) const {
   // Default data parallel weight replication
@@ -444,18 +444,18 @@ Domain Op::get_weight_tensor_shape(const ParallelConfig &pc,
 }
 
 void Op::solve_parallel_dim_mappings(
-    const std::vector<ParallelDim const *> &inputs,
-    const std::vector<ParallelDim *> &weights,
-    const std::vector<ParallelDim *> &outputs) const {
+    std::vector<ParallelDim const *> const &inputs,
+    std::vector<ParallelDim *> const &weights,
+    std::vector<ParallelDim *> const &outputs) const {
   FlexFlow::solve_parallel_dim_mappings(
       *this->parallel_dims_mapping, inputs, weights, outputs);
 }
 
 void solve_parallel_dim_mappings(
-    const std::vector<ParallelDimMappingRecord> &mapping,
-    const std::vector<ParallelDim const *> &inputs,
-    const std::vector<ParallelDim *> &weights,
-    const std::vector<ParallelDim *> &outputs) {
+    std::vector<ParallelDimMappingRecord> const &mapping,
+    std::vector<ParallelDim const *> const &inputs,
+    std::vector<ParallelDim *> const &weights,
+    std::vector<ParallelDim *> const &outputs) {
   for (ParallelDimMappingRecord const &record : mapping) {
     ParallelDim const &input_dim = inputs[record.input_idx][record.input_dim];
 
@@ -493,7 +493,7 @@ void solve_parallel_dim_mappings(
 }
 
 std::unordered_map<int, int>
-output_to_input_mapping(const std::vector<ParallelDimMappingRecord> &mapping) {
+output_to_input_mapping(std::vector<ParallelDimMappingRecord> const &mapping) {
   std::unordered_map<int, int> dim_mapping;
   for (ParallelDimMappingRecord const &record : mapping) {
     if (record.get_type() == MappingRecordType::INPUT_OUTPUT) {
@@ -505,7 +505,7 @@ output_to_input_mapping(const std::vector<ParallelDimMappingRecord> &mapping) {
 }
 
 std::unordered_map<int, int>
-input_to_output_mapping(const std::vector<ParallelDimMappingRecord> &mapping) {
+input_to_output_mapping(std::vector<ParallelDimMappingRecord> const &mapping) {
   std::unordered_map<int, int> dim_mapping;
   for (ParallelDimMappingRecord const &record : mapping) {
     if (record.get_type() == MappingRecordType::INPUT_OUTPUT) {
@@ -518,8 +518,8 @@ input_to_output_mapping(const std::vector<ParallelDimMappingRecord> &mapping) {
 
 #ifdef FF_USE_NCCL
 ncclUniqueId
-Op::get_nccl_unique_id_task(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+Op::get_nccl_unique_id_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   ncclUniqueId ncclId;
@@ -527,13 +527,13 @@ Op::get_nccl_unique_id_task(const Task *task,
   return ncclId;
 }
 
-ncclComm_t Op::init_nccl_comms_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+ncclComm_t Op::init_nccl_comms_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
   // Must be an index space launch
   assert(task->is_index_space);
-  ncclUniqueId ncclId = *((const ncclUniqueId *)task->args);
+  ncclUniqueId ncclId = *((ncclUniqueId const *)task->args);
   int allRanks = task->index_domain.get_volume();
   assert(task->index_domain.contains(task->index_point));
   int myRank = 0;
@@ -864,7 +864,7 @@ bool Op::check_output_input_weight_same_machine_view() const {
   return true;
 }
 
-void Op::set_argumentmap_for_init(const FFModel &ff, ArgumentMap &argmap) {
+void Op::set_argumentmap_for_init(FFModel const &ff, ArgumentMap &argmap) {
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   Domain domain = runtime->get_index_space_domain(ctx, this->parallel_is);
@@ -907,7 +907,7 @@ void Op::set_argumentmap_for_init(const FFModel &ff, ArgumentMap &argmap) {
   }
 }
 
-void Op::set_opmeta_from_futuremap(const FFModel &ff, const FutureMap &fm) {
+void Op::set_opmeta_from_futuremap(FFModel const &ff, FutureMap const &fm) {
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   Domain domain = runtime->get_index_space_domain(ctx, parallel_is);
@@ -928,7 +928,7 @@ void Op::set_opmeta_from_futuremap(const FFModel &ff, const FutureMap &fm) {
   }
 }
 
-void Op::set_argumentmap_for_forward(const FFModel &ff, ArgumentMap &argmap) {
+void Op::set_argumentmap_for_forward(FFModel const &ff, ArgumentMap &argmap) {
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   Domain domain = runtime->get_index_space_domain(ctx, parallel_is);
@@ -950,7 +950,7 @@ void Op::set_argumentmap_for_forward(const FFModel &ff, ArgumentMap &argmap) {
   }
 }
 
-void Op::set_argumentmap_for_backward(const FFModel &ff, ArgumentMap &argmap) {
+void Op::set_argumentmap_for_backward(FFModel const &ff, ArgumentMap &argmap) {
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   Domain domain = runtime->get_index_space_domain(ctx, parallel_is);
@@ -1126,8 +1126,8 @@ FFModel::FFModel(FFConfig &_config)
 }
 
 #ifdef FF_USE_NCCL
-ncclComm_t *FFModel::find_nccl_comms(const MachineView &view) const {
-  const auto &it = view_hash_to_nccl_comms.find(view.hash());
+ncclComm_t *FFModel::find_nccl_comms(MachineView const &view) const {
+  auto const &it = view_hash_to_nccl_comms.find(view.hash());
   if (it == view_hash_to_nccl_comms.end()) {
     assert(config.computationMode == COMP_MODE_INFERENCE);
     return NULL;
@@ -1139,7 +1139,7 @@ ncclComm_t *FFModel::find_nccl_comms(const MachineView &view) const {
 
 template <int NDIM>
 Tensor
-FFModel::create_constant(const int dims[], float value, DataType data_type) {
+FFModel::create_constant(int const dims[], float value, DataType data_type) {
   // FIXME: currently create gradients for constants since the current auto grad
   // algorithm computes gradients for all operators
   Tensor tensor = create_tensor<NDIM>(
@@ -1179,9 +1179,9 @@ PCG::Node FFModel::new_node(Op *op) {
 }
 
 Tensor FFModel::create_tensor(int numdim,
-                              const int dims[],
+                              int const dims[],
                               DataType data_type,
-                              const Layer *layer,
+                              Layer const *layer,
                               int idx,
                               bool create_grad) {
   switch (numdim) {
@@ -1198,7 +1198,7 @@ Tensor FFModel::create_tensor(int numdim,
 ParallelTensor FFModel::create_parallel_tensor(int numdim,
                                                const ParallelDim dims[],
                                                DataType data_type,
-                                               const Op *op,
+                                               Op const *op,
                                                int idx,
                                                bool create_grad,
                                                size_t input_tensor_guid) {
@@ -1215,9 +1215,9 @@ ParallelTensor FFModel::create_parallel_tensor(int numdim,
 }
 
 Tensor FFModel::create_tensor_legion_ordering(int numdim,
-                                              const int dims[],
+                                              int const dims[],
                                               DataType data_type,
-                                              const Layer *layer,
+                                              Layer const *layer,
                                               int idx,
                                               bool create_grad) {
   int c_dims[MAX_TENSOR_DIM];
@@ -1230,7 +1230,7 @@ ParallelTensor
 FFModel::create_parallel_tensor_legion_ordering(int numdim,
                                                 const ParallelDim dims[],
                                                 DataType data_type,
-                                                const Op *op,
+                                                Op const *op,
                                                 int idx,
                                                 bool create_grad,
                                                 size_t input_tensor_guid) {
@@ -1242,9 +1242,9 @@ FFModel::create_parallel_tensor_legion_ordering(int numdim,
 }
 
 template <int NDIM>
-Tensor FFModel::create_tensor(const int dims[],
+Tensor FFModel::create_tensor(int const dims[],
                               DataType data_type,
-                              const Layer *owner_layer,
+                              Layer const *owner_layer,
                               int owner_idx,
                               bool create_grad) {
   Tensor tensor = new TensorBase();
@@ -1278,7 +1278,7 @@ Tensor FFModel::create_tensor(const int dims[],
 template <int NDIM>
 ParallelTensor FFModel::create_parallel_tensor(const ParallelDim dims[],
                                                DataType data_type,
-                                               const Op *owner_op,
+                                               Op const *owner_op,
                                                int owner_idx,
                                                bool create_grad,
                                                size_t input_tensor_guid) {
@@ -1304,9 +1304,9 @@ ParallelTensor FFModel::create_parallel_tensor(const ParallelDim dims[],
 }
 
 Parameter FFModel::create_weight_legion_ordering(int numdim,
-                                                 const int dims[],
+                                                 int const dims[],
                                                  DataType data_type,
-                                                 const Layer *layer,
+                                                 Layer const *layer,
                                                  bool create_grad,
                                                  Initializer *initializer,
                                                  ParameterSyncType sync_type) {
@@ -1318,9 +1318,9 @@ Parameter FFModel::create_weight_legion_ordering(int numdim,
 }
 
 Parameter FFModel::create_weight(int numdim,
-                                 const int dims[],
+                                 int const dims[],
                                  DataType data_type,
-                                 const Layer *owner_layer,
+                                 Layer const *owner_layer,
                                  bool create_grad,
                                  Initializer *initializer,
                                  ParameterSyncType sync_type) {
@@ -1357,7 +1357,7 @@ Parameter FFModel::create_weight(int numdim,
 template <int NDIM>
 ParallelParameter FFModel::create_parallel_weight(const ParallelDim dims[],
                                                   DataType data_type,
-                                                  const Op *owner_op,
+                                                  Op const *owner_op,
                                                   bool create_grad,
                                                   Initializer *initializer,
                                                   ParameterSyncType sync_type) {
@@ -1387,7 +1387,7 @@ ParallelParameter FFModel::create_parallel_weight(const ParallelDim dims[],
 ParallelParameter FFModel::create_parallel_weight(int numdim,
                                                   const ParallelDim dims[],
                                                   DataType data_type,
-                                                  const Op *owner_op,
+                                                  Op const *owner_op,
                                                   bool create_grad,
                                                   Initializer *initializer,
                                                   ParameterSyncType sync_type) {
@@ -1407,7 +1407,7 @@ ParallelParameter
 FFModel::create_parallel_weight_legion_ordering(int numdim,
                                                 const ParallelDim dims[],
                                                 DataType data_type,
-                                                const Op *owner_op,
+                                                Op const *owner_op,
                                                 bool create_grad,
                                                 Initializer *initializer,
                                                 ParameterSyncType sync_type) {
@@ -1418,7 +1418,7 @@ FFModel::create_parallel_weight_legion_ordering(int numdim,
       numdim, c_dims, data_type, owner_op, create_grad, initializer, sync_type);
 }
 
-void FFModel::map_tensor(ParallelTensor tensor, const Op *op) {
+void FFModel::map_tensor(ParallelTensor tensor, Op const *op) {
   switch (tensor->num_dims) {
 #define DIMFUNC(NDIM)                                                          \
   case NDIM: {                                                                 \
@@ -1437,7 +1437,7 @@ void FFModel::map_tensor(ParallelTensor tensor, const Op *op) {
 // Map tensor using parallelization strategies described in parallel_op
 template <int NDIM>
 void FFModel::map_tensor_with_dim(ParallelTensor tensor,
-                                  const Op *parallel_op) {
+                                  Op const *parallel_op) {
   tensor->parallel_is = get_or_create_task_is(tensor);
   assert(tensor->owner_op != NULL);
   Context ctx = config.lg_ctx;
@@ -1460,7 +1460,7 @@ void FFModel::map_tensor_with_dim(ParallelTensor tensor,
 
 template <int NDIM, int TDIM>
 void FFModel::map_tensor_with_dim2(ParallelTensor tensor,
-                                   const Op *parallel_op) {
+                                   Op const *parallel_op) {
   // Step 0: check we are the owner or the owner is NULL
   // in which case set the owner to us
   if (tensor->owner_op == NULL) {
@@ -1540,7 +1540,7 @@ void FFModel::map_tensor_with_dim2(ParallelTensor tensor,
   }
 }
 
-void FFModel::map_weight(ParallelTensor weight, const Op *op) {
+void FFModel::map_weight(ParallelTensor weight, Op const *op) {
   switch (weight->num_dims) {
 #define DIMFUNC(DIM)                                                           \
   case DIM: {                                                                  \
@@ -1558,7 +1558,7 @@ void FFModel::map_weight(ParallelTensor weight, const Op *op) {
 
 template <int NDIM>
 void FFModel::map_weight_with_dim(ParallelTensor weight,
-                                  const Op *parallel_op) {
+                                  Op const *parallel_op) {
   // Step 0: check we are the owner or the owner is NULL
   // in which case set the owner to us
   if (weight->owner_op == NULL) {
@@ -1611,7 +1611,7 @@ bool FFModel::get_parallel_tensor_from_tensor(
   }
   if (tensor->owner_layer != nullptr) {
     Op *mapped_op = nullptr;
-    for (const auto &op : operators) {
+    for (auto const &op : operators) {
       if (op->layer_guid == tensor->owner_layer->layer_guid) {
         assert(mapped_op == nullptr);
         mapped_op = op;
@@ -1628,8 +1628,8 @@ bool FFModel::get_parallel_tensor_from_tensor(
 
 void FFModel::create_disjoint_partition(int num_dims,
                                         const ParallelDim dims[],
-                                        const IndexSpace &part_is,
-                                        const LogicalRegion &region,
+                                        IndexSpace const &part_is,
+                                        LogicalRegion const &region,
                                         LogicalPartition &part) {
   Context ctx = config.lg_ctx;
   Runtime *runtime = config.lg_hlr;
@@ -1651,8 +1651,8 @@ void FFModel::create_disjoint_partition(int num_dims,
 template <int NDIM, int TDIM>
 void FFModel::create_disjoint_partition_with_dim2(
     const ParallelDim dims[],
-    const IndexSpaceT<TDIM> &part_is,
-    const LogicalRegion &region,
+    IndexSpaceT<TDIM> const &part_is,
+    LogicalRegion const &region,
     LogicalPartition &part) {
   Context ctx = config.lg_ctx;
   Runtime *runtime = config.lg_hlr;
@@ -1682,8 +1682,8 @@ void FFModel::create_disjoint_partition_with_dim2(
 void FFModel::create_aliased_partition(int num_dims,
                                        const ParallelDim dims[],
                                        int aliased_dim,
-                                       const IndexSpace &part_is,
-                                       const LogicalRegion &region,
+                                       IndexSpace const &part_is,
+                                       LogicalRegion const &region,
                                        LogicalPartition &part) {
   Context ctx = config.lg_ctx;
   Runtime *runtime = config.lg_hlr;
@@ -1706,8 +1706,8 @@ template <int NDIM, int TDIM>
 void FFModel::create_aliased_partition_with_dim2(
     const ParallelDim dims[],
     int aliased_dim,
-    const IndexSpaceT<TDIM> &part_is,
-    const LogicalRegion &region,
+    IndexSpaceT<TDIM> const &part_is,
+    LogicalRegion const &region,
     LogicalPartition &part) {
   Context ctx = config.lg_ctx;
   Runtime *runtime = config.lg_hlr;
@@ -1738,7 +1738,7 @@ void FFModel::create_aliased_partition_with_dim2(
 
 template <int NDIM>
 void FFModel::create_disjoint_partition(const ParallelTensor tensor,
-                                        const IndexSpaceT<NDIM> &part_is,
+                                        IndexSpaceT<NDIM> const &part_is,
                                         LogicalPartition &part_fwd,
                                         LogicalPartition &part_bwd) {
   Context ctx = config.lg_ctx;
@@ -1783,7 +1783,7 @@ void FFModel::create_disjoint_partition(const ParallelTensor tensor,
 template <int NDIM, int TDIM>
 void FFModel::create_data_parallel_partition_with_diff_dims(
     const ParallelTensor tensor,
-    const IndexSpaceT<TDIM> &part_is,
+    IndexSpaceT<TDIM> const &part_is,
     LogicalPartition &part_fwd,
     LogicalPartition &part_bwd) {
   assert(tensor->num_dims == NDIM);
@@ -1832,7 +1832,7 @@ void FFModel::create_data_parallel_partition_with_diff_dims(
 // 2. partition is 2D (sample, channel_out)
 
 template <int NDIM, int TDIM>
-void FFModel::map_linear_weight(ParallelTensor weight, const Op *op) {
+void FFModel::map_linear_weight(ParallelTensor weight, Op const *op) {
   assert(op->op_type == OP_LINEAR);
   std::string pcname = op->name;
   Context ctx = config.lg_ctx;
@@ -1947,7 +1947,7 @@ void FFModel::map_linear_weight(ParallelTensor weight, const Op *op) {
 }
 
 template <int NDIM>
-void FFModel::map_conv_weight(ParallelTensor weight, const Op *op) {
+void FFModel::map_conv_weight(ParallelTensor weight, Op const *op) {
   Context ctx = config.lg_ctx;
   Runtime *runtime = config.lg_hlr;
   Rect<4> part_rect = runtime->get_index_space_domain(ctx, op->parallel_is);
@@ -2055,8 +2055,8 @@ void FFModel::map_conv_weight(ParallelTensor weight, const Op *op) {
 }
 
 template <int NDIM, int TDIM>
-ParallelTensor FFModel::create_linear_replica(const int dims[],
-                                              const IndexSpaceT<TDIM> &task_is,
+ParallelTensor FFModel::create_linear_replica(int const dims[],
+                                              IndexSpaceT<TDIM> const &task_is,
                                               DataType data_type) {
   // No need to create replica for INFERENCE
   assert(config.computationMode == COMP_MODE_TRAINING);
@@ -2115,13 +2115,13 @@ ParallelTensor FFModel::create_linear_replica(const int dims[],
   return replica;
 }
 
-IndexSpace FFModel::get_task_is(const MachineView &view) const {
-  const auto &iter = all_task_is.find(view);
+IndexSpace FFModel::get_task_is(MachineView const &view) const {
+  auto const &iter = all_task_is.find(view);
   assert(iter != all_task_is.end());
   return iter->second;
 }
 
-IndexSpace FFModel::get_task_is(const ParallelConfig &pc) const {
+IndexSpace FFModel::get_task_is(ParallelConfig const &pc) const {
   MachineView view;
   view.ndims = pc.nDims;
   for (int i = 0; i < view.ndims; i++)
@@ -2144,7 +2144,7 @@ IndexSpace FFModel::get_or_create_task_is(const ParallelTensor tensor) {
   return get_or_create_task_is(view);
 }
 
-IndexSpace FFModel::get_or_create_task_is(const ParallelConfig &pc) {
+IndexSpace FFModel::get_or_create_task_is(ParallelConfig const &pc) {
   MachineView view;
   view.ndims = pc.nDims;
   for (int i = 0; i < view.ndims; i++)
@@ -2152,7 +2152,7 @@ IndexSpace FFModel::get_or_create_task_is(const ParallelConfig &pc) {
   return get_or_create_task_is(view);
 }
 
-IndexSpace FFModel::get_or_create_task_is(const MachineView &view) {
+IndexSpace FFModel::get_or_create_task_is(MachineView const &view) {
   if (all_task_is.find(view) != all_task_is.end())
     return all_task_is[view];
   IndexSpace task_is;
@@ -2184,7 +2184,7 @@ IndexSpace FFModel::get_or_create_task_is(const MachineView &view) {
   return task_is;
 }
 
-IndexSpace FFModel::get_or_create_task_is(const Domain &domain) {
+IndexSpace FFModel::get_or_create_task_is(Domain const &domain) {
   MachineView view;
   view.ndims = domain.get_dim();
   for (int i = 0; i < view.ndims; i++) {
@@ -2211,12 +2211,12 @@ IndexSpace FFModel::get_task_is(int ndims, const std::string& pcname) const
 }
 */
 
-IndexSpace FFModel::get_task_is(const Domain &domain) const {
+IndexSpace FFModel::get_task_is(Domain const &domain) const {
   MachineView view;
   view.ndims = domain.get_dim();
   for (int i = 0; i < view.ndims; i++)
     view.dim[i] = domain.hi()[i] - domain.lo()[i] + 1;
-  const auto &iter = all_task_is.find(view);
+  auto const &iter = all_task_is.find(view);
   assert(iter != all_task_is.end());
   return iter->second;
 }
@@ -2302,13 +2302,13 @@ Op *FFModel::get_final_operator() const {
 
 void FFModel::compile(Optimizer *_optimizer,
                       LossType loss_type,
-                      const std::vector<MetricsType> &metrics,
+                      std::vector<MetricsType> const &metrics,
                       CompMode comp_mode) {
   optimizer = _optimizer;
   compile(loss_type, metrics, comp_mode);
 }
 
-bool FFModel::apply_fusion(const std::vector<Op *> &operators,
+bool FFModel::apply_fusion(std::vector<Op *> const &operators,
                            std::vector<Op *> &new_operators) {
   // Context ctx = config.lg_ctx;
   // Runtime* runtime = config.lg_hlr;
@@ -2390,7 +2390,7 @@ bool FFModel::apply_fusion(const std::vector<Op *> &operators,
 }
 
 Op *FFModel::create_operator_from_layer(
-    Layer *layer, const std::vector<ParallelTensor> &inputs) {
+    Layer *layer, std::vector<ParallelTensor> const &inputs) {
   switch (layer->op_type) {
   case OP_INPUT: {
     // Input op cannot have an input
@@ -2515,7 +2515,7 @@ Op *FFModel::create_operator_from_layer(
 
 void FFModel::create_operators_from_layers() {
   std::map<const Tensor, ParallelTensor> tensors_to_parallel_tensors;
-  for (const auto &l : layers) {
+  for (auto const &l : layers) {
     std::vector<ParallelTensor> inputs;
     for (int i = 0; i < l->numInputs; i++) {
       // create new input tensors
@@ -2532,7 +2532,7 @@ void FFModel::create_operators_from_layers() {
 }
 
 void FFModel::compile(LossType loss_type,
-                      const std::vector<MetricsType> &metrics,
+                      std::vector<MetricsType> const &metrics,
                       CompMode comp_mode) {
   if (metrics_input == -1)
     metrics_input = operators.size() - 1;
@@ -2567,12 +2567,12 @@ void FFModel::compile(LossType loss_type,
     operators.clear();
     convert_graph_to_operators(best_graph, optimal_views);
     delete best_graph;
-    for (const auto &layer : layers) {
+    for (auto const &layer : layers) {
       // map inputs to parallel tensor
       if (layer->op_type == OP_INPUT) {
         Tensor tensor = layer->outputs[0];
         ParallelTensor parallel_tensor = nullptr;
-        for (const auto &op : operators) {
+        for (auto const &op : operators) {
           if (op->op_type == OP_INPUT) {
             NoOp *noop = (NoOp *)op;
             if (noop->input_tensor_guid == tensor->tensor_guid) {
@@ -2588,7 +2588,7 @@ void FFModel::compile(LossType loss_type,
         assert(layer->weights[i] != nullptr);
         Tensor weight = layer->weights[i];
         ParallelTensor parallel_weight = nullptr;
-        for (const auto &op : operators) {
+        for (auto const &op : operators) {
           if (op->layer_guid == layer->layer_guid) {
             assert(op->op_type == layer->op_type);
             assert(op->numWeights == layer->numWeights);
@@ -2975,8 +2975,8 @@ void FFModel::propagate(std::map<Op *, ParallelConfig> const &current,
 }
 #endif
 
-void FFModel::rewrite(const std::map<const Op *, ParallelConfig> &current,
-                      std::map<const Op *, ParallelConfig> &next,
+void FFModel::rewrite(std::map<Op const *, ParallelConfig> const &current,
+                      std::map<Op const *, ParallelConfig> &next,
                       bool use_propagation) const {
   next = current;
   float propagate_chance;
@@ -2999,13 +2999,13 @@ void FFModel::rewrite(const std::map<const Op *, ParallelConfig> &current,
   }
 }
 
-void FFModel::mcmc_optimize(std::map<const Op *, ParallelConfig> &best,
+void FFModel::mcmc_optimize(std::map<Op const *, ParallelConfig> &best,
                             size_t budget,
                             float alpha,
                             CompMode comp_mode,
                             bool use_propagation) const {
   // Start from data parallel
-  std::map<const Op *, ParallelConfig> current, next;
+  std::map<Op const *, ParallelConfig> current, next;
   float best_runtime = simulator->simulate_runtime(this, best, comp_mode);
   current = best;
   float current_runtime = best_runtime;
@@ -3047,7 +3047,7 @@ void FFModel::mcmc_optimize(std::map<const Op *, ParallelConfig> &best,
   printf("=========== Best Discovered Strategy ==========\n");
   simulator->simulate_runtime(
       this, best, comp_mode, this->config.export_strategy_task_graph_file);
-  std::map<const Op *, ParallelConfig>::const_iterator it;
+  std::map<Op const *, ParallelConfig>::const_iterator it;
   for (it = best.begin(); it != best.end(); it++) {
     printf("[%s] num_dims(%d) dims[", it->first->name, it->second.nDims);
     for (int i = 0; i < it->second.nDims; i++)
@@ -3095,8 +3095,8 @@ FFModel::get_bwd_edge_map() const {
 };
 
 PerfMetrics
-FFModel::update_metrics_task(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+FFModel::update_metrics_task(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              Runtime *runtime) {
   Metrics *m = (Metrics *)task->args;
@@ -3120,31 +3120,31 @@ FFModel::update_metrics_task(const Task *task,
 }
 
 // TODO: Move to an appropriate place
-template <> std::tuple<> get_input_shape(const std::tuple<> &) {
+template <> std::tuple<> get_input_shape(std::tuple<> const &) {
   return std::tuple<>();
 }
 
-template <> ParallelTensorShape get_input_shape(const ParallelTensor &input) {
+template <> ParallelTensorShape get_input_shape(ParallelTensor const &input) {
   return input->get_shape();
 }
 
 template <>
 std::pair<ParallelTensorShape, ParallelTensorShape>
-get_input_shape(const std::pair<ParallelTensor, ParallelTensor> &inputs) {
+get_input_shape(std::pair<ParallelTensor, ParallelTensor> const &inputs) {
   return std::make_pair(inputs.first->get_shape(), inputs.second->get_shape());
 }
 
 template <>
 std::vector<ParallelTensorShape>
-get_input_shape(const std::vector<ParallelTensor> &inputs) {
+get_input_shape(std::vector<ParallelTensor> const &inputs) {
   std::vector<ParallelTensorShape> shapes;
-  for (const auto &input : inputs) {
+  for (auto const &input : inputs) {
     shapes.push_back(input->get_shape());
   }
   return shapes;
 }
 
-void Op::prefetch(const FFModel &ff) {
+void Op::prefetch(FFModel const &ff) {
   // TODO: perform prefetch for performance imporvement
 }
 
@@ -3283,7 +3283,7 @@ FFConfig::FFConfig() {
 
   // Parse input arguments
   {
-    const InputArgs &command_args = HighLevelRuntime::get_input_args();
+    InputArgs const &command_args = HighLevelRuntime::get_input_args();
     char **argv = command_args.argv;
     int argc = command_args.argc;
     parse_args(argv, argc);
@@ -4447,34 +4447,34 @@ void register_flexflow_internal_tasks() {
 
 // template instantiations
 #define DIMFUNC(DIM)                                                           \
-  template Tensor FFModel::create_tensor<DIM>(const int dims[],                \
+  template Tensor FFModel::create_tensor<DIM>(int const dims[],                \
                                               DataType data_type,              \
-                                              const Layer *owner_op,           \
+                                              Layer const *owner_op,           \
                                               int owner_idx,                   \
                                               bool create_grad);               \
   template ParallelTensor FFModel::create_parallel_tensor<DIM>(                \
       const ParallelDim dims[],                                                \
       DataType data_type,                                                      \
-      const Op *owner_op,                                                      \
+      Op const *owner_op,                                                      \
       int owner_idx,                                                           \
       bool create_grad,                                                        \
       size_t input_tensor_guid);                                               \
   template ParallelParameter FFModel::create_parallel_weight<DIM>(             \
       const ParallelDim dims[],                                                \
       DataType data_type,                                                      \
-      const Op *owner_op,                                                      \
+      Op const *owner_op,                                                      \
       bool create_grad,                                                        \
       Initializer *initializer,                                                \
       ParameterSyncType sync_type);                                            \
   template void FFModel::map_tensor_with_dim<DIM>(ParallelTensor tensor,       \
-                                                  const Op *parallel_op);      \
+                                                  Op const *parallel_op);      \
   template void FFModel::map_weight_with_dim<DIM>(ParallelTensor weight,       \
-                                                  const Op *parallel_op);      \
+                                                  Op const *parallel_op);      \
   template Tensor FFModel::create_constant<DIM>(                               \
-      const int *dims, float value, DataType data_type);                       \
+      int const *dims, float value, DataType data_type);                       \
   template void FFModel::create_disjoint_partition<DIM>(                       \
       const ParallelTensor tensor,                                             \
-      const IndexSpaceT<DIM> &part_is,                                         \
+      IndexSpaceT<DIM> const &part_is,                                         \
       LogicalPartition &part_fwd,                                              \
       LogicalPartition &part_bwd);
 LEGION_FOREACH_N(DIMFUNC)
@@ -4482,41 +4482,41 @@ LEGION_FOREACH_N(DIMFUNC)
 
 #define DIMFUNC(D1, D2)                                                        \
   template void FFModel::map_tensor_with_dim2<D1, D2>(ParallelTensor tensor,   \
-                                                      const Op *parallel_op);  \
+                                                      Op const *parallel_op);  \
   template void FFModel::create_disjoint_partition_with_dim2<D1, D2>(          \
       const ParallelDim dims[],                                                \
-      const IndexSpaceT<D2> &part_is,                                          \
-      const LogicalRegion &region,                                             \
+      IndexSpaceT<D2> const &part_is,                                          \
+      LogicalRegion const &region,                                             \
       LogicalPartition &part);                                                 \
   template void FFModel::create_aliased_partition_with_dim2<D1, D2>(           \
       const ParallelDim dims[],                                                \
       int aliased_dim,                                                         \
-      const IndexSpaceT<D2> &part_is,                                          \
-      const LogicalRegion &region,                                             \
+      IndexSpaceT<D2> const &part_is,                                          \
+      LogicalRegion const &region,                                             \
       LogicalPartition &part);                                                 \
   template void                                                                \
   FFModel::create_data_parallel_partition_with_diff_dims<D1, D2>(              \
       const ParallelTensor tensor,                                             \
-      const IndexSpaceT<D2> &part_is,                                          \
+      IndexSpaceT<D2> const &part_is,                                          \
       LogicalPartition &part_fwd,                                              \
       LogicalPartition &part_bwd);
 LEGION_FOREACH_NN(DIMFUNC)
 #undef DIMFUNC
 
 template void FFModel::map_conv_weight<4>(ParallelTensor weight,
-                                          const Op *parallel_op);
+                                          Op const *parallel_op);
 template void FFModel::map_conv_weight<1>(ParallelTensor weight,
-                                          const Op *parallel_op);
+                                          Op const *parallel_op);
 
 #define DIMFUNC(D1, D2)                                                        \
   template void FFModel::map_linear_weight<D1, D2>(ParallelTensor p,           \
-                                                   const Op *op);
+                                                   Op const *op);
 LEGION_FOREACH_NN(DIMFUNC)
 #undef DIMFUNC
 
 #define DIMFUNC(D1, D2)                                                        \
   template ParallelTensor FFModel::create_linear_replica<D1>(                  \
-      const int *dims, const IndexSpaceT<D2> &part_is, DataType data_type);
+      int const *dims, IndexSpaceT<D2> const &part_is, DataType data_type);
 LEGION_FOREACH_NN(DIMFUNC)
 #undef DIMFUNC
 

--- a/src/runtime/model.cpp
+++ b/src/runtime/model.cpp
@@ -84,13 +84,13 @@ void Op::inner_measure_operator_cost(Simulator *sim,
 }
 
 FFHandler
-UtilityTasks::init_cuda_task(const Task *task,
-                             const std::vector<PhysicalRegion> &regions,
+UtilityTasks::init_cuda_task(Task const *task,
+                             std::vector<PhysicalRegion> const &regions,
                              Context ctx,
                              Runtime *runtime) {
   assert(regions.size() == 0);
   assert(task->local_arglen == sizeof(FFInitInfo));
-  const FFInitInfo *info = (FFInitInfo *)task->local_args;
+  FFInitInfo const *info = (FFInitInfo *)task->local_args;
   // assert(task->arglen == sizeof(size_t));
   // size_t workSpaceSize = *(const size_t*) task->args;
   printf("workSpaceSize (%zu MB)\n", info->workSpaceSize / 1024 / 1024);
@@ -144,8 +144,8 @@ UtilityTasks::init_cuda_task(const Task *task,
   return handle;
 }
 
-void UtilityTasks::dummy_task(const Task *task,
-                              const std::vector<PhysicalRegion> &regions,
+void UtilityTasks::dummy_task(Task const *task,
+                              std::vector<PhysicalRegion> const &regions,
                               Context ctx,
                               Runtime *runtime) {}
 
@@ -181,15 +181,15 @@ void nearest_neighbor(unsigned char *image,
   regions[0]: image (unsigned char)
   regions[1]: label (int)
 */
-void UtilityTasks::load_images_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+void UtilityTasks::load_images_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
 #ifdef USE_DATA_LOADER
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
-  const AccessorWO<unsigned char, 3> acc_image(regions[0], FID_DATA);
-  const AccessorWO<int, 1> acc_label(regions[1], FID_DATA);
+  AccessorWO<unsigned char, 3> const acc_image(regions[0], FID_DATA);
+  AccessorWO<int, 1> const acc_label(regions[1], FID_DATA);
   Rect<3> rect_image;
   Rect<1> rect_label;
   unsigned char *buffer = (unsigned char *)malloc(3000 * 3000 * 3);
@@ -201,7 +201,7 @@ void UtilityTasks::load_images_task(const Task *task,
   assert(acc_label.accessor.is_dense_arbitrary(rect_label));
   unsigned char *image_ptr = acc_image.ptr(rect_image.lo);
   int *label_ptr = acc_label.ptr(rect_label.lo);
-  const DataLoadMeta *meta = (DataLoadMeta *)task->local_args;
+  DataLoadMeta const *meta = (DataLoadMeta *)task->local_args;
   int height = rect_image.hi[0] - rect_image.lo[0] + 1;
   int width = rect_image.hi[1] - rect_image.lo[1] + 1;
   int numImages = (rect_image.hi[2] - rect_image.lo[2] + 1) / 3;
@@ -259,11 +259,11 @@ void UtilityTasks::load_images_task(const Task *task,
 }
 
 __global__ void apply_normalize(float *tensor_ptr,
-                                const unsigned char *rgb_ptr,
+                                unsigned char const *rgb_ptr,
                                 size_t size,
                                 size_t hxw) {
-  const float mean[3] = {0.485, 0.456, 0.406};
-  const float var[3] = {0.229, 0.224, 0.225};
+  float const mean[3] = {0.485, 0.456, 0.406};
+  float const var[3] = {0.229, 0.224, 0.225};
 
   CUDA_KERNEL_LOOP(i, size) {
     // decide the color of the current position by assuming NCHW layout
@@ -277,14 +277,14 @@ __global__ void apply_normalize(float *tensor_ptr,
   regions[1](I): input_rgb
 */
 __host__ void
-UtilityTasks::normalize_images_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+UtilityTasks::normalize_images_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
   assert(regions.size() == 2);
   assert(task->regions.size() == 2);
-  const AccessorWO<float, 3> acc_tensor(regions[0], FID_DATA);
-  const AccessorRO<unsigned char, 3> acc_rgb(regions[1], FID_DATA);
+  AccessorWO<float, 3> const acc_tensor(regions[0], FID_DATA);
+  AccessorRO<unsigned char, 3> const acc_rgb(regions[1], FID_DATA);
   Rect<3> rect_tensor, rect_rgb;
   rect_tensor = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
@@ -296,7 +296,7 @@ UtilityTasks::normalize_images_task(const Task *task,
   size_t w = rect_tensor.hi[0] - rect_tensor.lo[0] + 1;
   size_t h = rect_tensor.hi[1] - rect_tensor.lo[1] + 1;
   float *tensor_ptr = acc_tensor.ptr(rect_tensor.lo);
-  const unsigned char *rgb_ptr = acc_rgb.ptr(rect_rgb.lo);
+  unsigned char const *rgb_ptr = acc_rgb.ptr(rect_rgb.lo);
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
   hipLaunchKernelGGL(apply_normalize,
@@ -324,12 +324,12 @@ __global__ void init_label_kernel(int *ptr, coord_t size) {
   }
 }
 
-void UtilityTasks::init_images_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+void UtilityTasks::init_images_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
-  const int BLKSIZE = 512;
-  const AccessorWO<float, 3> acc_image(regions[0], FID_DATA);
+  int const BLKSIZE = 512;
+  AccessorWO<float, 3> const acc_image(regions[0], FID_DATA);
   Rect<3> rect_image;
   rect_image = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
@@ -347,12 +347,12 @@ void UtilityTasks::init_images_task(const Task *task,
                      rect_image.volume());
 }
 
-void UtilityTasks::init_labels_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+void UtilityTasks::init_labels_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
-  const int BLKSIZE = 512;
-  const AccessorWO<int, 1> acc_label(regions[0], FID_DATA);
+  int const BLKSIZE = 512;
+  AccessorWO<int, 1> const acc_label(regions[0], FID_DATA);
   Rect<1> rect_label;
   rect_label = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -29,8 +29,8 @@ static std::uniform_real_distribution<float> unif(0, 1);
 
 // for summing connections...
 template <typename T>
-static std::vector<T> operator+(const std::vector<T> &a,
-                                const std::vector<T> &b) {
+static std::vector<T> operator+(std::vector<T> const &a,
+                                std::vector<T> const &b) {
   assert(a.size() == b.size());
 
   std::vector<T> result;
@@ -45,8 +45,8 @@ static std::vector<T> operator+(const std::vector<T> &a,
 }
 
 WeightedShortestPathRoutingStrategy::WeightedShortestPathRoutingStrategy(
-    const ConnectionMatrix &c,
-    const std::map<size_t, CommDevice *> &devmap,
+    ConnectionMatrix const &c,
+    std::map<size_t, CommDevice *> const &devmap,
     int total_devs)
     : conn(c), devmap(devmap), total_devs(total_devs) {}
 
@@ -258,8 +258,8 @@ WeightedShortestPathRoutingStrategy::hop_count(int src_node) {
 }
 
 ShortestPathNetworkRoutingStrategy::ShortestPathNetworkRoutingStrategy(
-    const ConnectionMatrix &c,
-    const std::map<size_t, CommDevice *> &devmap,
+    ConnectionMatrix const &c,
+    std::map<size_t, CommDevice *> const &devmap,
     int total_devs)
     : conn(c), devmap(devmap), total_devs(total_devs) {}
 
@@ -553,7 +553,7 @@ int FlatDegConstraintNetworkTopologyGenerator::get_id(int i, int j) const {
 }
 
 int FlatDegConstraintNetworkTopologyGenerator::get_if_in_use(
-    int node, const ConnectionMatrix &conn) const {
+    int node, ConnectionMatrix const &conn) const {
   int result = 0;
   for (int i = 0; i < num_nodes; i++) {
     result += conn[get_id(node, i)];

--- a/src/runtime/optimizer.cc
+++ b/src/runtime/optimizer.cc
@@ -20,9 +20,9 @@ namespace FlexFlow {
 
 using namespace Legion;
 
-Optimizer::Optimizer(const FFModel *_model) : model(_model) {}
+Optimizer::Optimizer(FFModel const *_model) : model(_model) {}
 
-ParallelTensor create_replica_parameter(const FFModel *model,
+ParallelTensor create_replica_parameter(FFModel const *model,
                                         const ParallelTensor p) {
   Context ctx = model->config.lg_ctx;
   Runtime *runtime = model->config.lg_hlr;
@@ -42,7 +42,7 @@ ParallelTensor create_replica_parameter(const FFModel *model,
   return v;
 }
 
-SGDOptimizer::SGDOptimizer(const FFModel *_model,
+SGDOptimizer::SGDOptimizer(FFModel const *_model,
                            double _lr,
                            double _momentum,
                            bool _nesterov,
@@ -192,11 +192,11 @@ void SGDOptimizer::update(const ParallelTensor p) {
   }
 }
 
-void SGDOptimizer::ps_update_task(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+void SGDOptimizer::ps_update_task(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime) {
-  const SGDOptimizer *op = (SGDOptimizer *)task->args;
+  SGDOptimizer const *op = (SGDOptimizer *)task->args;
   if (op->momentum > 0.0f) {
     assert(regions.size() == 3);
     assert(task->regions.size() == 3);
@@ -206,7 +206,7 @@ void SGDOptimizer::ps_update_task(const Task *task,
   }
   Domain domain = runtime->get_index_space_domain(
       ctx, task->regions[1].region.get_index_space());
-  const float *w_grad_ptr = NULL;
+  float const *w_grad_ptr = NULL;
   float *w_ptr = NULL, *v_ptr = NULL;
   size_t size = 0, num_replicas = 0;
   switch (domain.get_dim()) {
@@ -253,12 +253,12 @@ void SGDOptimizer::ps_update_task(const Task *task,
 }
 
 #ifdef FF_USE_NCCL
-void SGDOptimizer::nccl_update_task(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+void SGDOptimizer::nccl_update_task(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime) {
-  const SGDOptimizer *op = (SGDOptimizer *)task->args;
-  const OpMeta *meta = *((OpMeta **)task->local_args);
+  SGDOptimizer const *op = (SGDOptimizer *)task->args;
+  OpMeta const *meta = *((OpMeta **)task->local_args);
   // FFHandler handler = *((FFHandler*) task->local_args);
   if (op->momentum > 0.0f) {
     assert(regions.size() == 3);
@@ -269,7 +269,7 @@ void SGDOptimizer::nccl_update_task(const Task *task,
   }
   Domain domain = runtime->get_index_space_domain(
       ctx, task->regions[1].region.get_index_space());
-  const float *w_grad_ptr = NULL;
+  float const *w_grad_ptr = NULL;
   float *w_ptr = NULL, *v_ptr = NULL;
   size_t size = 0;
   switch (domain.get_dim()) {
@@ -315,7 +315,7 @@ void SGDOptimizer::nccl_update_task(const Task *task,
 //                        Adam Optimizer
 // ------------------------------------------------------------------
 
-AdamOptimizer::AdamOptimizer(const FFModel *_model,
+AdamOptimizer::AdamOptimizer(FFModel const *_model,
                              double _alpha,
                              double _beta1,
                              double _beta2,
@@ -487,16 +487,16 @@ void AdamOptimizer::update(const ParallelTensor p) {
   }
 }
 
-void AdamOptimizer::ps_update_task(const Task *task,
-                                   const std::vector<PhysicalRegion> &regions,
+void AdamOptimizer::ps_update_task(Task const *task,
+                                   std::vector<PhysicalRegion> const &regions,
                                    Context ctx,
                                    Runtime *runtime) {
   assert(regions.size() == 4);
   assert(task->regions.size() == 4);
-  const AdamOptimizer *op = (AdamOptimizer *)task->args;
+  AdamOptimizer const *op = (AdamOptimizer *)task->args;
   Domain domain = runtime->get_index_space_domain(
       ctx, task->regions[1].region.get_index_space());
-  const float *w_grad_ptr = NULL;
+  float const *w_grad_ptr = NULL;
   float *w_ptr = NULL, *v_ptr = NULL, *m_ptr = NULL;
   size_t size = 0, num_replicas = 0;
   switch (domain.get_dim()) {
@@ -543,18 +543,18 @@ void AdamOptimizer::ps_update_task(const Task *task,
 }
 
 #ifdef FF_USE_NCCL
-void AdamOptimizer::nccl_update_task(const Task *task,
-                                     const std::vector<PhysicalRegion> &regions,
+void AdamOptimizer::nccl_update_task(Task const *task,
+                                     std::vector<PhysicalRegion> const &regions,
                                      Context ctx,
                                      Runtime *runtime) {
   assert(regions.size() == 4);
   assert(task->regions.size() == 4);
-  const AdamOptimizer *op = (AdamOptimizer *)task->args;
-  const OpMeta *meta = *((OpMeta **)task->local_args);
+  AdamOptimizer const *op = (AdamOptimizer *)task->args;
+  OpMeta const *meta = *((OpMeta **)task->local_args);
   // FFHandler handler = *((FFHandler*) task->local_args);
   Domain domain = runtime->get_index_space_domain(
       ctx, task->regions[1].region.get_index_space());
-  const float *w_grad_ptr = NULL;
+  float const *w_grad_ptr = NULL;
   float *w_ptr = NULL, *v_ptr = NULL, *m_ptr = NULL;
   size_t size = 0;
   switch (domain.get_dim()) {

--- a/src/runtime/optimizer_kernel.cpp
+++ b/src/runtime/optimizer_kernel.cpp
@@ -28,7 +28,7 @@ __global__ void sgd_update(size_t count,
                            float weight_decay,
                            float momentum,
                            bool nesterov,
-                           const float *WGrad,
+                           float const *WGrad,
                            float *V,
                            float *W) {
   // Refernce https://pytorch.org/docs/stable/_modules/torch/optim/sgd.html#SGD
@@ -45,8 +45,8 @@ __global__ void sgd_update(size_t count,
   }
 }
 
-__host__ void SGDOptimizer::ps_update_task_gpu(const SGDOptimizer *op,
-                                               const float *w_grad_ptr,
+__host__ void SGDOptimizer::ps_update_task_gpu(SGDOptimizer const *op,
+                                               float const *w_grad_ptr,
                                                size_t size,
                                                int num_replicas,
                                                float *w_ptr,
@@ -55,7 +55,7 @@ __host__ void SGDOptimizer::ps_update_task_gpu(const SGDOptimizer *op,
   checkCUDA(get_legion_stream(&stream));
   // Step 1: Gather gradients in the first replica
   for (int i = 1; i < num_replicas; i++) {
-    const float *src = w_grad_ptr + i * size;
+    float const *src = w_grad_ptr + i * size;
     hipLaunchKernelGGL(HIP_KERNEL_NAME(apply_add_with_scale<float>),
                        GET_BLOCKS(size),
                        CUDA_NUM_THREADS,
@@ -85,8 +85,8 @@ __host__ void SGDOptimizer::ps_update_task_gpu(const SGDOptimizer *op,
 }
 
 #ifdef FF_USE_NCCL
-__host__ void SGDOptimizer::nccl_update_task_gpu(const SGDOptimizer *op,
-                                                 const float *w_grad_ptr,
+__host__ void SGDOptimizer::nccl_update_task_gpu(SGDOptimizer const *op,
+                                                 float const *w_grad_ptr,
                                                  size_t size,
                                                  float *w_ptr,
                                                  float *v_ptr) {
@@ -125,7 +125,7 @@ __host__ void SGDOptimizer::nccl_update_task_gpu(const SGDOptimizer *op,
 //                        Adam Optimizer
 // ==================================================================
 __global__ void
-add_kernel(int count, float scale, const float *src, float *dst) {
+add_kernel(int count, float scale, float const *src, float *dst) {
   CUDA_KERNEL_LOOP(i, count) { dst[i] += src[i] * scale; }
 }
 
@@ -139,7 +139,7 @@ __global__ void adam_update(int count,
                             float beta2,
                             float weight_decay,
                             float epsilon,
-                            const float *WGrad,
+                            float const *WGrad,
                             float *M,
                             float *V,
                             float *W) {
@@ -157,8 +157,8 @@ __global__ void adam_update(int count,
   }
 }
 
-__host__ void AdamOptimizer::ps_update_task_gpu(const AdamOptimizer *op,
-                                                const float *w_grad_ptr,
+__host__ void AdamOptimizer::ps_update_task_gpu(AdamOptimizer const *op,
+                                                float const *w_grad_ptr,
                                                 size_t size,
                                                 int num_replicas,
                                                 float *w_ptr,
@@ -168,7 +168,7 @@ __host__ void AdamOptimizer::ps_update_task_gpu(const AdamOptimizer *op,
   checkCUDA(get_legion_stream(&stream));
   // Step 1: Gather gradients in the first replica
   for (int i = 1; i < num_replicas; i++) {
-    const float *src = w_grad_ptr + i * size;
+    float const *src = w_grad_ptr + i * size;
     hipLaunchKernelGGL(add_kernel,
                        GET_BLOCKS(size),
                        CUDA_NUM_THREADS,
@@ -202,8 +202,8 @@ __host__ void AdamOptimizer::ps_update_task_gpu(const AdamOptimizer *op,
 }
 
 #ifdef FF_USE_NCCL
-__host__ void AdamOptimizer::nccl_update_task_gpu(const AdamOptimizer *op,
-                                                  const float *w_grad_ptr,
+__host__ void AdamOptimizer::nccl_update_task_gpu(AdamOptimizer const *op,
+                                                  float const *w_grad_ptr,
                                                   size_t size,
                                                   float *w_ptr,
                                                   float *v_ptr,

--- a/src/runtime/parallel_op.cc
+++ b/src/runtime/parallel_op.cc
@@ -4,7 +4,7 @@ namespace FlexFlow {
 
 ParallelOp::ParallelOp(FFModel &model,
                        OperatorType op_type,
-                       const char *name,
+                       char const *name,
                        const ParallelTensor input)
     : Op(model,
          op_type,

--- a/src/runtime/parallel_tensor.cc
+++ b/src/runtime/parallel_tensor.cc
@@ -19,7 +19,7 @@ namespace FlexFlow {
 
 using namespace Legion;
 
-TensorBase::TensorBase(const TensorBase &rhs) {
+TensorBase::TensorBase(TensorBase const &rhs) {
   tensor_guid = rhs.tensor_guid;
   num_dims = rhs.num_dims;
   for (int i = 0; i < num_dims; i++)
@@ -41,8 +41,8 @@ size_t TensorBase::get_volume() const {
 }
 
 template <typename T>
-bool TensorBase::set_tensor(const FFModel *ff,
-                            const std::vector<int> &dim_sizes,
+bool TensorBase::set_tensor(FFModel const *ff,
+                            std::vector<int> const &dim_sizes,
                             const T *data) {
   if (num_dims != (int)dim_sizes.size())
     return false;
@@ -57,7 +57,7 @@ bool TensorBase::set_tensor(const FFModel *ff,
 }
 
 template <typename T>
-bool TensorBase::get_tensor(const FFModel *ff, T *data, bool get_gradients) {
+bool TensorBase::get_tensor(FFModel const *ff, T *data, bool get_gradients) {
   ParallelTensor ptensor = nullptr;
   ff->get_parallel_tensor_from_tensor(this, ptensor);
   ptensor->get_tensor<T>(ff, data, get_gradients);
@@ -91,7 +91,7 @@ bool ParallelTensorShape::is_valid() const {
   return true;
 }
 
-bool ParallelTensorShape::operator==(const ParallelTensorShape &other) const {
+bool ParallelTensorShape::operator==(ParallelTensorShape const &other) const {
   if (this->num_dims != other.num_dims) {
     return false;
   }
@@ -113,7 +113,7 @@ bool ParallelTensorShape::operator==(const ParallelTensorShape &other) const {
   return true;
 }
 
-bool ParallelTensorShape::operator!=(const ParallelTensorShape &other) const {
+bool ParallelTensorShape::operator!=(ParallelTensorShape const &other) const {
   return !(*this == other);
 }
 
@@ -172,7 +172,7 @@ bool ParallelTensorBase::update_parallel_ids(int numdim, ParallelDim *dims) {
   return true;
 }
 
-ParallelTensorBase::ParallelTensorBase(const ParallelTensorBase &rhs) {
+ParallelTensorBase::ParallelTensorBase(ParallelTensorBase const &rhs) {
   parallel_tensor_guid = rhs.parallel_tensor_guid;
   num_dims = rhs.num_dims;
   for (int i = 0; i < num_dims; i++)
@@ -264,7 +264,7 @@ void ParallelTensorBase::detach_raw_ptr(FFConfig &config) {
 
 template <typename T>
 bool ParallelTensorBase::get_input_sub_tensor_via_mappings(
-    const ParallelConfig &pc, ParallelTensorBase &tensor) const {
+    ParallelConfig const &pc, ParallelTensorBase &tensor) const {
   if (pc.nDims != num_dims) {
     printf("Could not get input subtensor because the number of dimensions do "
            "not match: %d != %d\n",
@@ -284,7 +284,7 @@ bool ParallelTensorBase::get_input_sub_tensor_via_mappings(
   return true;
 }
 
-bool ParallelTensorBase::get_sub_tensor(const MachineView &mv,
+bool ParallelTensorBase::get_sub_tensor(MachineView const &mv,
                                         ParallelTensorBase &sub_tensor) const {
   sub_tensor.num_dims = this->num_dims;
   for (int i = 0; i < sub_tensor.num_dims; i++) {
@@ -300,7 +300,7 @@ bool ParallelTensorBase::get_sub_tensor(const MachineView &mv,
   return true;
 }
 
-bool ParallelTensorBase::get_input_sub_tensor(const ParallelConfig &pc,
+bool ParallelTensorBase::get_input_sub_tensor(ParallelConfig const &pc,
                                               ParallelTensorBase &tensor,
                                               OperatorType type) {
   // TODO: consider reduction dim for conv2d and linear
@@ -392,7 +392,7 @@ bool ParallelTensorBase::get_input_sub_tensor(const ParallelConfig &pc,
   return true;
 }
 
-bool ParallelTensorBase::get_output_sub_tensor(const ParallelConfig &pc,
+bool ParallelTensorBase::get_output_sub_tensor(ParallelConfig const &pc,
                                                ParallelTensorBase &tensor,
                                                OperatorType type) {
   if (pc.nDims != num_dims) {
@@ -491,7 +491,7 @@ bool ParallelTensorBase::check_valid() const {
   return true;
 }
 
-void TensorBase::print(const std::string &name) const {
+void TensorBase::print(std::string const &name) const {
   printf("%s: sizes[", name.c_str());
 
   for (int i = 0; i < num_dims; i++) {
@@ -500,7 +500,7 @@ void TensorBase::print(const std::string &name) const {
   printf("]\n");
 }
 
-void ParallelTensorBase::print(const std::string &name) const {
+void ParallelTensorBase::print(std::string const &name) const {
   printf("%s: sizes[", name.c_str());
 
   for (int i = 0; i < num_dims; i++) {
@@ -584,7 +584,7 @@ size_t hash<FlexFlow::ParallelTensorShape>::operator()(
 
 namespace FlexFlow {
 
-bool ParallelTensorBase::is_valid_machine_view(const MachineView &view) const {
+bool ParallelTensorBase::is_valid_machine_view(MachineView const &view) const {
   int is_dim = 0;
   for (int i = 0; i < num_dims; i++)
     if (dims[i].parallel_idx != -1) {
@@ -605,8 +605,8 @@ bool ParallelTensorBase::is_valid_machine_view(const MachineView &view) const {
 }
 
 template <typename T>
-bool ParallelTensorBase::set_tensor(const FFModel *ff,
-                                    const std::vector<int> &dim_sizes,
+bool ParallelTensorBase::set_tensor(FFModel const *ff,
+                                    std::vector<int> const &dim_sizes,
                                     const T *data) {
   Context ctx = ff->config.lg_ctx;
   Runtime *runtime = ff->config.lg_hlr;
@@ -653,7 +653,7 @@ bool ParallelTensorBase::set_tensor(const FFModel *ff,
 }
 
 template <typename T>
-bool ParallelTensorBase::get_tensor(const FFModel *ff,
+bool ParallelTensorBase::get_tensor(FFModel const *ff,
                                     T *data,
                                     bool get_gradients) {
   Context ctx = ff->config.lg_ctx;
@@ -708,49 +708,49 @@ bool ParallelTensorBase::get_tensor(const FFModel *ff,
 template float *ParallelTensorBase::get_raw_ptr<float>(FFConfig &config);
 template int32_t *ParallelTensorBase::get_raw_ptr<int32_t>(FFConfig &config);
 
-template bool TensorBase::set_tensor<float>(const FFModel *ff,
-                                            const std::vector<int> &dims,
-                                            const float *data);
-template bool TensorBase::get_tensor<float>(const FFModel *ff,
+template bool TensorBase::set_tensor<float>(FFModel const *ff,
+                                            std::vector<int> const &dims,
+                                            float const *data);
+template bool TensorBase::get_tensor<float>(FFModel const *ff,
                                             float *data,
                                             bool get_gradients);
-template bool TensorBase::set_tensor<double>(const FFModel *ff,
-                                             const std::vector<int> &dims,
-                                             const double *data);
-template bool TensorBase::get_tensor<double>(const FFModel *ff,
+template bool TensorBase::set_tensor<double>(FFModel const *ff,
+                                             std::vector<int> const &dims,
+                                             double const *data);
+template bool TensorBase::get_tensor<double>(FFModel const *ff,
                                              double *data,
                                              bool get_gradients);
-template bool TensorBase::set_tensor<int32_t>(const FFModel *ff,
-                                              const std::vector<int> &dims,
-                                              const int32_t *data);
-template bool TensorBase::get_tensor<int32_t>(const FFModel *ff,
+template bool TensorBase::set_tensor<int32_t>(FFModel const *ff,
+                                              std::vector<int> const &dims,
+                                              int32_t const *data);
+template bool TensorBase::get_tensor<int32_t>(FFModel const *ff,
                                               int32_t *data,
                                               bool get_gradients);
-template bool TensorBase::set_tensor<int64_t>(const FFModel *ff,
-                                              const std::vector<int> &dims,
-                                              const int64_t *data);
-template bool TensorBase::get_tensor<int64_t>(const FFModel *ff,
+template bool TensorBase::set_tensor<int64_t>(FFModel const *ff,
+                                              std::vector<int> const &dims,
+                                              int64_t const *data);
+template bool TensorBase::get_tensor<int64_t>(FFModel const *ff,
                                               int64_t *data,
                                               bool get_gradients);
 
 template bool ParallelTensorBase::set_tensor<float>(
-    const FFModel *ff, const std::vector<int> &dims, const float *data);
-template bool ParallelTensorBase::get_tensor<float>(const FFModel *ff,
+    FFModel const *ff, std::vector<int> const &dims, float const *data);
+template bool ParallelTensorBase::get_tensor<float>(FFModel const *ff,
                                                     float *data,
                                                     bool get_gradients);
 template bool ParallelTensorBase::set_tensor<double>(
-    const FFModel *ff, const std::vector<int> &dims, const double *data);
-template bool ParallelTensorBase::get_tensor<double>(const FFModel *ff,
+    FFModel const *ff, std::vector<int> const &dims, double const *data);
+template bool ParallelTensorBase::get_tensor<double>(FFModel const *ff,
                                                      double *data,
                                                      bool get_gradients);
 template bool ParallelTensorBase::set_tensor<int32_t>(
-    const FFModel *ff, const std::vector<int> &dims, const int32_t *data);
-template bool ParallelTensorBase::get_tensor<int32_t>(const FFModel *ff,
+    FFModel const *ff, std::vector<int> const &dims, int32_t const *data);
+template bool ParallelTensorBase::get_tensor<int32_t>(FFModel const *ff,
                                                       int32_t *data,
                                                       bool get_gradients);
 template bool ParallelTensorBase::set_tensor<int64_t>(
-    const FFModel *ff, const std::vector<int> &dims, const int64_t *data);
-template bool ParallelTensorBase::get_tensor<int64_t>(const FFModel *ff,
+    FFModel const *ff, std::vector<int> const &dims, int64_t const *data);
+template bool ParallelTensorBase::get_tensor<int64_t>(FFModel const *ff,
                                                       int64_t *data,
                                                       bool get_gradients);
 

--- a/src/runtime/simulator.cpp
+++ b/src/runtime/simulator.cpp
@@ -51,7 +51,7 @@ using Legion::TaskLauncher;
 typedef Realm::Point<1, coord_t> Point1;
 typedef Realm::Rect<1, coord_t> Rect1;
 
-Simulator::Simulator(const FFModel *model,
+Simulator::Simulator(FFModel const *model,
                      FFHandler _handler,
                      Memory _memory,
                      MachineModel *machine)
@@ -104,8 +104,8 @@ Simulator::Simulator(const FFModel *model,
 Simulator::~Simulator(void) { simulatorInst.destroy(); }
 
 __host__ void
-Simulator::strategy_search_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+Simulator::strategy_search_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   // This method should no longer be used

--- a/src/runtime/simulator.cu
+++ b/src/runtime/simulator.cu
@@ -50,7 +50,7 @@ using Legion::TaskLauncher;
 typedef Realm::Point<1, coord_t> Point1;
 typedef Realm::Rect<1, coord_t> Rect1;
 
-Simulator::Simulator(const FFModel *model,
+Simulator::Simulator(FFModel const *model,
                      FFHandler _handler,
                      Memory _memory,
                      MachineModel *machine)
@@ -115,8 +115,8 @@ Simulator::~Simulator(void) {
 }
 
 __host__ void
-Simulator::strategy_search_task(const Task *task,
-                                const std::vector<PhysicalRegion> &regions,
+Simulator::strategy_search_task(Task const *task,
+                                std::vector<PhysicalRegion> const &regions,
                                 Context ctx,
                                 Runtime *runtime) {
   // This method should no longer be used

--- a/src/runtime/strategy.cc
+++ b/src/runtime/strategy.cc
@@ -23,7 +23,7 @@ namespace FlexFlow {
 
 using namespace Legion;
 
-MappingTagID FFConfig::get_hash_id(const std::string &pcname) {
+MappingTagID FFConfig::get_hash_id(std::string const &pcname) {
   return std::hash<std::string>{}(pcname);
 }
 
@@ -98,7 +98,7 @@ bool FFConfig::find_parallel_config(int ndims,
 */
 
 bool load_strategies_from_file(
-    const std::string &filename,
+    std::string const &filename,
     std::map<MappingTagID, ParallelConfig> &strategies) {
   std::fstream input(filename, std::ios::in);
   if (!input) {
@@ -154,8 +154,8 @@ bool load_strategies_from_file(
 }
 
 bool save_strategies_to_file(
-    const std::string &filename,
-    const std::map<std::string, ParallelConfig> &strategies) {
+    std::string const &filename,
+    std::map<std::string, ParallelConfig> const &strategies) {
   std::fstream output(filename, std::ios::out | std::ios::trunc);
   if (!output) {
     std::cerr << "Failed to open strategy file for writing!" << std::endl;

--- a/tests/AlexNet_newapi/alexnet.cc
+++ b/tests/AlexNet_newapi/alexnet.cc
@@ -23,8 +23,8 @@ LegionRuntime::Logger::Category log_app("AlexNet");
 class DataLoader {
 public:
   DataLoader(FFModel &ff, Tensor input, Tensor label);
-  static void load_input(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_input(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
 
@@ -32,8 +32,8 @@ public:
   int num_samples;
 };
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   FFConfig ffConfig;
@@ -45,12 +45,12 @@ void top_level_task(const Task *task,
 
   Tensor input;
   {
-    const int dims[] = {ffConfig.batchSize, 3, 229, 229};
+    int const dims[] = {ffConfig.batchSize, 3, 229, 229};
     input = ff.create_tensor<4>(dims, "", DT_FLOAT);
   }
   Tensor label;
   {
-    const int dims[] = {ffConfig.batchSize, 1};
+    int const dims[] = {ffConfig.batchSize, 1};
     label = ff.create_tensor<2>(dims, "", DT_INT32);
   }
 
@@ -209,8 +209,8 @@ DataLoader::DataLoader(FFModel &ff, Tensor input, Tensor label) {
   }
 }
 
-void DataLoader::load_input(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_input(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   printf("CheckPoint#1\n");

--- a/tests/PCA/pca.cc
+++ b/tests/PCA/pca.cc
@@ -19,8 +19,8 @@ using namespace Legion;
 
 LegionRuntime::Logger::Category log_app("AlexNet");
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   int npcs = 5, nn_shl[6] = {10, 10, 10, 10, 10, 1};
@@ -32,7 +32,7 @@ void top_level_task(const Task *task,
   FFModel ff(ffConfig);
   Tensor pcvec_n, pcvec, pcmax, pcmin;
   {
-    const int dims[] = {1, npcs};
+    int const dims[] = {1, npcs};
     pcvec_n = ff.create_tensor<2>(dims, "", DT_FLOAT);
     pcvec = ff.create_tensor<2>(dims, "", DT_FLOAT);
     pcmax = ff.create_tensor<2>(dims, "", DT_FLOAT);
@@ -42,7 +42,7 @@ void top_level_task(const Task *task,
   for (int i = 1; i <= 5; i++) {
     // Treat sb1(:,i) as different tensors for different i
     // to allow additional parallelism across i's
-    const int dims[] = {1, nn_shl[i]};
+    int const dims[] = {1, nn_shl[i]};
     sb[i] = ff.create_tensor<2>(dims, "", DT_FLOAT);
   }
   // do i=1,npcs
@@ -66,7 +66,7 @@ void top_level_task(const Task *task,
       // to avoid multiple creations
       Tensor one, two, minus_two;
       {
-        const int dims[] = {1, nn_shl[i]};
+        int const dims[] = {1, nn_shl[i]};
         one = ff.create_constant<2>(dims, "", 1, DT_FLOAT);
         two = ff.create_constant<2>(dims, "", 2, DT_FLOAT);
         minus_two = ff.create_constant<2>(dims, "", -2, DT_FLOAT);

--- a/tests/alexnet_c/alexnet.cc
+++ b/tests/alexnet_c/alexnet.cc
@@ -27,8 +27,8 @@ public:
              flexflow_tensor_t input,
              flexflow_tensor_t label);
   DataLoader(FFModel &ff, Tensor input, Tensor label);
-  static void load_input(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_input(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
 
@@ -36,8 +36,8 @@ public:
   int num_samples;
 };
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   flexflow_config_t ffconfig;
@@ -55,13 +55,13 @@ void top_level_task(const Task *task,
   // Tensor input;
   flexflow_tensor_t input;
   {
-    const int dims[] = {flexflow_config_get_batch_size(ffconfig), 3, 229, 229};
+    int const dims[] = {flexflow_config_get_batch_size(ffconfig), 3, 229, 229};
     // input = ff->create_tensor<4>(dims, "", DT_FLOAT);
     input = flexflow_tensor_4d_create(ffmodel, dims, "", DT_FLOAT, true);
   }
   flexflow_tensor_t label;
   {
-    const int dims[] = {flexflow_config_get_batch_size(ffconfig), 1};
+    int const dims[] = {flexflow_config_get_batch_size(ffconfig), 1};
     label = flexflow_tensor_2d_create(ffmodel, dims, "", DT_INT32, true);
   }
   // Add layers
@@ -254,8 +254,8 @@ DataLoader::DataLoader(FFModel &ff, Tensor input, Tensor label) {
   }
 }
 
-void DataLoader::load_input(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_input(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   printf("CheckPoint#1\n");

--- a/tests/inception_c/inception.cc
+++ b/tests/inception_c/inception.cc
@@ -27,8 +27,8 @@ public:
              flexflow_tensor_t input,
              flexflow_tensor_t label);
   DataLoader(FFModel &ff, Tensor input, Tensor label);
-  static void load_input(const Task *task,
-                         const std::vector<PhysicalRegion> &regions,
+  static void load_input(Task const *task,
+                         std::vector<PhysicalRegion> const &regions,
                          Context ctx,
                          Runtime *runtime);
 
@@ -196,8 +196,8 @@ flexflow_tensor_t InceptionE(flexflow_model_t ffmodel,
   return output;
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   flexflow_config_t ffconfig;
@@ -215,13 +215,13 @@ void top_level_task(const Task *task,
   // Tensor input;
   flexflow_tensor_t input;
   {
-    const int dims[] = {flexflow_config_get_batch_size(ffconfig), 3, 299, 299};
+    int const dims[] = {flexflow_config_get_batch_size(ffconfig), 3, 299, 299};
     // input = ff->create_tensor<4>(dims, "", DT_FLOAT);
     input = flexflow_tensor_4d_create(ffmodel, dims, "", DT_FLOAT, true);
   }
   flexflow_tensor_t label;
   {
-    const int dims[] = {flexflow_config_get_batch_size(ffconfig), 1};
+    int const dims[] = {flexflow_config_get_batch_size(ffconfig), 1};
     label = flexflow_tensor_2d_create(ffmodel, dims, "", DT_INT32, true);
   }
   // Add layers
@@ -405,8 +405,8 @@ DataLoader::DataLoader(FFModel &ff, Tensor input, Tensor label) {
   }
 }
 
-void DataLoader::load_input(const Task *task,
-                            const std::vector<PhysicalRegion> &regions,
+void DataLoader::load_input(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
                             Context ctx,
                             Runtime *runtime) {
   printf("CheckPoint#1\n");

--- a/tests/ops/batch_matmul_test.cc
+++ b/tests/ops/batch_matmul_test.cc
@@ -21,8 +21,8 @@ BMMTestMeta get_test_meta(const std::string file_path) {
   return BMMTestMeta(m, k, n, d);
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   // std::cout<< "test framework launched" << std::endl;
@@ -33,7 +33,7 @@ void top_level_task(const Task *task,
   // create input tensor
   Tensor dense_input1;
   {
-    const int dims[3] = {
+    int const dims[3] = {
         test_meta.d, test_meta.k, test_meta.m}; // target shape (d,k,m)
     // HACK: have to pass "batch_matmul" 3-dimensional strategy string id to
     // tell FF to distribute this tensor correctly
@@ -41,7 +41,7 @@ void top_level_task(const Task *task,
   }
   Tensor dense_input2;
   {
-    const int dims[3] = {
+    int const dims[3] = {
         test_meta.d, test_meta.k, test_meta.n}; // shape (n,k,d)
     // HACK: have to pass "batch_matmul" 3-dimensional strategy string id to
     // tell FF to distribute this tensor correctly

--- a/tests/ops/concat_test.cc
+++ b/tests/ops/concat_test.cc
@@ -34,8 +34,8 @@ ConcatTestMeta get_test_meta(const std::string file_path) {
                         dense_projection_i_dim);
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   std::cout << "test framework launched" << std::endl;
@@ -53,7 +53,7 @@ void top_level_task(const Task *task,
   Tensor dense_embeddings[dense_embedding_channels];
   Tensor sparse_embeddings[sparse_embedding_channels];
   for (int i = 0; i < dense_embedding_channels; i++) {
-    const int dims[2] = {test_meta.batch_size, test_meta.i_dim};
+    int const dims[2] = {test_meta.batch_size, test_meta.i_dim};
     dense_embeddings[i] = ff.create_tensor<2>(dims, "", DT_FLOAT);
     // init tensor is checked, nothing wrong in init tensor
     // dense_embeddings[i] also checked, it's correct
@@ -62,7 +62,7 @@ void top_level_task(const Task *task,
   }
 
   for (int i = 0; i < sparse_embedding_channels; i++) {
-    const int dims[2] = {test_meta.batch_size, test_meta.i_dim};
+    int const dims[2] = {test_meta.batch_size, test_meta.i_dim};
     sparse_embeddings[i] = ff.create_tensor<2>(dims, "", DT_FLOAT);
     // init tensor is checked, nothing wrong in init tensor
     // sparse_embeddings[i] also checked, it's correct

--- a/tests/ops/flat_test.cc
+++ b/tests/ops/flat_test.cc
@@ -44,8 +44,8 @@ FlatTestMeta get_test_meta(const std::string file_path) {
   return FlatTestMeta(i_dim, o_dim, i_shape, o_shape);
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   // std::cout<< "test framework launched" << std::endl;
@@ -55,7 +55,7 @@ void top_level_task(const Task *task,
   FFModel ff(ffConfig);
   Tensor dense_input;
 #define input_dim 3
-  const int i_dims[input_dim] = {
+  int const i_dims[input_dim] = {
       test_meta.i_shape[0], test_meta.i_shape[1], test_meta.i_shape[2]
       // test_meta.i_shape[3]
   };

--- a/tests/ops/linear_test.cc
+++ b/tests/ops/linear_test.cc
@@ -34,8 +34,8 @@ LinearTestMeta get_test_meta(const std::string file_path) {
                         dense_projection_i_dim);
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   std::cout << "test framework launched" << std::endl;
@@ -48,7 +48,7 @@ void top_level_task(const Task *task,
   Initializer *bias_initializer = new ZeroInitializer();
   Tensor weights;
   {
-    const int dims[2] = {test_meta.dense_projection_o_dim,
+    int const dims[2] = {test_meta.dense_projection_o_dim,
                          test_meta.dense_projection_i_dim};
     weights = ff.create_linear_weight<2>(
         dims, (IndexSpaceT<2>)task_is, DT_FLOAT, kernel_initializer);
@@ -57,7 +57,7 @@ void top_level_task(const Task *task,
   }
   Tensor bias;
   {
-    const int dims[1] = {test_meta.dense_projection_o_dim};
+    int const dims[1] = {test_meta.dense_projection_o_dim};
     bias = ff.create_linear_weight<1>(
         dims, (IndexSpaceT<2>)task_is, DT_FLOAT, bias_initializer);
     auto bias_file_path = "test_bias1.txt";
@@ -69,7 +69,7 @@ void top_level_task(const Task *task,
   // create dense projection
   Tensor dense_projection;
   {
-    const int dims[2] = {test_meta.batch_size,
+    int const dims[2] = {test_meta.batch_size,
                          test_meta.dense_projection_i_dim};
     dense_projection = ff.create_tensor<2>(dims, "", DT_FLOAT);
     // dense_projection = ff.create_linear_weight<2>(dims,

--- a/tests/ops/reshape_test.cc
+++ b/tests/ops/reshape_test.cc
@@ -43,8 +43,8 @@ ReshapeTestMeta get_test_meta(const std::string file_path) {
   return ReshapeTestMeta(i_dim, o_dim, i_shape, o_shape);
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   // std::cout<< "test framework launched" << std::endl;
@@ -56,9 +56,9 @@ void top_level_task(const Task *task,
   if (test_meta.i_dim == 3 && test_meta.o_dim == 2) {
 #define input_dim 3
 #define output_dim 2
-    const int i_dims[input_dim] = {
+    int const i_dims[input_dim] = {
         test_meta.i_shape[0], test_meta.i_shape[1], test_meta.i_shape[2]};
-    const int o_shape[output_dim] = {
+    int const o_shape[output_dim] = {
         test_meta.o_shape[0],
         test_meta.o_shape[1],
     };
@@ -83,11 +83,11 @@ void top_level_task(const Task *task,
   } else if (test_meta.i_dim == 2 && test_meta.o_dim == 3) {
 #define input_dim 2
 #define output_dim 3
-    const int i_dims[input_dim] = {
+    int const i_dims[input_dim] = {
         test_meta.i_shape[0],
         test_meta.i_shape[1],
     };
-    const int o_shape[output_dim] = {
+    int const o_shape[output_dim] = {
         test_meta.o_shape[0], test_meta.o_shape[1], test_meta.o_shape[2]};
     dense_input = ff.create_tensor<input_dim>(i_dims, "", DT_FLOAT);
     Tensor ret = ff.reshape<input_dim, output_dim>("", dense_input, o_shape);

--- a/tests/ops/tanh_test.cc
+++ b/tests/ops/tanh_test.cc
@@ -43,8 +43,8 @@ TanhTestMeta get_test_meta(const std::string file_path) {
   return TanhTestMeta(i_dim, o_dim, i_shape, o_shape);
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   // std::cout<< "test framework launched" << std::endl;
@@ -55,7 +55,7 @@ void top_level_task(const Task *task,
   Tensor dense_input;
   if (test_meta.i_dim == 3) {
 #define input_dim 3
-    const int i_dims[input_dim] = {
+    int const i_dims[input_dim] = {
         test_meta.i_shape[0], test_meta.i_shape[1], test_meta.i_shape[2]};
     dense_input = ff.create_tensor<input_dim>(i_dims, "", DT_FLOAT);
     Tensor ret = ff.tanh<input_dim>("", dense_input, i_dims);
@@ -76,7 +76,7 @@ void top_level_task(const Task *task,
 #undef input_dim
   } else if (test_meta.i_dim == 2) {
 #define input_dim 2
-    const int i_dims[input_dim] = {
+    int const i_dims[input_dim] = {
         test_meta.i_shape[0],
         test_meta.i_shape[1],
     };
@@ -99,7 +99,7 @@ void top_level_task(const Task *task,
 #undef input_dim
   } else if (test_meta.i_dim == 1) {
 #define input_dim 1
-    const int i_dims[input_dim] = {test_meta.i_shape[0]};
+    int const i_dims[input_dim] = {test_meta.i_shape[0]};
     dense_input = ff.create_tensor<input_dim>(i_dims, "", DT_FLOAT);
     Tensor ret = ff.tanh<input_dim>("", dense_input, i_dims);
     auto input1_file_path = "test_input1.txt";

--- a/tests/ops/test_utils.cc
+++ b/tests/ops/test_utils.cc
@@ -11,13 +11,13 @@ struct ArgsConfig {
 
 void initialize_tensor_from_file(const std::string file_path,
                                  Tensor label,
-                                 const FFModel &ff,
+                                 FFModel const &ff,
                                  std::string data_type,
                                  int num_dim);
 
 void initialize_tensor_gradient_from_file(const std::string file_path,
                                           Tensor label,
-                                          const FFModel &ff,
+                                          FFModel const &ff,
                                           std::string data_type,
                                           int num_dim) {
   Context ctx = ff.config.lg_ctx;
@@ -76,7 +76,7 @@ void initialize_tensor_gradient_from_file(const std::string file_path,
 
 void initialize_tensor_from_file(const std::string file_path,
                                  Tensor label,
-                                 const FFModel &ff,
+                                 FFModel const &ff,
                                  std::string data_type,
                                  int num_dim) {
   Context ctx = ff.config.lg_ctx;
@@ -119,17 +119,17 @@ void initialize_tensor_from_file(const std::string file_path,
 
 template <int DIM>
 void initialize_tensor_from_file_task(
-    const Task *task,
-    const std::vector<PhysicalRegion> &regions,
+    Task const *task,
+    std::vector<PhysicalRegion> const &regions,
     Context ctx,
     Runtime *runtime) {
-  const ArgsConfig args_config = *((const ArgsConfig *)task->args);
-  std::string file_path((const char *)args_config.dataset_path);
-  std::string data_type((const char *)args_config.data_type);
+  const ArgsConfig args_config = *((ArgsConfig const *)task->args);
+  std::string file_path((char const *)args_config.dataset_path);
+  std::string data_type((char const *)args_config.data_type);
   Rect<DIM> rect_label_tensor = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   if (data_type == "int") {
-    const AccessorWO<int, DIM> acc_label_tensor(regions[0], FID_DATA);
+    AccessorWO<int, DIM> const acc_label_tensor(regions[0], FID_DATA);
     int *tensor_ptr = acc_label_tensor.ptr(rect_label_tensor.lo);
     std::fstream myfile(file_path, std::ios_base::in);
     int a;
@@ -140,7 +140,7 @@ void initialize_tensor_from_file_task(
     }
     myfile.close();
   } else if (data_type == "float") {
-    const AccessorWO<float, DIM> acc_label_tensor(regions[0], FID_DATA);
+    AccessorWO<float, DIM> const acc_label_tensor(regions[0], FID_DATA);
     float *tensor_ptr = acc_label_tensor.ptr(rect_label_tensor.lo);
     std::fstream myfile(file_path, std::ios_base::in);
     float a;
@@ -192,19 +192,19 @@ void dump_region_to_file(FFModel &ff,
 }
 
 template <int DIM>
-void dump_tensor_task(const Task *task,
-                      const std::vector<PhysicalRegion> &regions,
+void dump_tensor_task(Task const *task,
+                      std::vector<PhysicalRegion> const &regions,
                       Context ctx,
                       Runtime *runtime) {
   assert(task->regions.size() == 1);
   assert(regions.size() == 1);
-  const ArgsConfig args_config = *((const ArgsConfig *)task->args);
-  std::string file_path((const char *)args_config.dataset_path);
-  const AccessorRO<float, DIM> acc_tensor(regions[0], FID_DATA);
+  const ArgsConfig args_config = *((ArgsConfig const *)task->args);
+  std::string file_path((char const *)args_config.dataset_path);
+  AccessorRO<float, DIM> const acc_tensor(regions[0], FID_DATA);
   Rect<DIM> rect_fb = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
   assert(acc_tensor.accessor.is_dense_arbitrary(rect_fb));
-  const float *tensor_ptr = acc_tensor.ptr(rect_fb.lo);
+  float const *tensor_ptr = acc_tensor.ptr(rect_fb.lo);
   std::ofstream myfile;
   myfile.open(file_path);
   for (size_t i = 0; i < rect_fb.volume(); ++i) {
@@ -215,39 +215,39 @@ void dump_tensor_task(const Task *task,
   myfile.close();
 }
 
-template void dump_tensor_task<1>(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+template void dump_tensor_task<1>(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
-template void dump_tensor_task<2>(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+template void dump_tensor_task<2>(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
-template void dump_tensor_task<3>(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+template void dump_tensor_task<3>(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
-template void dump_tensor_task<4>(const Task *task,
-                                  const std::vector<PhysicalRegion> &regions,
+template void dump_tensor_task<4>(Task const *task,
+                                  std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
 template void
-initialize_tensor_from_file_task<1>(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+initialize_tensor_from_file_task<1>(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime);
 template void
-initialize_tensor_from_file_task<2>(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+initialize_tensor_from_file_task<2>(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime);
 template void
-initialize_tensor_from_file_task<3>(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+initialize_tensor_from_file_task<3>(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime);
 template void
-initialize_tensor_from_file_task<4>(const Task *task,
-                                    const std::vector<PhysicalRegion> &regions,
+initialize_tensor_from_file_task<4>(Task const *task,
+                                    std::vector<PhysicalRegion> const &regions,
                                     Context ctx,
                                     Runtime *runtime);

--- a/tests/ops/transpose_test.cc
+++ b/tests/ops/transpose_test.cc
@@ -19,8 +19,8 @@ TransposeTestMeta get_test_meta(const std::string file_path) {
   return TransposeTestMeta(m, k, d);
 }
 
-void top_level_task(const Task *task,
-                    const std::vector<PhysicalRegion> &regions,
+void top_level_task(Task const *task,
+                    std::vector<PhysicalRegion> const &regions,
                     Context ctx,
                     Runtime *runtime) {
   // std::cout<< "test framework launched" << std::endl;
@@ -31,7 +31,7 @@ void top_level_task(const Task *task,
   // create input tensor
   Tensor dense_input;
   {
-    const int dims[3] = {
+    int const dims[3] = {
         test_meta.d, test_meta.m, test_meta.k}; // target shape (d,m,k)
     dense_input = ff.create_tensor<3>(dims, "transpose", DT_FLOAT);
   }


### PR DESCRIPTION
`format.sh` will now rewrite
```
const int x;
```
to 
```
int const x;
```
so there is only one valid `const` position.