### PR TITLE
add jupyter notebook support

### DIFF
--- a/jupyter_notebook/README.md
+++ b/jupyter_notebook/README.md
@@ -1,0 +1,82 @@
+# Jupyter Notebook
+
+This directory contains the Jupyter notebook support for
+the FlexFlow Python binding.
+
+## Quick Start
+### Pre-requisite
+* Python >= 3.6
+* [Python binding of Legion](https://github.com/StanfordLegion/legion/tree/stable/bindings/python) 
+  or [Legate](https://github.com/nv-legate/legate.core) needs to be installed.
+* Install Jupyter notebook
+
+        pip install notebook
+
+### Install the Legion IPython kernel
+```
+python ./install.py --(configurations)
+```
+Please refer to the [Kernel Configurations](#kernel-configurations) section for the configuration details.
+
+If the installtion is successed, the following log will be printed to the terminal.
+The `flexflow_kernel_nocr` is the kernel name, and the `FlexFlow_SM_GPU` is the display name
+of the kernel, which can be modified by the configuration json file. 
+`FlexFlow` is the name entry in the json file, `SM` means the kernel
+is only for shared memory machine, and `GPU` meams GPU execution is enabled. 
+```
+IPython kernel: flexflow_kernel_nocr(FlexFlow_SM_GPU) has been installed
+```
+The installed kernel can be also seen by using the following command:
+```
+jupyter kernelspec list
+```
+
+### Start the Jupyter Notebook server
+* Launch jupyter notebook server on the computing node
+
+        jupyter notebook --port=8888 --no-browser
+
+
+* Create a turnel between localhost to the computing node, this step is not needed if
+the jupyter server is run on the local machine.
+
+        ssh -4 -t -L 8888:localhost:8002 username@login-node-hostname ssh -t -L 8002:localhost:8888 computing_node
+
+### Use the Jupyter Notebook in the browser
+* Open the browser, type the addredd http://localhost:8888/?token=xxx, the token will be
+displayed in the terminal once the server is started. 
+* Once the webpage is loaded, click "New" on the right top corner, and click the kernel 
+just installed. It is shown as the display name of the kernel, e.g. `FlexFlow_SM_GPU`.
+
+### Uninstall the kernel
+```
+jupyter kernelspec uninstall legion_kernel_nocr
+```
+If the kernel is re-installed, the old one will be automatically uninstalled by the install.py
+
+## Kernel Configurations
+The kernel can be configured by either passing arguments to `install.py` or using a json file.
+The accepted arguments can be seen by 
+```
+python ./install.py --help
+```
+
+It is always preferred to use a json file. 
+The `flexflow_python.json` is the template respect to the legate wrapper and
+legion_python. Most entries are using the following format:
+```
+"cpus": {
+    "cmd": "--cpus",
+    "value": 1
+}
+```
+* The `cpus` is the name of the field. 
+
+* The `cmd` is used to tell how to pass the value to the field.
+For example, flexflow uses `-ll:cpu` to set the number of CPUs, so the cmd in `flexflow_python.json` is `-ll:cpu`.
+
+* The `value` is the value of the field. It can be set to `null`. In this case, the value is read
+from the command line arguments. 
+
+Other configuration options can be added by either appending them to the command line arguments or
+using the `other_options` field of the json file. 

--- a/jupyter_notebook/README.md
+++ b/jupyter_notebook/README.md
@@ -6,13 +6,12 @@ the FlexFlow Python binding.
 ## Quick Start
 ### Pre-requisite
 * Python >= 3.6
-* [Python binding of Legion](https://github.com/StanfordLegion/legion/tree/stable/bindings/python) 
-  or [Legate](https://github.com/nv-legate/legate.core) needs to be installed.
+* FlexFlow Python binding needs to be installed, please check the [installtion guide](https://github.com/flexflow/FlexFlow/blob/master/INSTALL.md)
 * Install Jupyter notebook
 
         pip install notebook
 
-### Install the Legion IPython kernel
+### Install the FlexFlow IPython kernel
 ```
 python ./install.py --(configurations)
 ```
@@ -50,7 +49,7 @@ just installed. It is shown as the display name of the kernel, e.g. `FlexFlow_SM
 
 ### Uninstall the kernel
 ```
-jupyter kernelspec uninstall legion_kernel_nocr
+jupyter kernelspec uninstall flexflow_kernel_nocr
 ```
 If the kernel is re-installed, the old one will be automatically uninstalled by the install.py
 
@@ -62,8 +61,8 @@ python ./install.py --help
 ```
 
 It is always preferred to use a json file. 
-The `flexflow_python.json` is the template respect to the legate wrapper and
-legion_python. Most entries are using the following format:
+The `flexflow_python.json` is the template respect to the
+flexflow_python. Most entries are using the following format:
 ```
 "cpus": {
     "cmd": "--cpus",

--- a/jupyter_notebook/README.md
+++ b/jupyter_notebook/README.md
@@ -1,7 +1,10 @@
 # Jupyter Notebook
 
-This directory contains the Jupyter notebook support for
-the FlexFlow Python binding.
+This directory contains Jupyter notebook support for
+FlexFlow. 
+It allows user to run any FlexFlow Python
+program (e.g., training models) on a single node using
+the in-browser jupyter notebook UI. 
 
 ## Quick Start
 ### Pre-requisite
@@ -15,31 +18,35 @@ the FlexFlow Python binding.
 ```
 python ./install.py --(configurations)
 ```
-Please refer to the [Kernel Configurations](#kernel-configurations) section for the configuration details.
+Please refer to the [IPython Kernel Configurations](#kernel-configurations) section for the configuration details.
 
-If the installtion is successed, the following log will be printed to the terminal.
-The `flexflow_kernel_nocr` is the kernel name, and the `FlexFlow_SM_GPU` is the display name
+If the installation is successed, the following log will be printed to the terminal.
+The `flexflow_kernel_nocr` is the IPython kernel name, where `nocr` means control replication is not enabled. 
+The control replication can be enabled once multi-node jupyter notebook support is provided in the future. 
+The `FlexFlow_SM_GPU` is the display name
 of the kernel, which can be modified by the configuration json file. 
-`FlexFlow` is the name entry in the json file, `SM` means the kernel
-is only for shared memory machine, and `GPU` meams GPU execution is enabled. 
+`FlexFlow` is the name entry in the json file, `SM` means the IPython kernel
+is only for shared memory machine, and `GPU` means GPU execution is enabled. 
 ```
 IPython kernel: flexflow_kernel_nocr(FlexFlow_SM_GPU) has been installed
 ```
-The installed kernel can be also seen by using the following command:
+The installed IPython kernel can be also seen by using the following command:
 ```
 jupyter kernelspec list
 ```
 
+### Create a turnel (Optional)
+If you want to run the jupyter notebook server on a remote compute node instead of localhost, 
+you can create a turnel from localhost to the compute node.
+```
+ssh -4 -t -L 8888:localhost:8002 username@login-node-hostname ssh -t -L 8002:localhost:8888 computing_node
+```
+
 ### Start the Jupyter Notebook server
-* Launch jupyter notebook server on the computing node
-
-        jupyter notebook --port=8888 --no-browser
-
-
-* Create a turnel between localhost to the computing node, this step is not needed if
-the jupyter server is run on the local machine.
-
-        ssh -4 -t -L 8888:localhost:8002 username@login-node-hostname ssh -t -L 8002:localhost:8888 computing_node
+Launch jupyter notebook server on the compute node or localhost if the turnel is not created
+```
+jupyter notebook --port=8888 --no-browser
+```
 
 ### Use the Jupyter Notebook in the browser
 * Open the browser, type the addredd http://localhost:8888/?token=xxx, the token will be
@@ -47,15 +54,16 @@ displayed in the terminal once the server is started.
 * Once the webpage is loaded, click "New" on the right top corner, and click the kernel 
 just installed. It is shown as the display name of the kernel, e.g. `FlexFlow_SM_GPU`.
 
-### Uninstall the kernel
+### Uninstall the IPython kernel
 ```
 jupyter kernelspec uninstall flexflow_kernel_nocr
 ```
-If the kernel is re-installed, the old one will be automatically uninstalled by the install.py
+If the IPython kernel is re-installed, the old one will be automatically uninstalled by the install.py
 
-## Kernel Configurations
-The kernel can be configured by either passing arguments to `install.py` or using a json file.
-The accepted arguments can be seen by 
+
+## IPython Kernel Configurations
+The IPython kernel can be configured by either passing arguments to `install.py` or using a json file.
+The accepted arguments can be listed with
 ```
 python ./install.py --help
 ```
@@ -69,12 +77,12 @@ flexflow_python. Most entries are using the following format:
     "value": 1
 }
 ```
-* The `cpus` is the name of the field. 
+* `cpus` is the name of the field. 
 
-* The `cmd` is used to tell how to pass the value to the field.
-For example, flexflow uses `-ll:cpu` to set the number of CPUs, so the cmd in `flexflow_python.json` is `-ll:cpu`.
+* `cmd` is used to tell how to pass the value to the field.
+For example, flexflow uses `-ll:cpu` to set the number of CPUs, so the `cmd` in `flexflow_python.json` is `-ll:cpu`.
 
-* The `value` is the value of the field. It can be set to `null`. In this case, the value is read
+* `value` is the value of the field. It can be set to `null`. In this case, the value is read
 from the command line arguments. 
 
 Other configuration options can be added by either appending them to the command line arguments or

--- a/jupyter_notebook/README.md
+++ b/jupyter_notebook/README.md
@@ -9,7 +9,7 @@ the in-browser jupyter notebook UI.
 ## Quick Start
 ### Pre-requisite
 * Python >= 3.6
-* FlexFlow Python binding needs to be installed, please check the [installtion guide](https://github.com/flexflow/FlexFlow/blob/master/INSTALL.md)
+* FlexFlow Python binding needs to be installed, please check the [installation guide](https://github.com/flexflow/FlexFlow/blob/master/INSTALL.md)
 * Install Jupyter notebook
 
         pip install notebook

--- a/jupyter_notebook/flexflow_kernel_nocr.py
+++ b/jupyter_notebook/flexflow_kernel_nocr.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# Copyright 2022 Los Alamos National Laboratory, NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+from ipykernel.ipkernel import IPythonKernel
+import sys
+
+__version__ = '0.1'
+
+class FlexFlowKernelNoCR(IPythonKernel):
+    implementation = 'flexflow_kernel_nocr'
+    implementation_version = __version__
+
+    banner = "FlexFlow IPython Kernel for SM"
+    language = 'python'
+    language_version = __version__
+    language_info = {'name': 'flexflow_kernel_nocr',
+                     'mimetype': 'text/x-python',
+                     'codemirror_mode': {
+                        'name': 'ipython',
+                        'version': 3
+                        },
+                     'pygments_lexer': 'ipython3',
+                     'nbconvert_exporter': 'python',
+                     'file_extension': '.py'}
+
+    def __init__(self, **kwargs):
+        self.__stdout = None
+        self._set_stdout()
+        print("Init FlexFlow kernel for single node or multi-nodes without control replication.")
+        self._reset_stdout()
+        super().__init__(**kwargs)
+
+    def _set_stdout(self):
+        assert(self.__stdout == None), "stdout should be None"
+        self.__stdout = sys.stdout
+        sys.stdout = open('/dev/stdout', 'w')
+
+    def _reset_stdout(self):
+        assert(self.__stdout != None), "stdout should not be None"
+        sys.stdout = self.__stdout
+
+if __name__ == "__main__":
+    from ipykernel.kernelapp import IPKernelApp
+    IPKernelApp.launch_instance(kernel_class=FlexFlowKernelNoCR)

--- a/jupyter_notebook/flexflow_python.json
+++ b/jupyter_notebook/flexflow_python.json
@@ -1,0 +1,67 @@
+{
+    "name": "FlexFlow",
+    "kernel_name": "flexflow_kernel_nocr",
+    "flexflow_python_prefix": null,
+    "exe": "flexflow_python",
+    "cpus": {
+        "cmd": "-ll:cpu", 
+        "value": 1
+    },
+    "gpus": {
+        "cmd": "-ll:gpu",
+        "value": 1
+    },
+    "openmp": {
+        "cmd": "-ll:ocpu", 
+        "value": 0
+    },
+    "ompthreads": {
+        "cmd": "-ll:othr", 
+        "value": 0
+    },
+    "utility": {
+        "cmd": "-ll:util", 
+        "value": 1
+    },
+    "sysmem": {
+        "cmd": "-ll:csize", 
+        "value": null
+    },
+    "fbmem": {
+        "cmd": "-ll:fsize", 
+        "value": 4096
+    },
+    "zcmem": {
+        "cmd": "-ll:zsize", 
+        "value": 10240
+    },
+    "regmem": {
+        "cmd": "-ll:rsize", 
+        "value": null
+    },
+    "not_control_replicable": {
+        "action": "store_true",
+        "cmd": "--nocr", 
+        "value": null
+    },
+    "nodes": {
+        "cmd": "-n", 
+        "value": 1
+    },
+    "ranks_per_node": {
+        "cmd": "--npernode", 
+        "value": 1
+    },
+    "launcher": {
+        "type": "generic",
+        "cmd": "--launcher",
+        "value": null,
+        "launcher_extra": null
+    },
+    "other_options": [
+        {
+            "cmd": "-ll:py", 
+            "value": 1
+        }
+    ]
+}

--- a/jupyter_notebook/install.py
+++ b/jupyter_notebook/install.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Los Alamos National Laboratory, NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+import re
+import sys
+import argparse
+from distutils import log
+import json
+import inspect
+import shutil
+
+from jupyter_client.kernelspec import KernelSpecManager, NoSuchKernel
+from IPython.utils.tempdir import TemporaryDirectory
+
+kernel_json = {"argv": [],
+    "display_name": "None",
+    "language": "python",
+}
+
+kernel_json_suffix_nocr = ["flexflow_kernel_nocr.py", "-f", "{connection_file}"]
+
+
+required_cmd_dict_key = ["name", "kernel_name", "flexflow_python_prefix", "exe", "cpus", "gpus", "openmp", "ompthreads", "utility", "sysmem", "fbmem", "zcmem", "regmem", "not_control_replicable"]
+
+# This internal method is used to delete a kernel specified by kernel_name
+def _delete_kernel(ksm, kernel_name, mute=True):
+    try:
+        spec = ksm.get_kernel_spec(kernel_name)
+        shutil.rmtree(spec.resource_dir)
+        if mute == False:
+            print("Find existing kernel:" + kernel_name + ", delete it before installation.")
+    except NoSuchKernel:
+        if mute == False:
+            print("No existing kernel:" + kernel_name + " has been installed, continue to installation.")
+
+# This internal method is used to install a kernel
+def _install_kernel(ksm, kernel_name, kernel_json, user, prefix, mute=True):
+    with TemporaryDirectory() as td:
+        os.chmod(td, 0o755)
+        with open(os.path.join(td, "kernel.json"), "w") as f:
+            json.dump(kernel_json, f, sort_keys=True)
+        try:
+            ksm.install_kernel_spec(td, kernel_name, user=user, prefix=prefix)
+            if mute == False:
+                print("IPython kernel: " + kernel_name + "(" + kernel_json["display_name"] + ") has been installed")
+        except Exception as e:
+            if mute == False:
+                log.error("Failed to install the IPython kernel: " +  kernel_name + "(" + kernel_json["display_name"] + ") with error: " + str(e))
+
+# This method parses the json file into a dict named cmd_dict
+def parse_json(flexflow_python_prefix,
+               cpus, 
+               gpus,
+               openmp,
+               ompthreads,
+               utility,
+               sysmem,
+               fbmem,
+               zcmem,
+               regmem,
+               launcher,
+               nodes,
+               ranks_per_node,
+               not_control_replicable,
+               kernel_name,
+               filename):
+    with open(filename) as json_file:
+        cmd_dict = json.load(json_file)
+        for key in required_cmd_dict_key:
+            if key not in cmd_dict:
+                assert 0, "Key: " + key + " is not existed."
+    # Criterion
+    #   if entry in the json file is set to null, we load it from the cmd line
+    args = inspect.getfullargspec(parse_json)
+    keys = args.args[0: len(args.args)-1]
+    sig = inspect.signature(parse_json)
+    argv_dict = locals()
+    for key in keys:
+        if key == "launcher":
+            if cmd_dict[key]["value"] == None and argv_dict[key] != "none":
+                cmd_dict[key]["value"] = argv_dict[key]
+            if cmd_dict[key]["launcher_extra"] == None:
+                cmd_dict[key]["launcher_extra"] = list()
+        elif key == "flexflow_python_prefix" or key == "kernel_name":
+            if cmd_dict[key] == None:
+                cmd_dict[key] = argv_dict[key]
+        else:
+            if cmd_dict[key]["value"] == None:
+                cmd_dict[key]["value"] = argv_dict[key]
+
+    return cmd_dict
+
+# This method is used to install the kernel for jupyter notebook support for single or
+# multiple nodes runs without control replication
+def install_kernel_nocr(user, prefix, cmd_opts, cmd_dict, verbose, kernel_file_dir):
+    if verbose:
+        print("cmd_dict is:\n" + str(cmd_dict))
+
+    # setup name and argv
+    kernel_json["argv"] = [cmd_dict["flexflow_python_prefix"] + "/" + cmd_dict["exe"]] + kernel_json["argv"]
+    kernel_json["display_name"] = cmd_dict["name"]
+
+    # launcher
+    if cmd_dict["launcher"]["value"] == None:
+        kernel_json["display_name"] += "_SM"
+    else:
+        kernel_json["display_name"] += "_DM"
+        nodes = cmd_dict["nodes"]["value"]
+        ranks_per_node = cmd_dict["ranks_per_node"]["value"]
+        launcher = cmd_dict["launcher"]["value"]
+        if cmd_dict["launcher"]["type"] == "legate":
+            # use legate launcher
+            kernel_json["argv"] += cmd_dict["launcher"]["cmd"], launcher, \
+                                   cmd_dict["nodes"]["cmd"], str(nodes), \
+                                   cmd_dict["ranks_per_node"]["cmd"], str(ranks_per_node)
+        else:
+            # use mpirun, srun and jsrun launcher
+            ranks = nodes * ranks_per_node
+            if launcher == "mpirun":
+                kernel_json["argv"] = ["mpirun", "-n", str(ranks), "--npernode", str(ranks_per_node)] + cmd_dict["launcher"]["launcher_extra"] + kernel_json["argv"]
+            elif launcher == "srun":
+                kernel_json["argv"] = ["srun", "-n", str(ranks), "--ntasks-per-node", str(ranks_per_node)] + cmd_dict["launcher"]["launcher_extra"] + kernel_json["argv"]
+            elif launcher == "jsrun":
+                kernel_json["argv"] = ["jsrun", "-n", str(ranks // ranks_per_node), "-r", "1", "-a", str(ranks_per_node)] + cmd_dict["launcher"]["launcher_extra"] + kernel_json["argv"]
+            else:
+                assert 0, "Unknown launcher"
+
+    # let's do not enable control replication because pygion has issue with cleaning up
+    # disable control replication
+    # assert cmd_dict["not_control_replicable"]["value"] == True
+    # kernel_json["argv"].append(cmd_dict["not_control_replicable"]["cmd"])
+
+    # cpu
+    if cmd_dict["cpus"]["value"] > 0:
+        kernel_json["argv"] += cmd_dict["cpus"]["cmd"], str(cmd_dict["cpus"]["value"])
+
+    # gpu
+    if cmd_dict["gpus"]["value"] > 0:
+        kernel_json["display_name"] += "_GPU"
+        kernel_json["argv"] += cmd_dict["gpus"]["cmd"], str(cmd_dict["gpus"]["value"])
+        if cmd_dict["fbmem"]["value"] > 0:
+            kernel_json["argv"] += cmd_dict["fbmem"]["cmd"], str(cmd_dict["fbmem"]["value"])
+        if cmd_dict["zcmem"]["value"] > 0:
+            kernel_json["argv"] += cmd_dict["zcmem"]["cmd"], str(cmd_dict["zcmem"]["value"])
+
+    # openmp
+    if cmd_dict["openmp"]["value"] > 0:
+        if cmd_dict["ompthreads"]["value"] > 0:
+            kernel_json["argv"] += cmd_dict["openmp"]["cmd"], str(cmd_dict["openmp"]["value"])
+            kernel_json["argv"] += cmd_dict["ompthreads"]["cmd"], str(cmd_dict["ompthreads"]["value"])
+        else:
+            print(
+                "WARNING: ignore request for "
+                + str(cmd_dict["openmp"]["value"])
+                + "OpenMP processors with 0 threads"
+            )
+    
+    # utility
+    if cmd_dict["utility"]["value"] > 0:
+        kernel_json["argv"] += cmd_dict["utility"]["cmd"], str(cmd_dict["utility"]["value"])
+    
+    # system memory
+    if cmd_dict["sysmem"]["value"] > 0:
+        kernel_json["argv"] += cmd_dict["sysmem"]["cmd"], str(cmd_dict["sysmem"]["value"])
+    
+    # register memory
+    if cmd_dict["regmem"]["value"] > 0:
+        kernel_json["argv"] += cmd_dict["regmem"]["cmd"], str(cmd_dict["regmem"]["value"])
+    
+    # other options from json
+    if "other_options" in cmd_dict:
+        other_options = cmd_dict["other_options"]
+        for option in other_options:
+            if option["value"] == None:
+                kernel_json["argv"].append(option["cmd"])
+            else:
+                kernel_json["argv"] += option["cmd"], str(option["value"])
+
+    # other options from cmd line
+    for option in cmd_opts:
+        kernel_json["argv"].append(option)
+
+    ksm = KernelSpecManager()
+
+    # we need the installation dir of kernel, so first install a fake one
+    tmp_kernel_name = "tmp_legion_kernel"
+    tmp_kernel_json = {"argv": [], "display_name": "Tmp", "language": "python"}
+    _install_kernel(ksm, tmp_kernel_name, tmp_kernel_json, user, prefix)
+    spec = ksm.get_kernel_spec(tmp_kernel_name)
+    kernel_install_dir = os.path.dirname(spec.resource_dir)
+    _delete_kernel(ksm, tmp_kernel_name)
+
+    # Now start installation
+    kernel_name = cmd_dict["kernel_name"]
+
+    # add installation dir to legin_kernel_nocr.py
+    kernel_install_dir = os.path.join(kernel_install_dir, kernel_name)
+    kernel_filename = kernel_json_suffix_nocr[0]
+    kernel_json_suffix_nocr[0] = os.path.join(kernel_install_dir, kernel_filename)
+    kernel_json["argv"] += kernel_json_suffix_nocr
+    if verbose:
+        print("The kernel_json is:\n" + str(kernel_json))
+
+    # check if kernel is existed, if yes, then delete the old one before installation. 
+    _delete_kernel(ksm, kernel_name, False)
+
+    # install the kernel
+    _install_kernel(ksm, kernel_name, kernel_json, user, prefix, False)
+
+    # copy legion_kernel_nocr.py into kernel dir
+    if kernel_file_dir == None:
+        file_path = os.getcwd() + "/" + kernel_filename
+    else:
+        file_path = kernel_file_dir + "/" + kernel_filename
+    shutil.copy(file_path, kernel_install_dir)
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Install Legion IPython Kernel"
+    )
+
+    parser.add_argument(
+        "--user",
+        action="store_true",
+        default=True,
+        dest="user",
+        help="Install the kernel in user home directory",
+    )
+    parser.add_argument(
+        "--kernel-name",
+        default="",
+        dest="kernel_name",
+        help="Install the kernel into prefix",
+    )
+    parser.add_argument(
+        "--prefix",
+        default=None,
+        dest="prefix",
+        help="Install the kernel into prefix",
+    )
+    parser.add_argument(
+        "--json",
+        default="flexflow_python.json",
+        dest="json",
+        help="Configuration file of flexflow_python",
+    )
+    parser.add_argument(
+        "--flexflow-python-prefix",
+        default=None,
+        dest="flexflow_python_prefix",
+        help="The dirctory where flexflow_python is installed",
+    )
+    parser.add_argument(
+        "--cpus",
+        type=int,
+        default=1,
+        dest="cpus",
+        help="Number of CPUs to use per rank",
+    )
+    parser.add_argument(
+        "--gpus",
+        type=int,
+        default=1,
+        dest="gpus",
+        help="Number of GPUs to use per rank",
+    )
+    parser.add_argument(
+        "--omps",
+        type=int,
+        default=0,
+        dest="openmp",
+        help="Number of OpenMP groups to use per rank",
+    )
+    parser.add_argument(
+        "--ompthreads",
+        type=int,
+        default=4,
+        dest="ompthreads",
+        help="Number of threads per OpenMP group",
+    )
+    parser.add_argument(
+        "--utility",
+        type=int,
+        default=1,
+        dest="utility",
+        help="Number of Utility processors per rank to request for meta-work",
+    )
+    parser.add_argument(
+        "--sysmem",
+        type=int,
+        default=4000,
+        dest="sysmem",
+        help="Amount of DRAM memory per rank (in MBs)",
+    )
+    parser.add_argument(
+        "--fbmem",
+        type=int,
+        default=4000,
+        dest="fbmem",
+        help="Amount of framebuffer memory per GPU (in MBs)",
+    )
+    parser.add_argument(
+        "--zcmem",
+        type=int,
+        default=32,
+        dest="zcmem",
+        help="Amount of zero-copy memory per rank (in MBs)",
+    )
+    parser.add_argument(
+        "--regmem",
+        type=int,
+        default=0,
+        dest="regmem",
+        help="Amount of registered CPU-side pinned memory per rank (in MBs)",
+    )
+    parser.add_argument(
+        "--no-replicate",
+        dest="not_control_replicable",
+        action="store_true",
+        required=False,
+        default=True,
+        help="Execute this program without control replication.  Most of the "
+        "time, this is not recommended.  This option should be used for "
+        "debugging.  The -lg:safe_ctrlrepl Legion option may be helpful "
+        "with discovering issues with replicated control.",
+    )
+    parser.add_argument(
+        "--launcher",
+        dest="launcher",
+        choices=["mpirun", "jsrun", "srun", "none"],
+        default="none",
+        help='launcher program to use (set to "none" for local runs, or if '
+        "the launch has already happened by the time legate is invoked)",
+    )
+    parser.add_argument(
+        "--nodes",
+        type=int,
+        default=1,
+        dest="nodes",
+        help="Number of nodes to use",
+    )
+    parser.add_argument(
+        "--ranks-per-node",
+        type=int,
+        default=1,
+        dest="ranks_per_node",
+        help="Number of ranks (processes running copies of the program) to "
+        "launch per node. The default (1 rank per node) will typically result "
+        "in the best performance.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        dest="verbose",
+        help="Display the detailed log of installation",
+    )
+
+    args, opts = parser.parse_known_args()
+    return args, opts
+
+def driver(args, opts, kernel_file_dir=None):
+    cmd_dict = parse_json(flexflow_python_prefix=args.flexflow_python_prefix,
+                          cpus=args.cpus,
+                          gpus=args.gpus,
+                          openmp=args.openmp,
+                          ompthreads=args.ompthreads,
+                          utility=args.utility,
+                          sysmem=args.sysmem,
+                          fbmem=args.fbmem,
+                          zcmem=args.zcmem,
+                          regmem=args.regmem,
+                          launcher=args.launcher,
+                          nodes=args.nodes,
+                          ranks_per_node=args.ranks_per_node,
+                          not_control_replicable=args.not_control_replicable,
+                          kernel_name=args.kernel_name,
+                          filename=args.json)
+
+    if cmd_dict["not_control_replicable"]:
+        install_kernel_nocr(user=args.user, 
+                            prefix=args.prefix, 
+                            cmd_opts=opts,
+                            cmd_dict=cmd_dict,
+                            verbose=args.verbose,
+                            kernel_file_dir=kernel_file_dir)
+    else:
+        assert 0, "Control replication is not supported yet"
+
+if __name__ == '__main__':
+    args, opts = parse_args()
+    driver(args, opts)


### PR DESCRIPTION
I recently implemented the jupyter notebook support (single node) for legion python binding, so I cherry picked the code into FlexFlow, such that we are able to run FlexFlow code in jupyter notebook. If we plan to use `legion_python` instead of our own `flex flow_python` in the future, we can just use the jupyter support from Legion. Feel free to take a look at the instruction in README.md.

Current issues: we have a lot of prints in the C++ code, especially the accuracy, so we will see them printed in red color in jupyter notebook, while the regular python `print` is printed in black.  