### PR TITLE
Partially resolve transpose no get_params_hash overload issue

### DIFF
--- a/src/ops/reshape.cc
+++ b/src/ops/reshape.cc
@@ -380,12 +380,12 @@ bool Reshape::measure_operator_cost(Simulator *sim,
 
   if (sim->computationMode == COMP_MODE_TRAINING) {
     printf(
-        "[Meausre Reshape] name(%s) forward_time(%.4lf) backward_time(%.4lf)\n",
+        "[Measure Reshape] name(%s) forward_time(%.4lf) backward_time(%.4lf)\n",
         name,
         cost_metrics.forward_time,
         cost_metrics.backward_time);
   } else {
-    printf("[Meausre Reshape] name(%s) forward_time(%.4lf)\n",
+    printf("[Measure Reshape] name(%s) forward_time(%.4lf)\n",
            name,
            cost_metrics.forward_time);
   }

--- a/src/runtime/operator_params.cc
+++ b/src/runtime/operator_params.cc
@@ -12,6 +12,7 @@
 #include "flexflow/ops/pool_2d.h"
 #include "flexflow/ops/reshape.h"
 #include "flexflow/ops/softmax.h"
+#include "flexflow/ops/transpose.h"
 #include "flexflow/parallel_ops/combine.h"
 #include "flexflow/parallel_ops/fused_parallel_op.h"
 #include "flexflow/parallel_ops/partition.h"
@@ -71,6 +72,8 @@ tl::optional<OperatorParameters> get_op_parameters(Op const *op) {
       return ((Combine *)op)->get_params();
     case OP_FUSED_PARALLEL:
       return ((FusedParallelOp *)op)->get_params();
+    case OP_TRANSPOSE:
+      return ((Transpose *)op)->get_params();
     default:
       return tl::nullopt;
   }


### PR DESCRIPTION
This change (partially) fixes the error reported by Byungsoo:
```
[Meausre Reshape] name(view_1000002_2000002) forward_time(0.0036) backward_time(0.0029) 
terminate called after throwing an instance of 'std::runtime_error'
what():  No overload of get_params_hash defined for op type Transpose
```