### PR TITLE
[Docs] - Fix error in instructions on how to use Python interface

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,10 +77,10 @@ export FF_HOME=/path/to/FlexFlow
 ### Run FlexFlow Python examples
 The Python examples are in the [examples/python](https://github.com/flexflow/FlexFlow/tree/master/examples/python). The native, Keras integration and PyTorch integration examples are listed in `native`, `keras` and `pytorch` respectively.
 
-To run the Python examples, you have two options: you can use the `flexflow_python` interpreter, available in the `python` folder, or you can use the native Python interpreter. If you choose to use the native Python interpreter, you will need to set the following flag: `export FF_USE_NATIVE_PYTHON=1`. In case you wish to run the Python examples without installing FlexFlow, you will also need to set the PYTHONPATH as follows:
+To run the Python examples, you have two options: you can use the `flexflow_python` interpreter, available in the `python` folder, or you can use the native Python interpreter. If you choose to use the native Python interpreter, you should either install FlexFlow, or, if you prefer to build without installing, export the following flags:
 
-1. `export PYTHONPATH="${FF_HOME}/python"` (if using `flexflow_python` only)
-2. `export PYTHONPATH="${FF_HOME}/python:${FF_HOME}/build/python"` (if using the native Python interpreter or `flexflow_python`)
+* `export PYTHONPATH="${FF_HOME}/python:${FF_HOME}/build/python"`
+* `export FF_USE_NATIVE_PYTHON=1`
 
 **We recommend that you run the `mnist_mlp` test under `native` using the following cmd to check if FlexFlow has been installed correctly:**
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,15 +31,15 @@ If you are planning to build the Python interface, you will need to install seve
 ## 4. Configuring the FlexFlow build
 You can configure a FlexFlow build by running the `config/config.linux` file in the build folder. If you do not want to build with the default options, you can set your configurations by passing (or exporting) the relevant environment variables. We recommend that you spend some time familiarizing with the available options by scanning the `config/config.linux` file. In particular, the main parameters are:
 
-* `CUDA_DIR` is used to specify the directory of CUDA. It is only required when CMake can not automatically detect the installation directory of CUDA.
-* `CUDNN_DIR` is used to specify the directory of CUDNN. It is only required when CUDNN is not installed in the CUDA directory.
-* `FF_CUDA_ARCH` is used to set the architecture of targeted GPUs, for example, the value can be 60 if the GPU architecture is Pascal. To build for more than one architecture, pass a list of comma separated values (e.g. `FF_CUDA_ARCH=70,75`). To compile FlexFlow for all GPU architectures that are detected on the machine, pass `FF_CUDA_ARCH=autodetect` (this is the default value, so you can also leave `FF_CUDA_ARCH` unset. If you want to build for all GPU architectures compatible with FlexFlow, pass `FF_CUDA_ARCH=all`. **If your machine does not have any GPU, you have to set FF_CUDA_ARCH to at least one valid architecture code (or `all`)**, since the compiler won't be able to detect the architecture(s) automatically.
-* `FF_USE_PYTHON` controls whether to build the FlexFlow Python interface.
-* `FF_USE_NCCL` controls whether to build FlexFlow with NCCL support. By default, it is set to ON.
-* `FF_USE_GASNET` is used to enable distributed run of FlexFlow. You can then set the preferred GASNET conduit with `FF_USE_GASNET`. For instance, to run FlexFlow on multiple nodes using MPI, set `FF_USE_GASNET=ON` and `FF_GASNET_CONDUIT=mpi`
-* `FF_BUILD_EXAMPLES` controls whether to build all C++ example programs.
-* `FF_MAX_DIM` is used to set the maximum dimension of tensors, by default it is set to 4. 
-* `FF_USE_{NCCL,LEGION,ALL}_PRECOMPILED_LIBRARY`, controls whether to build FlexFlow using a pre-compiled version of the Legion, NCCL (if `FF_USE_NCCL` is `ON`), or both libraries . By default, `FF_USE_NCCL_PRECOMPILED_LIBRARY` and `FF_USE_LEGION_PRECOMPILED_LIBRARY` are both set to `ON`, allowing you to build FlexFlow faster. If you want to build Legion and NCCL from source, set them to `OFF`.
+1. `CUDA_DIR` is used to specify the directory of CUDA. It is only required when CMake can not automatically detect the installation directory of CUDA.
+2. `CUDNN_DIR` is used to specify the directory of CUDNN. It is only required when CUDNN is not installed in the CUDA directory.
+3. `FF_CUDA_ARCH` is used to set the architecture of targeted GPUs, for example, the value can be 60 if the GPU architecture is Pascal. To build for more than one architecture, pass a list of comma separated values (e.g. `FF_CUDA_ARCH=70,75`). To compile FlexFlow for all GPU architectures that are detected on the machine, pass `FF_CUDA_ARCH=autodetect` (this is the default value, so you can also leave `FF_CUDA_ARCH` unset. If you want to build for all GPU architectures compatible with FlexFlow, pass `FF_CUDA_ARCH=all`. **If your machine does not have any GPU, you have to set FF_CUDA_ARCH to at least one valid architecture code (or `all`)**, since the compiler won't be able to detect the architecture(s) automatically.
+4. `FF_USE_PYTHON` controls whether to build the FlexFlow Python interface.
+5. `FF_USE_NCCL` controls whether to build FlexFlow with NCCL support. By default, it is set to ON.
+6. `FF_USE_GASNET` is used to enable distributed run of FlexFlow. You can then set the preferred GASNET conduit with `FF_USE_GASNET`. For instance, to run FlexFlow on multiple nodes using MPI, set `FF_USE_GASNET=ON` and `FF_GASNET_CONDUIT=mpi`
+7. `FF_BUILD_EXAMPLES` controls whether to build all C++ example programs.
+8. `FF_MAX_DIM` is used to set the maximum dimension of tensors, by default it is set to 4. 
+9. `FF_USE_{NCCL,LEGION,ALL}_PRECOMPILED_LIBRARY`, controls whether to build FlexFlow using a pre-compiled version of the Legion, NCCL (if `FF_USE_NCCL` is `ON`), or both libraries . By default, `FF_USE_NCCL_PRECOMPILED_LIBRARY` and `FF_USE_LEGION_PRECOMPILED_LIBRARY` are both set to `ON`, allowing you to build FlexFlow faster. If you want to build Legion and NCCL from source, set them to `OFF`.
 
 More options are available in cmake, please run `ccmake` and search for options starting with FF. 
 
@@ -77,10 +77,10 @@ export FF_HOME=/path/to/FlexFlow
 ### Run FlexFlow Python examples
 The Python examples are in the [examples/python](https://github.com/flexflow/FlexFlow/tree/master/examples/python). The native, Keras integration and PyTorch integration examples are listed in `native`, `keras` and `pytorch` respectively.
 
-To run the Python examples, you have two options: you can use the `flexflow_python` interpreted, available in the `python` folder, or you can use the native Python interpreter. If you choose to use the native Python interpreter, you should either install FlexFlow, or, if you prefer to build without installing, export the following flags:
+To run the Python examples, you have two options: you can use the `flexflow_python` interpreter, available in the `python` folder, or you can use the native Python interpreter. If you choose to use the native Python interpreter, you will need to set the following flag: `export FF_USE_NATIVE_PYTHON=1`. In case you wish to run the Python examples without installing FlexFlow, you will also need to set the PYTHONPATH as follows:
 
-* `export PYTHONPATH="${FF_HOME}/python"`
-* `export FF_USE_NATIVE_PYTHON=1`
+1. `export PYTHONPATH="${FF_HOME}/python"` (if using `flexflow_python` only)
+2. `export PYTHONPATH="${FF_HOME}/python:${FF_HOME}/build/python"` (if using the native Python interpreter or `flexflow_python`)
 
 **We recommend that you run the `mnist_mlp` test under `native` using the following cmd to check if FlexFlow has been installed correctly:**
 


### PR DESCRIPTION
**Description of changes:**



**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
