### PR TITLE
[CI] - Add placeholder workflows for required jobs skipped by path filtering

### DIFF
--- a/.github/workflows/build-skip.yml
+++ b/.github/workflows/build-skip.yml
@@ -1,0 +1,37 @@
+name: "build"
+on:
+  pull_request:
+    paths-ignore:
+      - "include/**"
+      - "cmake/**"
+      - "config/**"
+      - "python/**"
+      - "src/**"
+      - ".github/workflows/helpers/install_dependencies.sh"
+      - ".github/workflows/build.yml"
+  push:
+    paths-ignore:
+      - "include/**"
+      - "cmake/**"
+      - "config/**"
+      - "python/**"
+      - "src/**"
+      - ".github/workflows/helpers/install_dependencies.sh"
+      - ".github/workflows/build.yml"
+  workflow_dispatch:
+concurrency:
+  group: build-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  cmake-build:
+    name: Build FlexFlow with CMake
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "No build required"'
+
+  makefile-build:
+    name: Build FlexFlow with the Makefile
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -7,19 +7,19 @@ jobs:
     strategy:
       matrix:
         path:
-          - check: 'src'
+          - check: "src"
             exclude: '\.proto$'
-          - check: 'include'
-          - check: 'nmt'
-          - check: 'python'
-          - check: 'scripts'
-          - check: 'tests'
-          - check: 'examples'
+          - check: "include"
+          - check: "nmt"
+          - check: "python"
+          - check: "scripts"
+          - check: "tests"
+          - check: "examples"
     steps:
-    - uses: actions/checkout@v2
-    - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.8.0
-      with:
-        clang-format-version: '14'
-        check-path: ${{ matrix.path['check'] }}
-        exclude-regex: ${{ matrix.path['exclude'] }}
+      - uses: actions/checkout@v2
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: jidicula/clang-format-action@v4.8.0
+        with:
+          clang-format-version: "14"
+          check-path: ${{ matrix.path['check'] }}
+          exclude-regex: ${{ matrix.path['exclude'] }}

--- a/.github/workflows/docker-build-skip.yml
+++ b/.github/workflows/docker-build-skip.yml
@@ -1,0 +1,25 @@
+name: "docker-build"
+on:
+  pull_request:
+    paths-ignore:
+      - "docker/**"
+      - "!docker/README.md"
+      - ".github/workflows/docker-build.yml"
+  push:
+    paths-ignore:
+      - "docker/**"
+      - "!docker/README.md"
+      - ".github/workflows/docker-build.yml"
+  workflow_dispatch:
+
+# Cancel outdated workflows if they are still running
+concurrency:
+  group: docker-build-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build:
+    name: Build and Install FlexFlow in a Docker Container
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "No docker-build required"'

--- a/.github/workflows/pip-install-skip.yml
+++ b/.github/workflows/pip-install-skip.yml
@@ -1,0 +1,29 @@
+name: "pip-install"
+on:
+  pull_request:
+    paths-ignore:
+      - "cmake/**"
+      - "config/**"
+      - "python/**"
+      - "setup.py"
+      - ".github/workflows/helpers/install_dependencies.sh"
+      - ".github/workflows/pip-install.yml"
+  push:
+    paths-ignore:
+      - "cmake/**"
+      - "config/**"
+      - "python/**"
+      - "setup.py"
+      - ".github/workflows/helpers/install_dependencies.sh"
+      - ".github/workflows/pip-install.yml"
+  workflow_dispatch:
+concurrency:
+  group: pip-install-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  pip-install-flexflow:
+    name: Install FlexFlow with pip
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "No pip-install required"'


### PR DESCRIPTION
This PR handles the case where required jobs are skipped due to path filtering (e.g. the `build` job is required, but if you make a change to the README, the job is skipped because it is unnecessary), but their status is expected before a PR can be merged, because the jobs are marked as required. We implement the official solution recommended by GitHub (see here: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks)