### PR TITLE
[Split] Kernel refactor

### DIFF
--- a/include/flexflow/ops/kernels/split_kernels.h
+++ b/include/flexflow/ops/kernels/split_kernels.h
@@ -1,0 +1,46 @@
+#ifndef _FLEXFLOW_OPS_KERNELS_SPLIT_KERNELS_H
+#define _FLEXFLOW_OPS_KERNELS_SPLIT_KERNELS_H
+
+#include "flexflow/device.h"
+#include "flexflow/fftype.h"
+#include "flexflow/op_meta.h"
+
+namespace FlexFlow {
+
+namespace Kernels {
+namespace Split {
+   void forward_kernel_wrapper(float **out_ptrs,
+                                     float const *in_ptr,
+                                     Legion::coord_t const *out_blk_sizes,
+                                     Legion::coord_t in_blk_size,
+                                     Legion::coord_t num_blks,
+                                     int numOutputs);
+   
+   void backward_kernel_wrapper(float *in_grad_ptr,
+                                      float const **out_grad_ptr,
+                                      Legion::coord_t const *out_blk_sizes,
+                                      Legion::coord_t in_blk_size,
+                                      Legion::coord_t num_blks,
+                                      int numOutputs);
+
+namespace Internal {
+ void forward_kernel(float **out_ptrs,
+                             float const *in_ptr,
+                             Legion::coord_t const *out_blk_sizes,
+                             Legion::coord_t in_blk_size,
+                             Legion::coord_t num_blks,
+                             int numOutputs,
+                             ffStream_t stream);
+void backward_kernel(float *in_grad_ptr,
+                              float const **out_grad_ptr,
+                              Legion::coord_t const *out_blk_sizes,
+                              Legion::coord_t in_blk_size,
+                              Legion::coord_t num_blks,
+                              int numOutputs,
+                              ffStream_t stream);
+} // namespace Internal
+} // namespace Split
+} // namespace Kernels
+} // namespace FlexFlow
+
+#endif // _FLEXFLOW_OPS_KERNELS_SPLIT_KERNELS_H

