### PR TITLE
[MOE] Measure operator costs

### DIFF
--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -409,10 +409,11 @@ bool Aggregate::measure_operator_cost(Simulator *sim,
                                       MachineView const &mv,
                                       CostMetrics &cost_metrics) const {
   assert(numInputs <= MAX_NUM_INPUTS);
-  ParallelTensorBase sub_inputs[MAX_NUM_INPUTS], sub_pred, sub_assign, sub_output;
-  
-  for (int i=0; i<numInputs; ++i) {
-    if (!inputs[i+4]->get_sub_tensor(mv, sub_inputs[i])) {
+  ParallelTensorBase sub_inputs[MAX_NUM_INPUTS], sub_pred, sub_assign,
+      sub_output;
+
+  for (int i = 0; i < numInputs; ++i) {
+    if (!inputs[i + 4]->get_sub_tensor(mv, sub_inputs[i])) {
       return false;
     }
   }
@@ -422,7 +423,7 @@ bool Aggregate::measure_operator_cost(Simulator *sim,
   if (!inputs[1]->get_sub_tensor(mv, sub_assign)) {
     return false;
   }
-  
+
   if (!outputs[0]->get_sub_tensor(mv, sub_output)) {
     return false;
   }
@@ -433,7 +434,7 @@ bool Aggregate::measure_operator_cost(Simulator *sim,
   sim->free_all();
   float *input_ptrs[MAX_NUM_INPUTS];
   bool out_of_memory = false;
-  for (int i=0; i<numInputs; ++i) {
+  for (int i = 0; i < numInputs; ++i) {
     input_ptrs[i] =
         (float *)sim->allocate(sub_inputs[i].get_volume(), DT_FLOAT);
     out_of_memory = out_of_memory || (input_ptrs[i] == NULL);
@@ -462,7 +463,7 @@ bool Aggregate::measure_operator_cost(Simulator *sim,
   int batch_size = inputs[0]->dims[1].size;
   int rows = inputs[4]->dims[0].size;
   int out_dim = outputs[0]->dims[0].size;
-  
+
   forward = [&] {
     forward_kernel_wrapper(m,
                            input_ptrs,
@@ -473,15 +474,13 @@ bool Aggregate::measure_operator_cost(Simulator *sim,
                            k,
                            rows,
                            batch_size,
-                           out_dim
-                           );
+                           out_dim);
   };
 
   inner_measure_operator_cost(sim, forward, backward, cost_metrics);
-  log_measure.debug(
-    "[Measure Aggregate] name(%s) forward_time(%.4lf)\n",
-    name,
-    cost_metrics.forward_time);
+  log_measure.debug("[Measure Aggregate] name(%s) forward_time(%.4lf)\n",
+                    name,
+                    cost_metrics.forward_time);
 
   cost_metrics.backward_time = 0.0f; // not implemented for backward
   delete m;

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -409,31 +409,41 @@ bool Aggregate::measure_operator_cost(Simulator *sim,
                                       MachineView const &mv,
                                       CostMetrics &cost_metrics) const {
   assert(numInputs <= MAX_NUM_INPUTS);
-  ParallelTensorBase sub_inputs[MAX_NUM_INPUTS], sub_output;
+  ParallelTensorBase sub_inputs[MAX_NUM_INPUTS], sub_pred, sub_assign, sub_output;
+  
+  for (int i=0; i<numInputs; ++i) {
+    if (!inputs[i+4]->get_sub_tensor(mv, sub_inputs[i])) {
+      return false;
+    }
+  }
+  if (!inputs[0]->get_sub_tensor(mv, sub_pred)) {
+    return false;
+  }
+  if (!inputs[1]->get_sub_tensor(mv, sub_assign)) {
+    return false;
+  }
+  
   if (!outputs[0]->get_sub_tensor(mv, sub_output)) {
     return false;
   }
 
-  for (int i=0; i<numInputs, ++i) {
-    if (!inputs[i]->get_sub_tensor(mv, sub_inputs[i])) {
-      return false;
-    }
-  }
-
   AggregateMeta *m = new AggregateMeta(sim->handler, n);
 
-  // inputs memory
+  // allocate
   sim->free_all();
   float *input_ptrs[MAX_NUM_INPUTS];
   bool out_of_memory = false;
-  for (int i = 0; i < numInputs; i++) {
+  for (int i=0; i<numInputs; ++i) {
     input_ptrs[i] =
         (float *)sim->allocate(sub_inputs[i].get_volume(), DT_FLOAT);
     out_of_memory = out_of_memory || (input_ptrs[i] == NULL);
   }
+  int *assign_ptr = (int *)sim->allocate(sub_assign.get_volume(), DT_INT32);
+  out_of_memory = out_of_memory || (assign_ptr == NULL);
+  float *pred_ptr = (float *)sim->allocate(sub_pred.get_volume(), DT_FLOAT);
+  out_of_memory = out_of_memory || (pred_ptr == NULL);
   cost_metrics.inputs_memory += cost_metrics.total_mem_diff_from(sim->offset);
 
-  // outputs memory
   float *output_ptr = (float *)sim->allocate(sub_output.get_volume(), DT_FLOAT);
   cost_metrics.outputs_memory += cost_metrics.total_mem_diff_from(sim->offset);
   out_of_memory = out_of_memory || (output_ptr == NULL);
@@ -443,38 +453,37 @@ bool Aggregate::measure_operator_cost(Simulator *sim,
     cost_metrics.backward_time = Simulator::MAXIMUM_TASK_RUN_TIME;
     return true;
   }
+
   assert(m->profiling == false);
 
-  // time
+  // compute
   std::function<void()> forward, backward;
-  // forward
-
-  /*forward = [&] {
-    forward_kernel_wrapper(m,);
-  };*/
-  if (sim->computationMode == COMP_MODE_TRAINING) {
-    // backward
-
-
-    /*backward = [&] {
-      backward_kernel_wrapper(m,);
-    };*/
-  }
+  int k = inputs[0]->dims[0].size;
+  int batch_size = inputs[0]->dims[1].size;
+  int rows = inputs[4]->dims[0].size;
+  int out_dim = outputs[0]->dims[0].size;
+  
+  forward = [&] {
+    forward_kernel_wrapper(m,
+                           input_ptrs,
+                           assign_ptr,
+                           pred_ptr,
+                           output_ptr,
+                           n,
+                           k,
+                           rows,
+                           batch_size,
+                           out_dim
+                           );
+  };
 
   inner_measure_operator_cost(sim, forward, backward, cost_metrics);
-  if (sim->computationMode == COMP_MODE_TRAINING) {
-    log_measure.debug(
-      "[Measure Aggregate] name(%s) forward_time(%.4lf) backward_time(%.4lf)\n",
-      name,
-      cost_metrics.forward_time,
-      cost_metrics.backward_time);
-  } else {
-    log_measure.debug(
-      "[Measure Aggregate] name(%s) forward_time(%.4lf)\n",
-      name,
-      cost_metrics.forward_time);
-  }
+  log_measure.debug(
+    "[Measure Aggregate] name(%s) forward_time(%.4lf)\n",
+    name,
+    cost_metrics.forward_time);
 
+  cost_metrics.backward_time = 0.0f; // not implemented for backward
   delete m;
   return true;
 }

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -459,10 +459,13 @@ bool Aggregate::measure_operator_cost(Simulator *sim,
 
   // compute
   std::function<void()> forward, backward;
-  int k = inputs[0]->dims[0].size;
-  int batch_size = inputs[0]->dims[1].size;
-  int rows = inputs[4]->dims[0].size;
-  int out_dim = outputs[0]->dims[0].size;
+  Domain assign_domain = sub_assign.get_domain();
+  Domain exp_domain = sub_inputs[0].get_domain();
+
+  int k = assign_domain.hi()[0] - assign_domain.lo()[0] + 1;
+  int batch_size = assign_domain.hi()[1] - assign_domain.lo()[1] + 1;
+  int rows = exp_domain.hi()[1] - exp_domain.lo()[1] + 1;
+  int out_dim = exp_domain.hi()[0] - exp_domain.lo()[0] + 1;
 
   forward = [&] {
     forward_kernel_wrapper(m,

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -408,13 +408,75 @@ void Aggregate::backward_task(Task const *task,
 bool Aggregate::measure_operator_cost(Simulator *sim,
                                       MachineView const &mv,
                                       CostMetrics &cost_metrics) const {
-  // TODO: implement
-  cost_metrics.forward_time = 0.0f;
-  cost_metrics.backward_time = 0.0f;
-  cost_metrics.inputs_memory = 0;
-  cost_metrics.outputs_memory = 0;
-  cost_metrics.weights_memory = 0;
-  return false;
+  assert(numInputs <= MAX_NUM_INPUTS);
+  ParallelTensorBase sub_inputs[MAX_NUM_INPUTS], sub_output;
+  if (!outputs[0]->get_sub_tensor(mv, sub_output)) {
+    return false;
+  }
+
+  for (int i=0; i<numInputs, ++i) {
+    if (!inputs[i]->get_sub_tensor(mv, sub_inputs[i])) {
+      return false;
+    }
+  }
+
+  AggregateMeta *m = new AggregateMeta(sim->handler, n);
+
+  // inputs memory
+  sim->free_all();
+  float *input_ptrs[MAX_NUM_INPUTS];
+  bool out_of_memory = false;
+  for (int i = 0; i < numInputs; i++) {
+    input_ptrs[i] =
+        (float *)sim->allocate(sub_inputs[i].get_volume(), DT_FLOAT);
+    out_of_memory = out_of_memory || (input_ptrs[i] == NULL);
+  }
+  cost_metrics.inputs_memory += cost_metrics.total_mem_diff_from(sim->offset);
+
+  // outputs memory
+  float *output_ptr = (float *)sim->allocate(sub_output.get_volume(), DT_FLOAT);
+  cost_metrics.outputs_memory += cost_metrics.total_mem_diff_from(sim->offset);
+  out_of_memory = out_of_memory || (output_ptr == NULL);
+
+  if (out_of_memory) {
+    cost_metrics.forward_time = Simulator::MAXIMUM_TASK_RUN_TIME;
+    cost_metrics.backward_time = Simulator::MAXIMUM_TASK_RUN_TIME;
+    return true;
+  }
+  assert(m->profiling == false);
+
+  // time
+  std::function<void()> forward, backward;
+  // forward
+
+  /*forward = [&] {
+    forward_kernel_wrapper(m,);
+  };*/
+  if (sim->computationMode == COMP_MODE_TRAINING) {
+    // backward
+
+
+    /*backward = [&] {
+      backward_kernel_wrapper(m,);
+    };*/
+  }
+
+  inner_measure_operator_cost(sim, forward, backward, cost_metrics);
+  if (sim->computationMode == COMP_MODE_TRAINING) {
+    log_measure.debug(
+      "[Measure Aggregate] name(%s) forward_time(%.4lf) backward_time(%.4lf)\n",
+      name,
+      cost_metrics.forward_time,
+      cost_metrics.backward_time);
+  } else {
+    log_measure.debug(
+      "[Measure Aggregate] name(%s) forward_time(%.4lf)\n",
+      name,
+      cost_metrics.forward_time);
+  }
+
+  delete m;
+  return true;
 }
 
 }; // namespace FlexFlow

--- a/src/ops/aggregate_spec.cc
+++ b/src/ops/aggregate_spec.cc
@@ -402,7 +402,7 @@ bool AggregateSpec::measure_operator_cost(Simulator *sim,
 
   AggregateSpecMeta *m = new AggregateSpecMeta(sim->handler, n);
 
-  // allocate memory
+  // allocate
   sim->free_all();
   float *input_ptrs[MAX_NUM_INPUTS];
   bool out_of_memory = false;
@@ -427,10 +427,8 @@ bool AggregateSpec::measure_operator_cost(Simulator *sim,
 
   assert(m->profiling == false);
 
-  // time
+  // compute
   std::function<void()> forward, backward;
-
-  // forward
   coord_t k = inputs[0]->dims[0].size;
   coord_t batch_size = inputs[0]->dims[1].size;
   coord_t rows = inputs[4]->dims[0].size;

--- a/src/ops/aggregate_spec.cc
+++ b/src/ops/aggregate_spec.cc
@@ -429,10 +429,13 @@ bool AggregateSpec::measure_operator_cost(Simulator *sim,
 
   // compute
   std::function<void()> forward, backward;
-  coord_t k = inputs[0]->dims[0].size;
-  coord_t batch_size = inputs[0]->dims[1].size;
-  coord_t rows = inputs[4]->dims[0].size;
-  coord_t out_dim = outputs[0]->dims[0].size;
+  Domain assign_domain = sub_assign.get_domain();
+  Domain exp_domain = sub_inputs[0].get_domain();
+  
+  int k = assign_domain.hi()[0] - assign_domain.lo()[0] + 1;
+  int batch_size = assign_domain.hi()[1] - assign_domain.lo()[1] + 1;
+  int rows = exp_domain.hi()[1] - exp_domain.lo()[1] + 1;
+  int out_dim = exp_domain.hi()[0] - exp_domain.lo()[0] + 1;
 
   forward = [&] {
     forward_kernel_wrapper(

--- a/src/ops/aggregate_spec.cc
+++ b/src/ops/aggregate_spec.cc
@@ -386,30 +386,35 @@ bool AggregateSpec::measure_operator_cost(Simulator *sim,
                                           MachineView const &mv,
                                           CostMetrics &cost_metrics) const {
   assert(numInputs <= MAX_NUM_INPUTS);
-  ParallelTensorBase sub_inputs[MAX_NUM_INPUTS], sub_output;
+  ParallelTensorBase sub_inputs[MAX_NUM_INPUTS], sub_assign, sub_output;
+  for (int i=0; i<numInputs; ++i) {
+    if (!inputs[i+4]->get_sub_tensor(mv, sub_inputs[i])) {
+      return false;
+    }
+  }
+  if (!inputs[1]->get_sub_tensor(mv, sub_assign)) {
+    return false;
+  }
+  
   if (!outputs[0]->get_sub_tensor(mv, sub_output)) {
     return false;
   }
 
-  for (int i=0; i<numInputs, ++i) {
-    if (!inputs[i]->get_sub_tensor(mv, sub_inputs[i])) {
-      return false;
-    }
-  }
   AggregateSpecMeta *m = new AggregateSpecMeta(sim->handler, n);
 
-  // inputs memory
+  // allocate memory
   sim->free_all();
   float *input_ptrs[MAX_NUM_INPUTS];
   bool out_of_memory = false;
-  for (int i = 0; i < numInputs; i++) {
+  for (int i=0; i<numInputs; ++i) {
     input_ptrs[i] =
         (float *)sim->allocate(sub_inputs[i].get_volume(), DT_FLOAT);
     out_of_memory = out_of_memory || (input_ptrs[i] == NULL);
   }
+  int *assign_ptr = (int *)sim->allocate(sub_assign.get_volume(), DT_INT32);
+  out_of_memory = out_of_memory || (assign_ptr == NULL);
   cost_metrics.inputs_memory += cost_metrics.total_mem_diff_from(sim->offset);
 
-  // outputs memory
   float *output_ptr = (float *)sim->allocate(sub_output.get_volume(), DT_FLOAT);
   cost_metrics.outputs_memory += cost_metrics.total_mem_diff_from(sim->offset);
   out_of_memory = out_of_memory || (output_ptr == NULL);
@@ -424,34 +429,33 @@ bool AggregateSpec::measure_operator_cost(Simulator *sim,
 
   // time
   std::function<void()> forward, backward;
+
   // forward
-
-  /*forward = [&] {
-    forward_kernel_wrapper(m,);
-  };*/
-  if (sim->computationMode == COMP_MODE_TRAINING) {
-    // backward
-
-
-    /*backward = [&] {
-      backward_kernel_wrapper(m,);
-    };*/
-  }
+  coord_t k = inputs[0]->dims[0].size;
+  coord_t batch_size = inputs[0]->dims[1].size;
+  coord_t rows = inputs[4]->dims[0].size;
+  coord_t out_dim = outputs[0]->dims[0].size;
+  
+  forward = [&] {
+    forward_kernel_wrapper(m,
+                           input_ptrs,
+                           assign_ptr,
+                           output_ptr,
+                           n,
+                           k,
+                           rows,
+                           batch_size,
+                           out_dim
+                           );
+  };
 
   inner_measure_operator_cost(sim, forward, backward, cost_metrics);
-  if (sim->computationMode == COMP_MODE_TRAINING) {
-    log_measure.debug(
-      "[Measure Agg Spec] name(%s) forward_time(%.4lf) backward_time(%.4lf)\n",
-      name,
-      cost_metrics.forward_time,
-      cost_metrics.backward_time);
-  } else {
-    log_measure.debug(
-      "[Measure Agg Spec] name(%s) forward_time(%.4lf)\n",
-      name,
-      cost_metrics.forward_time);
-  }
+  log_measure.debug(
+    "[Measure Agg Spec] name(%s) forward_time(%.4lf)\n",
+    name,
+    cost_metrics.forward_time);
 
+  cost_metrics.backward_time = 0.0f; // not implemented for backward
   delete m;
   return true;
 }

--- a/src/ops/aggregate_spec.cc
+++ b/src/ops/aggregate_spec.cc
@@ -387,15 +387,15 @@ bool AggregateSpec::measure_operator_cost(Simulator *sim,
                                           CostMetrics &cost_metrics) const {
   assert(numInputs <= MAX_NUM_INPUTS);
   ParallelTensorBase sub_inputs[MAX_NUM_INPUTS], sub_assign, sub_output;
-  for (int i=0; i<numInputs; ++i) {
-    if (!inputs[i+4]->get_sub_tensor(mv, sub_inputs[i])) {
+  for (int i = 0; i < numInputs; ++i) {
+    if (!inputs[i + 4]->get_sub_tensor(mv, sub_inputs[i])) {
       return false;
     }
   }
   if (!inputs[1]->get_sub_tensor(mv, sub_assign)) {
     return false;
   }
-  
+
   if (!outputs[0]->get_sub_tensor(mv, sub_output)) {
     return false;
   }
@@ -406,7 +406,7 @@ bool AggregateSpec::measure_operator_cost(Simulator *sim,
   sim->free_all();
   float *input_ptrs[MAX_NUM_INPUTS];
   bool out_of_memory = false;
-  for (int i=0; i<numInputs; ++i) {
+  for (int i = 0; i < numInputs; ++i) {
     input_ptrs[i] =
         (float *)sim->allocate(sub_inputs[i].get_volume(), DT_FLOAT);
     out_of_memory = out_of_memory || (input_ptrs[i] == NULL);
@@ -433,25 +433,16 @@ bool AggregateSpec::measure_operator_cost(Simulator *sim,
   coord_t batch_size = inputs[0]->dims[1].size;
   coord_t rows = inputs[4]->dims[0].size;
   coord_t out_dim = outputs[0]->dims[0].size;
-  
+
   forward = [&] {
-    forward_kernel_wrapper(m,
-                           input_ptrs,
-                           assign_ptr,
-                           output_ptr,
-                           n,
-                           k,
-                           rows,
-                           batch_size,
-                           out_dim
-                           );
+    forward_kernel_wrapper(
+        m, input_ptrs, assign_ptr, output_ptr, n, k, rows, batch_size, out_dim);
   };
 
   inner_measure_operator_cost(sim, forward, backward, cost_metrics);
-  log_measure.debug(
-    "[Measure Agg Spec] name(%s) forward_time(%.4lf)\n",
-    name,
-    cost_metrics.forward_time);
+  log_measure.debug("[Measure Agg Spec] name(%s) forward_time(%.4lf)\n",
+                    name,
+                    cost_metrics.forward_time);
 
   cost_metrics.backward_time = 0.0f; // not implemented for backward
   delete m;

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -342,7 +342,7 @@ bool Group_by::measure_operator_cost(Simulator *sim,
   if (!inputs[0]->get_sub_tensor(mv, sub_assign)) {
     return false;
   }
-  for (int i=0; i<numOutputs, ++i) {
+  for (int i = 0; i < numOutputs; ++i) {
     if (!outputs[i]->get_sub_tensor(mv, sub_outputs[i])) {
       return false;
     }
@@ -393,10 +393,9 @@ bool Group_by::measure_operator_cost(Simulator *sim,
   };
 
   inner_measure_operator_cost(sim, forward, backward, cost_metrics);
-  log_measure.debug(
-    "[Measure GroupBy] name(%s) forward_time(%.4lf)\n",
-    name,
-    cost_metrics.forward_time);
+  log_measure.debug("[Measure GroupBy] name(%s) forward_time(%.4lf)\n",
+                    name,
+                    cost_metrics.forward_time);
 
   cost_metrics.backward_time = 0.0f; // not implemented for MOE
   delete m;

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -376,9 +376,10 @@ bool Group_by::measure_operator_cost(Simulator *sim,
   // compute
   std::function<void()> forward, backward;
 
+  Domain in_domain = sub_input.get_domain();
   int k = sub_assign.dims[0].size;
-  int batch_size = inputs[0]->dims[1].size;
-  int data_dim = inputs[0]->dims[0].size;
+  int batch_size = in_domain.hi()[1] - in_domain.lo()[1] + 1;
+  int data_dim = in_domain.hi()[0] - in_domain.lo()[0] + 1;
 
   forward = [&] {
     forward_kernel_wrapper(m,

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -398,7 +398,7 @@ bool Group_by::measure_operator_cost(Simulator *sim,
     name,
     cost_metrics.forward_time);
 
-  cost_metrics.backward_time = 0.0f; // not implemented for backward
+  cost_metrics.backward_time = 0.0f; // not implemented for MOE
   delete m;
   return true;
 }

--- a/src/ops/topk.cc
+++ b/src/ops/topk.cc
@@ -311,8 +311,9 @@ bool TopK::measure_operator_cost(Simulator *sim,
   // compute
   std::function<void()> forward, backward;
 
-  int length = inputs[0]->dims[1].size;
-  size_t batch_size = sub_input.get_volume() / length;
+  Domain in_domain = sub_input.get_domain();
+  int length = in_domain.hi()[0] - in_domain.lo()[0] + 1;
+  size_t batch_size = in_domain.get_volume() / length;
 
   forward = [&] {
     forward_kernel_wrapper(m,

--- a/src/ops/topk.cc
+++ b/src/ops/topk.cc
@@ -296,7 +296,8 @@ bool TopK::measure_operator_cost(Simulator *sim,
   cost_metrics.inputs_memory += cost_metrics.total_mem_diff_from(sim->offset);
 
   float *output_ptr = (float *)sim->allocate(sub_output.get_volume(), DT_FLOAT);
-  int *output_ind_ptr = (int *)sim->allocate(sub_output_ind.get_volume(), DT_INT32);
+  int *output_ind_ptr =
+      (int *)sim->allocate(sub_output_ind.get_volume(), DT_INT32);
   cost_metrics.outputs_memory += cost_metrics.total_mem_diff_from(sim->offset);
 
   if (!(input_ptr && output_ptr && output_ind_ptr)) {
@@ -325,15 +326,13 @@ bool TopK::measure_operator_cost(Simulator *sim,
   };
 
   inner_measure_operator_cost(sim, forward, backward, cost_metrics);
-  log_measure.debug(
-    "[Measure TopK] name(%s) forward_time(%.4lf)\n",
-    name,
-    cost_metrics.forward_time);
+  log_measure.debug("[Measure TopK] name(%s) forward_time(%.4lf)\n",
+                    name,
+                    cost_metrics.forward_time);
 
   cost_metrics.backward_time = 0.0f; // not implemented for MOE
   delete m;
   return true;
-
 }
 
 }; // namespace FlexFlow


### PR DESCRIPTION
**Description of changes:**

Implement measure operator costs for MOE operators (`aggregate`, `aggregate_spec`, `group_by`, `topk`). The only cost metric not included is `cost_metrics.backward_time`. 

Question: does each operator have the correct computation for `batch_size`, `k`, `length` and other fields?

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules? **n/a**
