### PR TITLE
Dropout kernels

### DIFF
--- a/include/flexflow/ops/dropout.h
+++ b/include/flexflow/ops/dropout.h
@@ -1,17 +1,12 @@
 #ifndef _FLEXFLOW_DROPOUT_H
 #define _FLEXFLOW_DROPOUT_H
 
-#include "flexflow/device.h"
-#include "flexflow/fftype.h"
 #include "flexflow/layer.h"
 #include "flexflow/node.h"
-#include "flexflow/op_meta.h"
 #include "flexflow/operator.h"
 #include "flexflow/ops/dropout_params.h"
 
 namespace FlexFlow {
-
-class DropoutMeta;
 
 class Dropout : public Op {
 public:
@@ -50,20 +45,6 @@ public:
                             std::vector<Legion::PhysicalRegion> const &regions,
                             Legion::Context ctx,
                             Legion::Runtime *runtime);
-  static void forward_kernel(DropoutMeta *m,
-                             float const *input_ptr,
-                             float *output_ptr,
-                             ffStream_t stream);
-  static void forward_kernel_wrapper(DropoutMeta *m,
-                                     float const *input_ptr,
-                                     float *output_ptr);
-  static void backward_kernel(DropoutMeta *m,
-                              float const *output_grad_ptr,
-                              float *input_grad_ptr,
-                              ffStream_t stream);
-  static void backward_kernel_wrapper(DropoutMeta *m,
-                                      float const *output_grad_ptr,
-                                      float *input_grad_ptr);
   bool measure_operator_cost(Simulator *sim,
                              MachineView const &pc,
                              CostMetrics &cost_metrics) const override;
@@ -79,25 +60,6 @@ public:
 public:
   float rate;
   unsigned long long seed;
-};
-
-class DropoutMeta : public OpMeta {
-public:
-  DropoutMeta(FFHandler handle,
-              Dropout const *dropout,
-              Legion::Memory gpu_mem,
-              Legion::Domain const &output_domain);
-  ~DropoutMeta(void);
-  Realm::RegionInstance reserveInst;
-#if defined(FF_USE_CUDA) || defined(FF_USE_HIP_CUDA)
-  cudnnTensorDescriptor_t inputTensor, outputTensor;
-  cudnnDropoutDescriptor_t dropoutDesc;
-#else
-  miopenTensorDescriptor_t inputTensor, outputTensor;
-  miopenDropoutDescriptor_t dropoutDesc;
-#endif
-  void *reserveSpace, *dropoutStates;
-  size_t reserveSpaceSize, dropoutStateSize;
 };
 
 }; // namespace FlexFlow

--- a/include/flexflow/ops/kernels/dropout_kernels.h
+++ b/include/flexflow/ops/kernels/dropout_kernels.h
@@ -4,6 +4,7 @@
 #include "flexflow/device.h"
 #include "flexflow/fftype.h"
 #include "flexflow/op_meta.h"