--- a/include/flexflow/ops/kernels/split_kernels.h
+++ b/include/flexflow/ops/kernels/split_kernels.h
@@ -9,35 +9,35 @@ namespace FlexFlow {
 
 namespace Kernels {
 namespace Split {
-   void forward_kernel_wrapper(float **out_ptrs,
-                                     float const *in_ptr,
-                                     Legion::coord_t const *out_blk_sizes,
-                                     Legion::coord_t in_blk_size,
-                                     Legion::coord_t num_blks,
-                                     int numOutputs);
-   
-   void backward_kernel_wrapper(float *in_grad_ptr,
-                                      float const **out_grad_ptr,
-                                      Legion::coord_t const *out_blk_sizes,
-                                      Legion::coord_t in_blk_size,
-                                      Legion::coord_t num_blks,
-                                      int numOutputs);
+void forward_kernel_wrapper(float **out_ptrs,
+                            float const *in_ptr,
+                            Legion::coord_t const *out_blk_sizes,
+                            Legion::coord_t in_blk_size,
+                            Legion::coord_t num_blks,
+                            int numOutputs);
 
-namespace Internal {
- void forward_kernel(float **out_ptrs,
-                             float const *in_ptr,
+void backward_kernel_wrapper(float *in_grad_ptr,
+                             float const **out_grad_ptr,
                              Legion::coord_t const *out_blk_sizes,
                              Legion::coord_t in_blk_size,
                              Legion::coord_t num_blks,
-                             int numOutputs,
-                             ffStream_t stream);
+                             int numOutputs);
+
+namespace Internal {
+void forward_kernel(float **out_ptrs,
+                    float const *in_ptr,
+                    Legion::coord_t const *out_blk_sizes,
+                    Legion::coord_t in_blk_size,
+                    Legion::coord_t num_blks,
+                    int numOutputs,
+                    ffStream_t stream);
 void backward_kernel(float *in_grad_ptr,
-                              float const **out_grad_ptr,
-                              Legion::coord_t const *out_blk_sizes,
-                              Legion::coord_t in_blk_size,
-                              Legion::coord_t num_blks,
-                              int numOutputs,
-                              ffStream_t stream);
+                     float const **out_grad_ptr,
+                     Legion::coord_t const *out_blk_sizes,
+                     Legion::coord_t in_blk_size,
+                     Legion::coord_t num_blks,
+                     int numOutputs,
+                     ffStream_t stream);
 } // namespace Internal
 } // namespace Split
 } // namespace Kernels

--- a/include/flexflow/ops/split.h
+++ b/include/flexflow/ops/split.h
@@ -1,11 +1,8 @@
 #ifndef _FLEXFLOW_SPLIT_H
 #define _FLEXFLOW_SPLIT_H
 
-#include "flexflow/device.h"
-#include "flexflow/fftype.h"
 #include "flexflow/layer.h"
 #include "flexflow/node.h"
-#include "flexflow/op_meta.h"
 #include "flexflow/operator.h"
 #include "flexflow/ops/split_params.h"
 
@@ -47,32 +44,6 @@ public:
                             std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void forward_kernel(float **out_ptrs,
-                             float const *in_ptr,
-                             Legion::coord_t const *out_blk_sizes,
-                             Legion::coord_t in_blk_size,
-                             Legion::coord_t num_blks,
-                             int numOutputs,
-                             ffStream_t stream);
-  static void forward_kernel_wrapper(float **out_ptrs,
-                                     float const *in_ptr,
-                                     Legion::coord_t const *out_blk_sizes,
-                                     Legion::coord_t in_blk_size,
-                                     Legion::coord_t num_blks,
-                                     int numOutputs);
-  static void backward_kernel(float *in_grad_ptr,
-                              float const **out_grad_ptr,
-                              Legion::coord_t const *out_blk_sizes,
-                              Legion::coord_t in_blk_size,
-                              Legion::coord_t num_blks,
-                              int numOutputs,
-                              ffStream_t stream);
-  static void backward_kernel_wrapper(float *in_grad_ptr,
-                                      float const **out_grad_ptr,
-                                      Legion::coord_t const *out_blk_sizes,
-                                      Legion::coord_t in_blk_size,
-                                      Legion::coord_t num_blks,
-                                      int numOutputs);
   bool measure_operator_cost(Simulator *sim,
                              MachineView const &pc,
                              CostMetrics &cost_metrics) const override;

--- a/src/ops/kernels/split_kernels.cpp
+++ b/src/ops/kernels/split_kernels.cpp
@@ -24,7 +24,6 @@ using Legion::coord_t;
 namespace Kernels {
 namespace Split {
 
-/*static*/
 void backward_kernel_wrapper(float *in_grad_ptr,
                              float const **out_grad_ptr,
                              coord_t const *out_blk_sizes,
@@ -43,7 +42,6 @@ void backward_kernel_wrapper(float *in_grad_ptr,
   // checkCUDA(cudaDeviceSynchronize());
 }
 
-/*static*/
 void forward_kernel_wrapper(float **out_ptrs,
                             float const *in_ptr,
                             coord_t const *out_blk_sizes,
@@ -63,7 +61,6 @@ void forward_kernel_wrapper(float **out_ptrs,
 
 namespace Internal {
 
-/*static*/
 void forward_kernel(float **out_ptrs,
                     float const *in_ptr,
                     coord_t const *out_blk_sizes,
@@ -86,7 +83,6 @@ void forward_kernel(float **out_ptrs,
   }
 }
 
-/*static*/
 void backward_kernel(float *in_grad_ptr,
                      float const **out_grad_ptr,
                      coord_t const *out_blk_sizes,

--- a/src/ops/kernels/split_kernels.cpp
+++ b/src/ops/kernels/split_kernels.cpp
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include "flexflow/ops/split.h"
+#include "flexflow/ops/kernels/split_kernels.h"
 #include "flexflow/utils/hip_helper.h"
 #include <hip/hip_runtime.h>
 
@@ -21,8 +21,50 @@ namespace FlexFlow {
 // declare Legion names
 using Legion::coord_t;
 
+namespace Kernels {
+namespace Split {
+
+  /*static*/
+void backward_kernel_wrapper(float *in_grad_ptr,
+                                    float const **out_grad_ptr,
+                                    coord_t const *out_blk_sizes,
+                                    coord_t in_blk_size,
+                                    coord_t num_blks,
+                                    int numOutputs) {
+  hipStream_t stream;
+  checkCUDA(get_legion_stream(&stream));
+  Internal::backward_kernel(in_grad_ptr,
+                         out_grad_ptr,
+                         out_blk_sizes,
+                         in_blk_size,
+                         num_blks,
+                         numOutputs,
+                         stream);
+  // checkCUDA(cudaDeviceSynchronize());
+}
+
 /*static*/
-void Split::forward_kernel(float **out_ptrs,
+void forward_kernel_wrapper(float **out_ptrs,
+                                   float const *in_ptr,
+                                   coord_t const *out_blk_sizes,
+                                   coord_t in_blk_size,
+                                   coord_t num_blks,
+                                   int numOutputs) {
+  hipStream_t stream;
+  checkCUDA(get_legion_stream(&stream));
+  Internal::forward_kernel(out_ptrs,
+                        in_ptr,
+                        out_blk_sizes,
+                        in_blk_size,
+                        num_blks,
+                        numOutputs,
+                        stream);
+}
+
+namespace Internal {
+
+/*static*/
+void forward_kernel(float **out_ptrs,
                            float const *in_ptr,
                            coord_t const *out_blk_sizes,
                            coord_t in_blk_size,
@@ -45,25 +87,7 @@ void Split::forward_kernel(float **out_ptrs,
 }
 
 /*static*/
-void Split::forward_kernel_wrapper(float **out_ptrs,
-                                   float const *in_ptr,
-                                   coord_t const *out_blk_sizes,
-                                   coord_t in_blk_size,
-                                   coord_t num_blks,
-                                   int numOutputs) {
-  hipStream_t stream;
-  checkCUDA(get_legion_stream(&stream));
-  Split::forward_kernel(out_ptrs,
-                        in_ptr,
-                        out_blk_sizes,
-                        in_blk_size,
-                        num_blks,
-                        numOutputs,
-                        stream);
-}
-
-/*static*/
-void Split::backward_kernel(float *in_grad_ptr,
+void backward_kernel(float *in_grad_ptr,
                             float const **out_grad_ptr,
                             coord_t const *out_blk_sizes,
                             coord_t in_blk_size,
@@ -85,23 +109,7 @@ void Split::backward_kernel(float *in_grad_ptr,
   }
 }
 
-/*static*/
-void Split::backward_kernel_wrapper(float *in_grad_ptr,
-                                    float const **out_grad_ptr,
-                                    coord_t const *out_blk_sizes,
-                                    coord_t in_blk_size,
-                                    coord_t num_blks,
-                                    int numOutputs) {
-  hipStream_t stream;
-  checkCUDA(get_legion_stream(&stream));
-  Split::backward_kernel(in_grad_ptr,
-                         out_grad_ptr,
-                         out_blk_sizes,
-                         in_blk_size,
-                         num_blks,
-                         numOutputs,
-                         stream);
-  // checkCUDA(cudaDeviceSynchronize());
-}
-
-}; // namespace FlexFlow
+} // namespace Internal
+} // namespace Split
+} // namespace Kernels
+} // namespace FlexFlow

--- a/src/ops/kernels/split_kernels.cpp
+++ b/src/ops/kernels/split_kernels.cpp
@@ -24,53 +24,53 @@ using Legion::coord_t;
 namespace Kernels {
 namespace Split {
 
-  /*static*/
+/*static*/
 void backward_kernel_wrapper(float *in_grad_ptr,
-                                    float const **out_grad_ptr,
-                                    coord_t const *out_blk_sizes,
-                                    coord_t in_blk_size,
-                                    coord_t num_blks,
-                                    int numOutputs) {
+                             float const **out_grad_ptr,
+                             coord_t const *out_blk_sizes,
+                             coord_t in_blk_size,
+                             coord_t num_blks,
+                             int numOutputs) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
   Internal::backward_kernel(in_grad_ptr,
-                         out_grad_ptr,
-                         out_blk_sizes,
-                         in_blk_size,
-                         num_blks,
-                         numOutputs,
-                         stream);
+                            out_grad_ptr,
+                            out_blk_sizes,
+                            in_blk_size,
+                            num_blks,
+                            numOutputs,
+                            stream);
   // checkCUDA(cudaDeviceSynchronize());
 }
 
 /*static*/
 void forward_kernel_wrapper(float **out_ptrs,
-                                   float const *in_ptr,
-                                   coord_t const *out_blk_sizes,
-                                   coord_t in_blk_size,
-                                   coord_t num_blks,
-                                   int numOutputs) {
+                            float const *in_ptr,
+                            coord_t const *out_blk_sizes,
+                            coord_t in_blk_size,
+                            coord_t num_blks,
+                            int numOutputs) {
   hipStream_t stream;
   checkCUDA(get_legion_stream(&stream));
   Internal::forward_kernel(out_ptrs,
-                        in_ptr,
-                        out_blk_sizes,
-                        in_blk_size,
-                        num_blks,
-                        numOutputs,
-                        stream);
+                           in_ptr,
+                           out_blk_sizes,
+                           in_blk_size,
+                           num_blks,
+                           numOutputs,
+                           stream);
 }
 
 namespace Internal {
 
 /*static*/
 void forward_kernel(float **out_ptrs,
-                           float const *in_ptr,
-                           coord_t const *out_blk_sizes,
-                           coord_t in_blk_size,
-                           coord_t num_blks,
-                           int numOutputs,
-                           hipStream_t stream) {
+                    float const *in_ptr,
+                    coord_t const *out_blk_sizes,
+                    coord_t in_blk_size,
+                    coord_t num_blks,
+                    int numOutputs,
+                    hipStream_t stream) {
   for (int i = 0; i < numOutputs; i++) {
     hipLaunchKernelGGL(copy_with_stride,
                        GET_BLOCKS(out_blk_sizes[i] * num_blks),
@@ -88,12 +88,12 @@ void forward_kernel(float **out_ptrs,
 
 /*static*/
 void backward_kernel(float *in_grad_ptr,
-                            float const **out_grad_ptr,
-                            coord_t const *out_blk_sizes,
-                            coord_t in_blk_size,
-                            coord_t num_blks,
-                            int numOutputs,
-                            hipStream_t stream) {
+                     float const **out_grad_ptr,
+                     coord_t const *out_blk_sizes,
+                     coord_t in_blk_size,
+                     coord_t num_blks,
+                     int numOutputs,
+                     hipStream_t stream) {
   for (int i = 0; i < numOutputs; i++) {
     hipLaunchKernelGGL(add_with_stride,
                        GET_BLOCKS(out_blk_sizes[i] * num_blks),

--- a/src/ops/kernels/split_kernels.cu
+++ b/src/ops/kernels/split_kernels.cu
@@ -25,38 +25,38 @@ namespace Split {
 
 /*static*/
 void forward_kernel_wrapper(float **out_ptrs,
-                                   float const *in_ptr,
-                                   coord_t const *out_blk_sizes,
-                                   coord_t in_blk_size,
-                                   coord_t num_blks,
-                                   int numOutputs) {
+                            float const *in_ptr,
+                            coord_t const *out_blk_sizes,
+                            coord_t in_blk_size,
+                            coord_t num_blks,
+                            int numOutputs) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
   Internal::forward_kernel(out_ptrs,
-                        in_ptr,
-                        out_blk_sizes,
-                        in_blk_size,
-                        num_blks,
-                        numOutputs,
-                        stream);
+                           in_ptr,
+                           out_blk_sizes,
+                           in_blk_size,
+                           num_blks,
+                           numOutputs,
+                           stream);
 }
 
 /*static*/
 void backward_kernel_wrapper(float *in_grad_ptr,
-                                    float const **out_grad_ptr,
-                                    coord_t const *out_blk_sizes,
-                                    coord_t in_blk_size,
-                                    coord_t num_blks,
-                                    int numOutputs) {
+                             float const **out_grad_ptr,
+                             coord_t const *out_blk_sizes,
+                             coord_t in_blk_size,
+                             coord_t num_blks,
+                             int numOutputs) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
   Internal::backward_kernel(in_grad_ptr,
-                         out_grad_ptr,
-                         out_blk_sizes,
-                         in_blk_size,
-                         num_blks,
-                         numOutputs,
-                         stream);
+                            out_grad_ptr,
+                            out_blk_sizes,
+                            in_blk_size,
+                            num_blks,
+                            numOutputs,
+                            stream);
   // checkCUDA(cudaDeviceSynchronize());
 }
 
@@ -64,12 +64,12 @@ namespace Internal {
 
 /*static*/
 void forward_kernel(float **out_ptrs,
-                           float const *in_ptr,
-                           coord_t const *out_blk_sizes,
-                           coord_t in_blk_size,
-                           coord_t num_blks,
-                           int numOutputs,
-                           cudaStream_t stream) {
+                    float const *in_ptr,
+                    coord_t const *out_blk_sizes,
+                    coord_t in_blk_size,
+                    coord_t num_blks,
+                    int numOutputs,
+                    cudaStream_t stream) {
   for (int i = 0; i < numOutputs; i++) {
     copy_with_stride<<<GET_BLOCKS(out_blk_sizes[i] * num_blks),
                        CUDA_NUM_THREADS,
@@ -82,12 +82,12 @@ void forward_kernel(float **out_ptrs,
 
 /*static*/
 void backward_kernel(float *in_grad_ptr,
-                            float const **out_grad_ptr,
-                            coord_t const *out_blk_sizes,
-                            coord_t in_blk_size,
-                            coord_t num_blks,
-                            int numOutputs,
-                            cudaStream_t stream) {
+                     float const **out_grad_ptr,
+                     coord_t const *out_blk_sizes,
+                     coord_t in_blk_size,
+                     coord_t num_blks,
+                     int numOutputs,
+                     cudaStream_t stream) {
   for (int i = 0; i < numOutputs; i++) {
     add_with_stride<<<GET_BLOCKS(out_blk_sizes[i] * num_blks),
                       CUDA_NUM_THREADS,

--- a/src/ops/kernels/split_kernels.cu
+++ b/src/ops/kernels/split_kernels.cu
@@ -23,7 +23,6 @@ using Legion::coord_t;
 namespace Kernels {
 namespace Split {
 
-/*static*/
 void forward_kernel_wrapper(float **out_ptrs,
                             float const *in_ptr,
                             coord_t const *out_blk_sizes,
@@ -41,7 +40,6 @@ void forward_kernel_wrapper(float **out_ptrs,
                            stream);
 }
 
-/*static*/
 void backward_kernel_wrapper(float *in_grad_ptr,
                              float const **out_grad_ptr,
                              coord_t const *out_blk_sizes,
@@ -62,7 +60,6 @@ void backward_kernel_wrapper(float *in_grad_ptr,
 
 namespace Internal {
 
-/*static*/
 void forward_kernel(float **out_ptrs,
                     float const *in_ptr,
                     coord_t const *out_blk_sizes,
@@ -80,7 +77,6 @@ void forward_kernel(float **out_ptrs,
   }
 }
 
-/*static*/
 void backward_kernel(float *in_grad_ptr,
                      float const **out_grad_ptr,
                      coord_t const *out_blk_sizes,

--- a/src/ops/split.cc
+++ b/src/ops/split.cc
@@ -317,11 +317,11 @@ void Split::backward_task(Task const *task,
   assert(total_volume == in_grad_domain.get_volume());
 
   backward_kernel_wrapper(in_grad_ptr,
-                                 out_grad_ptr,
-                                 out_blk_size,
-                                 in_blk_size,
-                                 num_blks,
-                                 split->numOutputs);
+                          out_grad_ptr,
+                          out_blk_size,
+                          in_blk_size,
+                          num_blks,
+                          split->numOutputs);
 }
 
 bool Split::measure_operator_cost(Simulator *sim,

--- a/src/ops/split.cc
+++ b/src/ops/split.cc
@@ -15,6 +15,7 @@
 
 #include "flexflow/ops/split.h"
 #include "flexflow/model.h"
+#include "flexflow/ops/kernels/split_kernels.h"
 #include "flexflow/utils/hash_utils.h"
 
 namespace FlexFlow {
@@ -34,6 +35,8 @@ using Legion::Task;
 using Legion::TaskArgument;
 using Legion::TaskLauncher;
 using PCG::Node;
+
+using namespace FlexFlow::Kernels::Split;
 
 bool operator==(SplitParams const &lhs, SplitParams const &rhs) {
   return lhs.splits == rhs.splits && lhs.legion_axis == rhs.legion_axis;
@@ -247,7 +250,7 @@ void Split::forward_task(Task const *task,
   }
   assert(total_volume == in_domain.get_volume());
 
-  Split::forward_kernel_wrapper(
+  forward_kernel_wrapper(
       out_ptr, in_ptr, out_blk_size, in_blk_size, num_blks, split->numOutputs);
 }
 
@@ -313,7 +316,7 @@ void Split::backward_task(Task const *task,
   }
   assert(total_volume == in_grad_domain.get_volume());
 
-  Split::backward_kernel_wrapper(in_grad_ptr,
+  backward_kernel_wrapper(in_grad_ptr,
                                  out_grad_ptr,
                                  out_blk_size,
                                  in_blk_size,


### PR DESCRIPTION
**Description of changes:**

This PR removes kernel functions from `split.h` and `split.cc` into separate `split_kernels.h`, `split_kernels.cu`, and `split_kernels.cpp`.

**Related Issues:**

Linked Issues:
- Issue #303 

Issues closed by this PR:
- Closes #436 

**Before merging:**

- [x] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules? **n/a**
