### PR TITLE
[Makefile] - Add makefile check to `build` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-install-flexflow:
-    name: Build and Install FlexFlow
+  cmake-build:
+    name: Build FlexFlow with CMake
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Git Repository
@@ -50,6 +50,7 @@ jobs:
           export FF_HOME=$(pwd)
           cores_available=$(nproc --all)
           n_build_cores=$(( cores_available -1 ))
+          if (( $n_build_cores < 1 )) ; then n_build_cores=1 ; fi
           sed -i "/FF_CUDA_ARCH/c\FF_CUDA_ARCH=70" ./config/config.linux
           sed -i "/FF_BUILD_UNIT_TESTS/c\FF_BUILD_UNIT_TESTS=ON" ./config/config.linux
           mkdir build
@@ -82,3 +83,35 @@ jobs:
           sudo ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
           cd build
           ./tests/unit/unit-test
+
+  makefile-build:
+    name: Build FlexFlow with the Makefile
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install CUDA
+        uses: Jimver/cuda-toolkit@v0.2.8
+        id: cuda-toolkit
+        with:
+          cuda: "11.1.1"
+
+      - name: Install FlexFlow Dependencies
+        run: .github/workflows/helpers/install_dependencies.sh
+
+      - name: Build FlexFlow
+        run: |
+          export PATH=/opt/conda/bin:$PATH
+          export CUDNN_DIR=/usr/local/cuda
+          export CUDA_DIR=/usr/local/cuda
+          export FF_HOME=$(pwd)
+          cores_available=$(nproc --all)
+          n_build_cores=$(( cores_available -1 ))
+          if (( $n_build_cores < 1 )) ; then n_build_cores=1 ; fi
+
+          mkdir build
+          cd build
+          make -f ../FlexFlow.mk -j $n_build_cores

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,5 +114,4 @@ jobs:
 
           cd python
           make -j $n_build_cores
-          pip install -e .
           python -c 'import flexflow.core'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
           n_build_cores=$(( cores_available -1 ))
           if (( $n_build_cores < 1 )) ; then n_build_cores=1 ; fi
 
-          mkdir build
-          cd build
-          make -f ../FlexFlow.mk -j $n_build_cores
+          cd python
+          make -j $n_build_cores
+          pip install -e .
+          python -c 'import flexflow.core'


### PR DESCRIPTION
The current CI workflows only test the build / installation of FlexFlow using the Cmake system. As a result, changes that break the Makefile system (like my own PR #389 ) go un-noticed. This PR introduces a new job in the `build` workflow, running in parallel to the existing one, testing the build with Makefile.