+#include "flexflow/ops/dropout.h"
 
 namespace FlexFlow {
 

--- a/include/flexflow/ops/kernels/dropout_kernels.h
+++ b/include/flexflow/ops/kernels/dropout_kernels.h
@@ -1,0 +1,52 @@
+#ifndef _FLEXFLOW_OPS_KERNELS_DROPOUT_KERNELS_H
+#define _FLEXFLOW_OPS_KERNELS_DROPOUT_KERNELS_H
+
+#include "flexflow/device.h"
+#include "flexflow/fftype.h"
+#include "flexflow/op_meta.h"
+
+namespace FlexFlow {
+
+class DropoutMeta : public OpMeta {
+public:
+  DropoutMeta(FFHandler handle,
+              Dropout const *dropout,
+              Legion::Memory gpu_mem,
+              Legion::Domain const &output_domain);
+  ~DropoutMeta(void);
+  Realm::RegionInstance reserveInst;
+#if defined(FF_USE_CUDA) || defined(FF_USE_HIP_CUDA)
+  cudnnTensorDescriptor_t inputTensor, outputTensor;
+  cudnnDropoutDescriptor_t dropoutDesc;
+#else
+  miopenTensorDescriptor_t inputTensor, outputTensor;
+  miopenDropoutDescriptor_t dropoutDesc;
+#endif
+  void *reserveSpace, *dropoutStates;
+  size_t reserveSpaceSize, dropoutStateSize;
+};
+
+namespace Kernels {
+namespace Dropout {
+void forward_kernel_wrapper(DropoutMeta *m,
+                            float const *input_ptr,
+                            float *output_ptr);
+void backward_kernel_wrapper(DropoutMeta *m,
+                             float const *output_grad_ptr,
+                             float *input_grad_ptr);
+
+namespace Internal {
+void forward_kernel(DropoutMeta *m,
+                    float const *input_ptr,
+                    float *output_ptr,
+                    ffStream_t stream);
+void backward_kernel(DropoutMeta *m,
+                     float const *output_grad_ptr,
+                     float *input_grad_ptr,
+                     ffStream_t stream);
+} // namespace Internal
+} // namespace Dropout
+} // namespace Kernels
+} // namespace FlexFlow
+
+#endif // _FLEXFLOW_OPS_KERNELS_DROPOUT_KERNELS_H

--- a/src/ops/dropout.cc
+++ b/src/ops/dropout.cc
@@ -1,5 +1,6 @@
 #include "flexflow/ops/dropout.h"
 #include "flexflow/model.h"
+#include "flexflow/ops/kernels/dropout_kernels.h"
 #include "flexflow/utils/hash_utils.h"
 #include "legion/legion_utilities.h"
 
@@ -24,6 +25,8 @@ using Legion::Task;
 using Legion::TaskArgument;
 using Legion::TaskLauncher;
 using PCG::Node;
+
+using namespace FlexFlow::Kernels::Dropout;
 
 Tensor FFModel::dropout(const Tensor input,
                         float rate,

--- a/src/ops/fused.cpp
+++ b/src/ops/fused.cpp
@@ -16,11 +16,11 @@
 #include "flexflow/ops/fused.h"
 #include "flexflow/model.h"
 #include "flexflow/ops/batch_norm.h"
-#include "flexflow/ops/dropout.h"
 #include "flexflow/ops/element_unary.h"
 #include "flexflow/ops/kernels/batch_matmul_kernels.h"
 #include "flexflow/ops/kernels/concat_kernels.h"
 #include "flexflow/ops/kernels/conv_2d_kernels.h"
+#include "flexflow/ops/kernels/dropout_kernels.h"
 #include "flexflow/ops/kernels/element_binary_kernels.h"
 #include "flexflow/ops/kernels/flat_kernels.h"
 #include "flexflow/ops/kernels/linear_kernels.h"
@@ -199,9 +199,10 @@ __host__ void FusedOp::forward_task(Task const *task,
         assert(fused->op_num_inputs[op] == 1);
         assert(fused->op_num_outputs[op] == 1);
         DropoutMeta *m = (DropoutMeta *)metas->meta[op];
-        Dropout::forward_kernel_wrapper(m,
-                                        my_input_accessor[0].get_float_ptr(),
-                                        my_output_accessor[0].get_float_ptr());
+        Kernels::Dropout::forward_kernel_wrapper(
+            m,
+            my_input_accessor[0].get_float_ptr(),
+            my_output_accessor[0].get_float_ptr());
         break;
       }
       case OP_LINEAR: {
@@ -586,7 +587,7 @@ __host__ void FusedOp::backward_task(Task const *task,
         assert(fused->op_num_inputs[op] == 1);
         assert(fused->op_num_outputs[op] == 1);
         DropoutMeta *m = (DropoutMeta *)metas->meta[op];
-        Dropout::backward_kernel_wrapper(
+        Kernels::Dropout::backward_kernel_wrapper(
             m,
             my_output_grad_accessor[0].get_float_ptr(),
             my_input_grad_accessor[0].get_float_ptr());

--- a/src/ops/fused.cu
+++ b/src/ops/fused.cu
@@ -16,18 +16,18 @@
 #include "flexflow/accessor.h"
 #include "flexflow/model.h"
 #include "flexflow/ops/batch_norm.h"
-#include "flexflow/ops/dropout.h"
 #include "flexflow/ops/element_unary.h"
 #include "flexflow/ops/embedding.h"
 #include "flexflow/ops/fused.h"
 #include "flexflow/ops/kernels/batch_matmul_kernels.h"
 #include "flexflow/ops/kernels/concat_kernels.h"
 #include "flexflow/ops/kernels/conv_2d_kernels.h"
+#include "flexflow/ops/kernels/dropout_kernels.h"
 #include "flexflow/ops/kernels/element_binary_kernels.h"
+#include "flexflow/ops/kernels/flat_kernels.h"
 #include "flexflow/ops/kernels/linear_kernels.h"
 #include "flexflow/ops/kernels/pool_2d_kernels.h"
 #include "flexflow/ops/kernels/reshape_kernels.h"
-#include "flexflow/ops/kernels/flat_kernels.h"
 #include "flexflow/ops/kernels/transpose_kernels.h"
 #include "flexflow/utils/cuda_helper.h"
 
@@ -210,9 +210,10 @@ __host__ void FusedOp::forward_task(Task const *task,
         assert(fused->op_num_inputs[op] == 1);
         assert(fused->op_num_outputs[op] == 1);
         DropoutMeta *m = (DropoutMeta *)metas->meta[op];
-        Dropout::forward_kernel_wrapper(m,
-                                        my_input_accessor[0].get_float_ptr(),
-                                        my_output_accessor[0].get_float_ptr());
+        Kernels::Dropout::forward_kernel_wrapper(
+            m,
+            my_input_accessor[0].get_float_ptr(),
+            my_output_accessor[0].get_float_ptr());
         break;
       }
       case OP_LINEAR: {
@@ -732,7 +733,7 @@ __host__ void FusedOp::backward_task(Task const *task,
         assert(fused->op_num_inputs[op] == 1);
         assert(fused->op_num_outputs[op] == 1);
         DropoutMeta *m = (DropoutMeta *)metas->meta[op];
-        Dropout::backward_kernel_wrapper(
+        Kernels::Dropout::backward_kernel_wrapper(
             m,
             my_output_grad_accessor[0].get_float_ptr(),
             my_input_grad_accessor[0].get_float_ptr());

--- a/src/ops/kernels/dropout_kernels.cpp
+++ b/src/ops/kernels/dropout_kernels.cpp
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include "flexflow/ops/dropout.h"
+#include "flexflow/ops/kernels/dropout_kernels.h"
 #include "flexflow/utils/hip_helper.h"
 #include <hip/hip_runtime.h>
 
@@ -23,58 +23,6 @@ namespace FlexFlow {
 using Legion::coord_t;
 using Legion::Domain;
 using Legion::Memory;
-
-void Dropout::forward_kernel(DropoutMeta *m,
-                             float const *input_ptr,
-                             float *output_ptr,
-                             hipStream_t stream) {
-  checkCUDNN(miopenSetStream(m->handle.dnn, stream));
-
-  checkCUDNN(miopenDropoutForward(m->handle.dnn,
-                                  m->dropoutDesc,
-                                  m->inputTensor /* not used */,
-                                  m->inputTensor,
-                                  input_ptr,
-                                  m->outputTensor,
-                                  output_ptr,
-                                  m->reserveSpace,
-                                  m->reserveSpaceSize));
-}
-
-/*static*/
-void Dropout::forward_kernel_wrapper(DropoutMeta *m,
-                                     float const *input_ptr,
-                                     float *output_ptr) {
-  hipStream_t stream;
-  checkCUDA(get_legion_stream(&stream));
-  Dropout::forward_kernel(m, input_ptr, output_ptr, stream);
-}
-
-void Dropout::backward_kernel(DropoutMeta *m,
-                              float const *output_grad_ptr,
-                              float *input_grad_ptr,
-                              hipStream_t stream) {
-  checkCUDNN(miopenSetStream(m->handle.dnn, stream));
-
-  checkCUDNN(miopenDropoutBackward(m->handle.dnn,
-                                   m->dropoutDesc,
-                                   m->inputTensor /* not used */,
-                                   m->outputTensor,
-                                   output_grad_ptr,
-                                   m->inputTensor,
-                                   input_grad_ptr,
-                                   m->reserveSpace,
-                                   m->reserveSpaceSize));
-}
-
-/*static*/
-void Dropout::backward_kernel_wrapper(DropoutMeta *m,
-                                      float const *output_grad_ptr,
-                                      float *input_grad_ptr) {
-  hipStream_t stream;
-  checkCUDA(get_legion_stream(&stream));
-  Dropout::backward_kernel(m, output_grad_ptr, input_grad_ptr, stream);
-}
 
 DropoutMeta::DropoutMeta(FFHandler handler,
                          Dropout const *dropout,
@@ -127,4 +75,62 @@ DropoutMeta::~DropoutMeta(void) {
   checkCUDNN(miopenDestroyDropoutDescriptor(dropoutDesc));
 }
 
-}; // namespace FlexFlow
+namespace Kernels {
+namespace Dropout {
+
+void forward_kernel_wrapper(DropoutMeta *m,
+                            float const *input_ptr,
+                            float *output_ptr) {
+  hipStream_t stream;
+  checkCUDA(get_legion_stream(&stream));
+  Internal::forward_kernel(m, input_ptr, output_ptr, stream);
+}
+
+void backward_kernel_wrapper(DropoutMeta *m,
+                             float const *output_grad_ptr,
+                             float *input_grad_ptr) {
+  hipStream_t stream;
+  checkCUDA(get_legion_stream(&stream));
+  Internal::backward_kernel(m, output_grad_ptr, input_grad_ptr, stream);
+}
+
+namespace Internal {
+
+void forward_kernel(DropoutMeta *m,
+                    float const *input_ptr,
+                    float *output_ptr,
+                    hipStream_t stream) {
+  checkCUDNN(miopenSetStream(m->handle.dnn, stream));
+
+  checkCUDNN(miopenDropoutForward(m->handle.dnn,
+                                  m->dropoutDesc,
+                                  m->inputTensor /* not used */,
+                                  m->inputTensor,
+                                  input_ptr,
+                                  m->outputTensor,
+                                  output_ptr,
+                                  m->reserveSpace,
+                                  m->reserveSpaceSize));
+}
+
+void backward_kernel(DropoutMeta *m,
+                     float const *output_grad_ptr,
+                     float *input_grad_ptr,
+                     hipStream_t stream) {
+  checkCUDNN(miopenSetStream(m->handle.dnn, stream));
+
+  checkCUDNN(miopenDropoutBackward(m->handle.dnn,
+                                   m->dropoutDesc,
+                                   m->inputTensor /* not used */,
+                                   m->outputTensor,
+                                   output_grad_ptr,
+                                   m->inputTensor,
+                                   input_grad_ptr,
+                                   m->reserveSpace,
+                                   m->reserveSpaceSize));
+}
+
+} // namespace Internal
+} // namespace Dropout
+} // namespace Kernels
+} // namespace FlexFlow

--- a/src/ops/kernels/element_binary_kernels.cu
+++ b/src/ops/kernels/element_binary_kernels.cu
@@ -268,21 +268,21 @@ void forward_kernel(ElementBinaryMeta const *m,
     // currently only handle add and sub
     assert(m->op_type == OP_EW_SUB || m->op_type == OP_EW_ADD ||
            m->op_type == OP_EW_MUL);
-    if(m->op_type == OP_EW_SUB || m->op_type == OP_EW_ADD){
+    if (m->op_type == OP_EW_SUB || m->op_type == OP_EW_ADD) {
       // output = (beta*output + alpha1*input1) + beta*output = input1
       checkCUDNN(cudnnOpTensor(m->handle.dnn,
-                              m->opDesc,
-                              &beta,
-                              m->outputTensor,
-                              out_ptr,
-                              &alpha1,
-                              m->input1Tensor,
-                              in1_ptr,
-                              &beta,
-                              m->outputTensor,
-                              out_ptr));
-      // output = (beta*output + alpha2*input2) + alpha1*output = alpha2*input2 
-      // + alpha1*input1 
+                               m->opDesc,
+                               &beta,
+                               m->outputTensor,
+                               out_ptr,
+                               &alpha1,
+                               m->input1Tensor,
+                               in1_ptr,
+                               &beta,
+                               m->outputTensor,
+                               out_ptr));
+      // output = (beta*output + alpha2*input2) + alpha1*output = alpha2*input2
+      // + alpha1*input1
       checkCUDNN(cudnnOpTensor(m->handle.dnn,
                                m->opDesc,
                                &beta,
@@ -294,7 +294,7 @@ void forward_kernel(ElementBinaryMeta const *m,
                                &alpha1,
                                m->outputTensor,
                                out_ptr));
-    } else if(m->op_type == OP_EW_MUL) {
+    } else if (m->op_type == OP_EW_MUL) {
       checkCUDNN(cudnnSetOpTensorDescriptor(m->opDesc,
                                             CUDNN_OP_TENSOR_ADD,
                                             CUDNN_DATA_FLOAT,
@@ -437,16 +437,16 @@ void backward_kernel(ElementBinaryMeta const *m,
             in1_grad_ptr));
       } else {
         checkCUDNN(cudnnOpTensor(m->handle.dnn,
-                                m->opDesc,
-                                &alpha1,
-                                m->outputTensor,
-                                out_grad_ptr,
-                                &alpha2,
-                                m->input2Tensor,
-                                in2_ptr,
-                                &beta,
-                                m->input1Tensor,
-                                in1_grad_ptr));
+                                 m->opDesc,
+                                 &alpha1,
+                                 m->outputTensor,
+                                 out_grad_ptr,
+                                 &alpha2,
+                                 m->input2Tensor,
+                                 in2_ptr,
+                                 &beta,
+                                 m->input1Tensor,
+                                 in1_grad_ptr));
       }
     }
     if (in2_grad_ptr != nullptr) {
@@ -477,16 +477,16 @@ void backward_kernel(ElementBinaryMeta const *m,
             in2_grad_ptr));
       } else {
         checkCUDNN(cudnnOpTensor(m->handle.dnn,
-                                m->opDesc,
-                                &alpha1,
-                                m->outputTensor,
-                                out_grad_ptr,
-                                &alpha2,
-                                m->input1Tensor,
-                                in1_ptr,
-                                &beta,
-                                m->input2Tensor,
-                                in2_grad_ptr));
+                                 m->opDesc,
+                                 &alpha1,
+                                 m->outputTensor,
+                                 out_grad_ptr,
+                                 &alpha2,
+                                 m->input1Tensor,
+                                 in1_ptr,
+                                 &beta,
+                                 m->input2Tensor,
+                                 in2_grad_ptr));
       }
     }
   } else {

--- a/src/ops/kernels/flat_kernels.cu
+++ b/src/ops/kernels/flat_kernels.cu
@@ -35,7 +35,8 @@ void backward_kernel_wrapper(float *input_grad_ptr,
                              size_t num_elements) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
-  Internal::backward_kernel(input_grad_ptr, output_grad_ptr, num_elements, stream);
+  Internal::backward_kernel(
+      input_grad_ptr, output_grad_ptr, num_elements, stream);
   // checkCUDA(cudaMemcpyAsync(acc_input_grad.ptr, acc_output_grad.ptr,
   //                           acc_input_grad.rect.volume() * sizeof(float),
   //                           cudaMemcpyDeviceToDevice));


### PR DESCRIPTION
**Description of changes:**

This PR removes kernel functions from `dropout.h` and refactors `dropout.cu` and `dropout.cpp`. 

**Related Issues:**

Linked Issues:
- Issue #303 

Issues closed by this PR:
- Closes #442 

**Before merging:**

- [x] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules? **n/a**
