### PR TITLE
[CI] - Fix workflow concurrency groups

### DIFF
--- a/.github/workflows/build-skip.yml
+++ b/.github/workflows/build-skip.yml
@@ -20,7 +20,7 @@ on:
       - ".github/workflows/build.yml"
   workflow_dispatch:
 concurrency:
-  group: build-${{ github.head_ref || github.run_id }}
+  group: build-skip-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker-build-skip.yml
+++ b/.github/workflows/docker-build-skip.yml
@@ -14,7 +14,7 @@ on:
 
 # Cancel outdated workflows if they are still running
 concurrency:
-  group: docker-build-${{ github.head_ref || github.run_id }}
+  group: docker-build-skip-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pip-install-skip.yml
+++ b/.github/workflows/pip-install-skip.yml
@@ -18,7 +18,7 @@ on:
       - ".github/workflows/pip-install.yml"
   workflow_dispatch:
 concurrency:
-  group: pip-install-${{ github.head_ref || github.run_id }}
+  group: pip-install-skip-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
In PR #399 we introduced some placeholder workflows to handle the case of skipped but required checks, following the official Github instructions [from here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks). The idea is to create, for each workflow with required jobs, another workflow with the same name (but different filename), and with placeholder jobs that carry the same name, but do nothing. However, the name of the concurrency group used in the placeholder workflow to cancel in-progress jobs that become out-of-date should be different from the one used in the original workflow. I did not realize this until now, and so my previous PR introduced a race condition between the concurrency groups of the original vs placeholder workflows. This PR aims to fix that.