### PR TITLE
Shellcheck fix in `install_cudnn.sh`

### DIFF
--- a/.github/workflows/helpers/install_cudnn.sh
+++ b/.github/workflows/helpers/install_cudnn.sh
@@ -46,9 +46,9 @@ wget -c -q $CUDNN_LINK
 if [[ "$cuda_version" == "11.6" || "$cuda_version" == "11.7" ]]; then
     tar -xf $CUDNN_TARBALL_NAME -C ./
     CUDNN_EXTRACTED_TARBALL_NAME="${CUDNN_TARBALL_NAME::-7}"
-    sudo cp -r $CUDNN_EXTRACTED_TARBALL_NAME/include/* /usr/local/include
-    sudo cp -r $CUDNN_EXTRACTED_TARBALL_NAME/lib/* /usr/local/lib
-    rm -rf $CUDNN_EXTRACTED_TARBALL_NAME
+    sudo cp -r "$CUDNN_EXTRACTED_TARBALL_NAME/include/*" "/usr/local/include"
+    sudo cp -r "$CUDNN_EXTRACTED_TARBALL_NAME/lib/*" "/usr/local/lib"
+    rm -rf "$CUDNN_EXTRACTED_TARBALL_NAME"
 else
     sudo tar -xzf $CUDNN_TARBALL_NAME -C /usr/local
 fi


### PR DESCRIPTION
**Description of changes:**

Fix Shellcheck by adding double quotes 

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [x] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules? **n/a**
