### PR TITLE
Device placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,9 +378,9 @@ if(FF_BUILD_MLP_UNIFY OR FF_BUILD_ALL_EXAMPLES)
   add_subdirectory(examples/cpp/MLP_Unify)
 endif()
 
-if(FF_BUILD_MLP_UNIFY OR FF_BUILD_ALL_INFERENCE_EXAMPLES)
-  add_subdirectory(examples/cpp/inference/MLP_Unify)
-endif()
+# if(FF_BUILD_MLP_UNIFY OR FF_BUILD_ALL_INFERENCE_EXAMPLES)
+#   add_subdirectory(examples/cpp/inference/MLP_Unify)
+# endif()
 
 if(FF_BUILD_SPLIT_TEST OR FF_BUILD_ALL_EXAMPLES)
   add_subdirectory(examples/cpp/split_test)

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -109,6 +109,8 @@ void FlexFlow::top_level_task(Task const *task,
 
   MoeConfig moeConfig;
   FFConfig ffConfig;
+  ffConfig.realWorkersPerNode = ffConfig.workersPerNode;
+  ffConfig.workersPerNode = 1;
   ffConfig.batchSize = moeConfig.batch_size;
   {
     InputArgs const &command_args = HighLevelRuntime::get_input_args();
@@ -121,7 +123,6 @@ void FlexFlow::top_level_task(Task const *task,
                   ffConfig.numNodes);
   }
   FFModel ff(ffConfig);
-
   Tensor input;
   {
     int const dims[] = {
@@ -131,8 +132,8 @@ void FlexFlow::top_level_task(Task const *task,
 
   //-----------------------------------------------------------------
 
-  Tensor t = create_moe_encoder(&ff, &moeConfig, input);
-  // Tensor t = create_moe(&ff, &moeConfig, input);
+  // Tensor t = create_moe_encoder(&ff, &moeConfig, input);
+  Tensor t = create_moe(&ff, &moeConfig, input);
   t = ff.dense(t, OUT_DIM, AC_MODE_RELU);
 
   InferenceManager im(&ff, num_requests_per_batch, num_inflight_batches);

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -109,8 +109,6 @@ void FlexFlow::top_level_task(Task const *task,
 
   MoeConfig moeConfig;
   FFConfig ffConfig;
-  ffConfig.realWorkersPerNode = ffConfig.workersPerNode;
-  ffConfig.workersPerNode = 1;
   ffConfig.batchSize = moeConfig.batch_size;
   {
     InputArgs const &command_args = HighLevelRuntime::get_input_args();
@@ -123,6 +121,7 @@ void FlexFlow::top_level_task(Task const *task,
                   ffConfig.numNodes);
   }
   FFModel ff(ffConfig);
+
   Tensor input;
   {
     int const dims[] = {
@@ -132,8 +131,8 @@ void FlexFlow::top_level_task(Task const *task,
 
   //-----------------------------------------------------------------
 
-  // Tensor t = create_moe_encoder(&ff, &moeConfig, input);
-  Tensor t = create_moe(&ff, &moeConfig, input);
+  Tensor t = create_moe_encoder(&ff, &moeConfig, input);
+  // Tensor t = create_moe(&ff, &moeConfig, input);
   t = ff.dense(t, OUT_DIM, AC_MODE_RELU);
 
   InferenceManager im(&ff, num_requests_per_batch, num_inflight_batches);

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -161,19 +161,17 @@ void FlexFlow::top_level_task(Task const *task,
   int index = 0;
   int processed_requests = 0;
   int num_devices = ffConfig.workersPerNode * ffConfig.numNodes;
-  int device_index = 0;
   Generator data_generator(
       total_requests, request_tensor_size, poisson_distribution, lambda);
   int iterations = 2;
 
   for (int iter = 0; iter < iterations; iter++) {
     // data_loader.next_batch(ff);
-    runtime->begin_trace(ctx, 111 + index % num_inflight_batches /*trace_id*/);
+    runtime->begin_trace(ctx, 111 + index % num_devices /*trace_id*/);
     printf("Calling inference now!\n");
-    im.inference(index % num_inflight_batches, device_index % num_devices);
-    runtime->end_trace(ctx, 111 + index % num_inflight_batches /*trace_id*/);
+    im.inference(index);
+    runtime->end_trace(ctx, 111 + index % num_devices /*trace_id*/);
     index++;
-    device_index++;
   }
 
   // data_loader.reset();

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -168,11 +168,12 @@ void FlexFlow::top_level_task(Task const *task,
 
   for (int iter = 0; iter < iterations; iter++) {
     // data_loader.next_batch(ff);
-    runtime->begin_trace(ctx, 111 /*trace_id*/);
+    runtime->begin_trace(ctx, 111 + index % num_inflight_batches /*trace_id*/);
     printf("Calling inference now!\n");
-    im.inference((index++) % num_inflight_batches,
-                 (device_index++) % num_devices);
-    runtime->end_trace(ctx, 111 /*trace_id*/);
+    im.inference(index % num_inflight_batches, device_index % num_devices);
+    runtime->end_trace(ctx, 111 + index % num_inflight_batches /*trace_id*/);
+    index++;
+    device_index++;
   }
 
   // data_loader.reset();

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -98,7 +98,7 @@ void FlexFlow::top_level_task(Task const *task,
                               Runtime *runtime) {
   // Inference parameters
   int total_requests =
-      256; // total number of requests processed as part of the simulation
+      5; // total number of requests processed as part of the simulation
   int request_tensor_size = 4; // request tensor dimensions
   bool poisson_distribution = true;
   double lambda = 25; // average number of request arrivals per second
@@ -164,18 +164,30 @@ void FlexFlow::top_level_task(Task const *task,
   int device_index = 0;
   Generator data_generator(
       total_requests, request_tensor_size, poisson_distribution, lambda);
-  // data_loader.reset();
-  while (processed_requests < total_requests) {
-    vector<vector<double>> req = data_generator.get_requests();
-    int iterations = req.size();
-    for (int iter = 0; iter < iterations; iter++) {
-      // data_loader.next_batch(ff);
-      runtime->begin_trace(ctx, 111 /*trace_id*/);
-      im.inference((index++) % num_inflight_batches, (device_index++) % num_devices);
-      runtime->end_trace(ctx, 111 /*trace_id*/);
-    }
-    processed_requests += iterations;
+  int iterations = 2;
+
+  for (int iter = 0; iter < iterations; iter++) {
+    // data_loader.next_batch(ff);
+    runtime->begin_trace(ctx, 111 /*trace_id*/);
+    printf("Calling inference now!\n");
+    im.inference((index++) % num_inflight_batches,
+                 (device_index++) % num_devices);
+    runtime->end_trace(ctx, 111 /*trace_id*/);
   }
+
+  // data_loader.reset();
+  // while (processed_requests < total_requests) {
+  //   vector<vector<double>> req = data_generator.get_requests();
+  //   int iterations = req.size() / num_requests_per_batch;
+  //   for (int iter = 0; iter < iterations; iter++) {
+  //     // data_loader.next_batch(ff);
+  //     runtime->begin_trace(ctx, 111 /*trace_id*/);
+  //     printf("Calling inference now!\n");
+  //     im.inference((index++) % num_inflight_batches, (device_index++) %
+  //     num_devices); runtime->end_trace(ctx, 111 /*trace_id*/);
+  //   }
+  //   processed_requests += iterations;
+  // }
 
   ///////////////////////////////////////////////////////////////////////////////////
 

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -160,6 +160,8 @@ void FlexFlow::top_level_task(Task const *task,
 
   int index = 0;
   int processed_requests = 0;
+  int num_devices = ffConfig.workersPerNode * ffConfig.numNodes;
+  int device_index = 0;
   Generator data_generator(
       total_requests, request_tensor_size, poisson_distribution, lambda);
   // data_loader.reset();
@@ -169,7 +171,7 @@ void FlexFlow::top_level_task(Task const *task,
     for (int iter = 0; iter < iterations; iter++) {
       // data_loader.next_batch(ff);
       runtime->begin_trace(ctx, 111 /*trace_id*/);
-      im.inference((index++) % num_inflight_batches);
+      im.inference((index++) % num_inflight_batches, (device_index++) % num_devices);
       runtime->end_trace(ctx, 111 /*trace_id*/);
     }
     processed_requests += iterations;

--- a/include/flexflow/config.h
+++ b/include/flexflow/config.h
@@ -116,7 +116,7 @@ public:
 public:
   int epochs, batchSize, printFreq;
   // int inputHeight, inputWidth;
-  int numNodes, cpusPerNode, workersPerNode, realWorkersPerNode;
+  int numNodes, cpusPerNode, workersPerNode;
   float learningRate, weightDecay;
   size_t workSpaceSize;
   Legion::Context lg_ctx;

--- a/include/flexflow/config.h
+++ b/include/flexflow/config.h
@@ -116,7 +116,7 @@ public:
 public:
   int epochs, batchSize, printFreq;
   // int inputHeight, inputWidth;
-  int numNodes, cpusPerNode, workersPerNode;
+  int numNodes, cpusPerNode, workersPerNode, realWorkersPerNode;
   float learningRate, weightDecay;
   size_t workSpaceSize;
   Legion::Context lg_ctx;

--- a/include/flexflow/inference.h
+++ b/include/flexflow/inference.h
@@ -28,7 +28,7 @@ public:
                    int max_num_inflight_batches);
   void compile_model_and_allocate_buffer(void);
   void init_operators_inference();
-  void inference(int index);
+  void inference(int index, int device_index);
 
 public:
   std::unordered_map<ParallelTensor, std::vector<ParallelTensor>> tensor_buffer;

--- a/include/flexflow/inference.h
+++ b/include/flexflow/inference.h
@@ -28,13 +28,15 @@ public:
                    int max_num_inflight_batches);
   void compile_model_and_allocate_buffer(void);
   void init_operators_inference();
-  void inference(int index, int device_index);
+  void inference(int index);
 
 public:
   std::unordered_map<ParallelTensor, std::vector<ParallelTensor>> tensor_buffer;
   FFModel *model;
   int max_num_requests_per_batch;
   int max_num_inflight_batches;
+  int num_devices;
+  std::vector<MachineView> machine_views;
 };
 
 } // namespace FlexFlow

--- a/include/flexflow/operator.h
+++ b/include/flexflow/operator.h
@@ -260,10 +260,16 @@ protected:
                                           MachineView const *view);
   void set_argumentmap_for_forward(FFModel const &ff,
                                    Legion::ArgumentMap &argmap);
+  void set_argumentmap_for_inference(FFModel const &ff,
+                                     Legion::ArgumentMap &argmap,
+                                     MachineView const *view);
   void set_argumentmap_for_backward(FFModel const &ff,
                                     Legion::ArgumentMap &argmap);
   void set_opmeta_from_futuremap(FFModel const &ff,
                                  Legion::FutureMap const &fm);
+  void set_opmeta_from_futuremap_inference(FFModel const &ff,
+                                           Legion::FutureMap const &fm,
+                                           MachineView const *view);
   void solve_parallel_dim_mappings(
       std::vector<ParallelDim const *> const &inputs,
       std::vector<ParallelDim *> const &weights,
@@ -283,6 +289,7 @@ public:
   ParallelParameter weights[MAX_NUM_WEIGHTS];
   bool trainableInputs[MAX_NUM_INPUTS];
   OpMeta *meta[MAX_NUM_WORKERS];
+  std::map<size_t, OpMeta *[MAX_NUM_WORKERS]> inference_meta;
   int numInputs, numWeights, numOutputs;
   bool profiling;
 #ifdef FF_USE_NCCL

--- a/include/flexflow/operator.h
+++ b/include/flexflow/operator.h
@@ -187,7 +187,8 @@ public:
   virtual void init(FFModel const &) = 0;
   virtual void init_inference(FFModel const &,
                               std::vector<ParallelTensor> const &,
-                              std::vector<ParallelTensor> const &) {
+                              std::vector<ParallelTensor> const &,
+                              MachineView const *mv = nullptr) {
     assert(false);
   };
   virtual void forward(FFModel const &) = 0;

--- a/include/flexflow/operator.h
+++ b/include/flexflow/operator.h
@@ -255,6 +255,9 @@ public:
 #endif
 protected:
   void set_argumentmap_for_init(FFModel const &ff, Legion::ArgumentMap &argmap);
+  void set_argumentmap_for_init_inference(FFModel const &ff,
+                                          Legion::ArgumentMap &argmap,
+                                          MachineView const *view);
   void set_argumentmap_for_forward(FFModel const &ff,
                                    Legion::ArgumentMap &argmap);
   void set_argumentmap_for_backward(FFModel const &ff,

--- a/include/flexflow/ops/aggregate.h
+++ b/include/flexflow/ops/aggregate.h
@@ -37,7 +37,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void inference(FFModel const &,
                  std::vector<ParallelTensor> const &,

--- a/include/flexflow/ops/aggregate_spec.h
+++ b/include/flexflow/ops/aggregate_spec.h
@@ -29,7 +29,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void inference(FFModel const &,
                  std::vector<ParallelTensor> const &,

--- a/include/flexflow/ops/attention.h
+++ b/include/flexflow/ops/attention.h
@@ -66,7 +66,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void backward(FFModel const &) override;
   void inference(FFModel const &,

--- a/include/flexflow/ops/element_binary.h
+++ b/include/flexflow/ops/element_binary.h
@@ -27,7 +27,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void backward(FFModel const &) override;
   void inference(FFModel const &,

--- a/include/flexflow/ops/experts.h
+++ b/include/flexflow/ops/experts.h
@@ -47,7 +47,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void backward(FFModel const &) override;
   void inference(FFModel const &,

--- a/include/flexflow/ops/groupby.h
+++ b/include/flexflow/ops/groupby.h
@@ -36,7 +36,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void backward(FFModel const &) override;
   void inference(FFModel const &,

--- a/include/flexflow/ops/layer_norm.h
+++ b/include/flexflow/ops/layer_norm.h
@@ -26,7 +26,8 @@ public:
   void init(FFModel const &);
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &);
   void backward(FFModel const &);
   void inference(FFModel const &,

--- a/include/flexflow/ops/linear.h
+++ b/include/flexflow/ops/linear.h
@@ -37,7 +37,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void backward(FFModel const &) override;
   void inference(FFModel const &,

--- a/include/flexflow/ops/noop.h
+++ b/include/flexflow/ops/noop.h
@@ -19,7 +19,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void inference(FFModel const &,
                  std::vector<ParallelTensor> const &,

--- a/include/flexflow/ops/softmax.h
+++ b/include/flexflow/ops/softmax.h
@@ -23,7 +23,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void inference(FFModel const &,
                  std::vector<ParallelTensor> const &,

--- a/include/flexflow/ops/topk.h
+++ b/include/flexflow/ops/topk.h
@@ -30,7 +30,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void backward(FFModel const &) override;
   void inference(FFModel const &,

--- a/include/flexflow/parallel_ops/partition.h
+++ b/include/flexflow/parallel_ops/partition.h
@@ -31,7 +31,8 @@ public:
   void init(FFModel const &) override;
   void init_inference(FFModel const &,
                       std::vector<ParallelTensor> const &,
-                      std::vector<ParallelTensor> const &) override;
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void inference(FFModel const &,
                  std::vector<ParallelTensor> const &,

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -378,6 +378,7 @@ void FFMapper::slice_task(const MapperContext ctx,
                           Task const &task,
                           SliceTaskInput const &input,
                           SliceTaskOutput &output) {
+  printf("Slicing task %s task id %d\n", task.get_task_name(), task.task_id);
   output.slices.resize(input.domain.get_volume());
   std::vector<Processor> const *devices;
   MachineView view;

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -378,7 +378,6 @@ void FFMapper::slice_task(const MapperContext ctx,
                           Task const &task,
                           SliceTaskInput const &input,
                           SliceTaskOutput &output) {
-  printf("Slicing task %s task id %d\n", task.get_task_name(), task.task_id);
   output.slices.resize(input.domain.get_volume());
   std::vector<Processor> const *devices;
   MachineView view;

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -204,7 +204,7 @@ void Aggregate::init_inference(FFModel const &ff,
                          machine_view_hash);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 void Aggregate::init(FFModel const &ff) {
@@ -291,11 +291,12 @@ void Aggregate::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_forward(ff, argmap);
-  parallel_is = outputs[0]->parallel_is;
-  size_t machine_view_hash = mv ? mv->hash() : outputs[0]->machine_view.hash();
-  std::cout << "Aggregate op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "Aggregate op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(AGGREGATE_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -292,6 +292,8 @@ void Aggregate::inference(FFModel const &ff,
   set_argumentmap_for_init(ff, argmap);
   parallel_is = outputs[0]->parallel_is;
   size_t machine_view_hash = mv ? mv->hash() : outputs[0]->machine_view.hash();
+  std::cout << "Aggregate op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(AGGREGATE_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -182,16 +182,18 @@ Node Aggregate::deserialize(FFModel &ff,
   return ff.get_or_create_node<Aggregate>(inputs, params);
 }
 
-void Aggregate::init_inference(
-    FFModel const &ff,
-    std::vector<ParallelTensor> const &batch_inputs,
-    std::vector<ParallelTensor> const &batch_outputs) {
+void Aggregate::init_inference(FFModel const &ff,
+                               std::vector<ParallelTensor> const &batch_inputs,
+                               std::vector<ParallelTensor> const &batch_outputs,
+                               MachineView const *mv) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = batch_outputs[0]->parallel_is;
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   set_argumentmap_for_init(ff, argmap);
+  size_t machine_view_hash =
+      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   IndexLauncher launcher(AGGREGATE_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Aggregate)),
@@ -199,7 +201,7 @@ void Aggregate::init_inference(
                          Predicate::TRUE_PRED,
                          false /*must*/,
                          0 /*mapper_id*/,
-                         batch_outputs[0]->machine_view.hash());
+                         machine_view_hash);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
   set_opmeta_from_futuremap(ff, fm);

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -191,9 +191,9 @@ void Aggregate::init_inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(AGGREGATE_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Aggregate)),
@@ -291,7 +291,7 @@ void Aggregate::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
+  set_argumentmap_for_forward(ff, argmap);
   parallel_is = outputs[0]->parallel_is;
   size_t machine_view_hash = mv ? mv->hash() : outputs[0]->machine_view.hash();
   std::cout << "Aggregate op machine_view: " << *(MachineView const *)mv

--- a/src/ops/aggregate_spec.cc
+++ b/src/ops/aggregate_spec.cc
@@ -178,7 +178,7 @@ void AggregateSpec::init_inference(
                          machine_view_hash);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 void AggregateSpec::init(FFModel const &ff) {
@@ -265,11 +265,12 @@ void AggregateSpec::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_forward(ff, argmap);
-  parallel_is = outputs[0]->parallel_is;
-  size_t machine_view_hash = mv ? mv->hash() : outputs[0]->machine_view.hash();
-  std::cout << "AggregateSpec op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "AggregateSpec op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(AGG_SPEC_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/aggregate_spec.cc
+++ b/src/ops/aggregate_spec.cc
@@ -165,9 +165,9 @@ void AggregateSpec::init_inference(
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(AGG_SPEC_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(AggregateSpec)),
@@ -265,7 +265,7 @@ void AggregateSpec::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
+  set_argumentmap_for_forward(ff, argmap);
   parallel_is = outputs[0]->parallel_is;
   size_t machine_view_hash = mv ? mv->hash() : outputs[0]->machine_view.hash();
   std::cout << "AggregateSpec op machine_view: " << *(MachineView const *)mv

--- a/src/ops/aggregate_spec.cc
+++ b/src/ops/aggregate_spec.cc
@@ -265,6 +265,8 @@ void AggregateSpec::inference(FFModel const &ff,
   set_argumentmap_for_init(ff, argmap);
   parallel_is = outputs[0]->parallel_is;
   size_t machine_view_hash = mv ? mv->hash() : outputs[0]->machine_view.hash();
+  std::cout << "AggregateSpec op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(AGG_SPEC_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/attention.cc
+++ b/src/ops/attention.cc
@@ -375,13 +375,16 @@ MultiHeadAttention::MultiHeadAttention(
 void MultiHeadAttention::init_inference(
     FFModel const &ff,
     std::vector<ParallelTensor> const &batch_inputs,
-    std::vector<ParallelTensor> const &batch_outputs) {
+    std::vector<ParallelTensor> const &batch_outputs,
+    MachineView const *mv) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = batch_outputs[0]->parallel_is;
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   set_argumentmap_for_init(ff, argmap);
+  size_t machine_view_hash =
+      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   IndexLauncher launcher(ATTENTION_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(MultiHeadAttention)),
@@ -389,7 +392,7 @@ void MultiHeadAttention::init_inference(
                          Predicate::TRUE_PRED,
                          false /*must*/,
                          0 /*mapper_id*/,
-                         batch_outputs[0]->machine_view.hash());
+                         machine_view_hash);
   launcher.add_region_requirement(RegionRequirement(batch_inputs[0]->part,
                                                     0 /*projection id*/,
                                                     READ_ONLY,

--- a/src/ops/attention.cc
+++ b/src/ops/attention.cc
@@ -588,6 +588,8 @@ void MultiHeadAttention::inference(
   int idx = 0;
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "Attention op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(ATTENTION_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/attention.cc
+++ b/src/ops/attention.cc
@@ -382,9 +382,9 @@ void MultiHeadAttention::init_inference(
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(ATTENTION_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(MultiHeadAttention)),

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -258,9 +258,9 @@ void ElementBinary::init_inference(
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(ELEMENTBINARY_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(ElementBinary)),

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -311,7 +311,7 @@ void ElementBinary::init_inference(
   //}
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 void ElementBinary::init(FFModel const &ff) {
@@ -499,11 +499,12 @@ void ElementBinary::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_forward(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "ElementBinary op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "ElementBinary op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(ELEMENTBINARY_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -499,6 +499,8 @@ void ElementBinary::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "ElementBinary op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(ELEMENTBINARY_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -501,6 +501,7 @@ void Experts::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "Experts op machine_view: " <<  batch_outputs[0]->machine_view << std::endl;
   IndexLauncher launcher(EXPERTS_INF_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -494,7 +494,7 @@ void Experts::init_inference(FFModel const &ff,
   }
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 void Experts::init(FFModel const &ff) {
@@ -649,14 +649,12 @@ void Experts::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_forward(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "Experts op machine_view: " << *(MachineView const *)mv
-            << std::endl;
-  // std::cout << "machine_view hash passed: " << mv->hash() << " machine view
-  // gotten: " << machine_view_hash
-  //           << std::endl;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "Experts op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(EXPERTS_INF_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -501,6 +501,8 @@ void Experts::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "Experts op machine_view: " << batch_outputs[0]->machine_view
+            << std::endl;
   IndexLauncher launcher(EXPERTS_INF_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -501,8 +501,10 @@ void Experts::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "Experts op machine_view: " << batch_outputs[0]->machine_view
+  std::cout << "Experts op machine_view: " << *(MachineView const *)mv
             << std::endl;
+  // std::cout << "machine_view hash passed: " << mv->hash() << " machine view gotten: " << machine_view_hash
+  //           << std::endl;
   IndexLauncher launcher(EXPERTS_INF_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -501,7 +501,6 @@ void Experts::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "Experts op machine_view: " <<  batch_outputs[0]->machine_view << std::endl;
   IndexLauncher launcher(EXPERTS_INF_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -501,7 +501,8 @@ void Experts::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "Experts op machine_view: " <<  batch_outputs[0]->machine_view << std::endl;
+  std::cout << "Experts op machine_view: " << batch_outputs[0]->machine_view
+            << std::endl;
   IndexLauncher launcher(EXPERTS_INF_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -503,7 +503,8 @@ void Experts::inference(FFModel const &ff,
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   std::cout << "Experts op machine_view: " << *(MachineView const *)mv
             << std::endl;
-  // std::cout << "machine_view hash passed: " << mv->hash() << " machine view gotten: " << machine_view_hash
+  // std::cout << "machine_view hash passed: " << mv->hash() << " machine view
+  // gotten: " << machine_view_hash
   //           << std::endl;
   IndexLauncher launcher(EXPERTS_INF_TASK_ID,
                          parallel_is,
@@ -619,7 +620,7 @@ void Experts::inference_task(Task const *task,
         regions[3 + i], task->regions[3 + i], FID_DATA, ctx, runtime);
     assert(outputs[i] != nullptr);
   }
-
+  return;
   Experts::forward_kernel_wrapper(m,
                                   input_ptr,
                                   indices_ptr,

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -501,8 +501,7 @@ void Experts::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "Experts op machine_view: " << batch_outputs[0]->machine_view
-            << std::endl;
+  std::cout << "Experts op machine_view: " <<  batch_outputs[0]->machine_view << std::endl;
   IndexLauncher launcher(EXPERTS_INF_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -436,9 +436,9 @@ void Experts::init_inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(EXPERTS_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Experts)),

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -164,16 +164,18 @@ Group_by::Group_by(FFModel &model,
     : Group_by(
           model, inputs.first, inputs.second, params.n, params.alpha, name) {}
 
-void Group_by::init_inference(
-    FFModel const &ff,
-    std::vector<ParallelTensor> const &batch_inputs,
-    std::vector<ParallelTensor> const &batch_outputs) {
+void Group_by::init_inference(FFModel const &ff,
+                              std::vector<ParallelTensor> const &batch_inputs,
+                              std::vector<ParallelTensor> const &batch_outputs,
+                              MachineView const *mv) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = batch_outputs[0]->parallel_is;
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   set_argumentmap_for_init(ff, argmap);
+  size_t machine_view_hash =
+      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   IndexLauncher launcher(GROUP_BY_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Group_by)),
@@ -181,7 +183,7 @@ void Group_by::init_inference(
                          Predicate::TRUE_PRED,
                          false /*must*/,
                          0 /*mapper_id*/,
-                         batch_outputs[0]->machine_view.hash());
+                         machine_view_hash);
   // data
   launcher.add_region_requirement(RegionRequirement(batch_inputs[0]->part,
                                                     0 /*projection id*/,

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -318,6 +318,8 @@ void Group_by::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "GroupBy op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(GROUP_BY_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -173,9 +173,9 @@ void Group_by::init_inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(GROUP_BY_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Group_by)),

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -211,7 +211,7 @@ void Group_by::init_inference(FFModel const &ff,
   }
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 void Group_by::init(FFModel const &ff) {
@@ -320,8 +320,8 @@ void Group_by::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "GroupBy op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  /* std::cout << "GroupBy op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(GROUP_BY_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/layer_norm.cc
+++ b/src/ops/layer_norm.cc
@@ -194,16 +194,18 @@ LayerNorm::LayerNorm(FFModel &model,
   return;
 }
 
-void LayerNorm::init_inference(
-    FFModel const &ff,
-    std::vector<ParallelTensor> const &batch_inputs,
-    std::vector<ParallelTensor> const &batch_outputs) {
+void LayerNorm::init_inference(FFModel const &ff,
+                               std::vector<ParallelTensor> const &batch_inputs,
+                               std::vector<ParallelTensor> const &batch_outputs,
+                               MachineView const *mv) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = batch_outputs[0]->parallel_is;
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   set_argumentmap_for_init(ff, argmap);
+  size_t machine_view_hash =
+      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   IndexLauncher launcher(LAYERNORM_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(LayerNorm)),
@@ -211,7 +213,7 @@ void LayerNorm::init_inference(
                          Predicate::TRUE_PRED,
                          false /*must*/,
                          0 /*mapper_id*/,
-                         batch_outputs[0]->machine_view.hash());
+                         machine_view_hash);
   launcher.add_region_requirement(RegionRequirement(batch_outputs[0]->part,
                                                     0 /*projection id*/,
                                                     WRITE_ONLY,

--- a/src/ops/layer_norm.cc
+++ b/src/ops/layer_norm.cc
@@ -323,6 +323,8 @@ void LayerNorm::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "LayerNorm op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(LAYERNORM_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/layer_norm.cc
+++ b/src/ops/layer_norm.cc
@@ -228,7 +228,7 @@ void LayerNorm::init_inference(FFModel const &ff,
   launcher.add_field(1, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 void LayerNorm::init(FFModel const &ff) {
@@ -322,11 +322,12 @@ void LayerNorm::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_forward(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "LayerNorm op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "LayerNorm op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(LAYERNORM_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/layer_norm.cc
+++ b/src/ops/layer_norm.cc
@@ -203,9 +203,9 @@ void LayerNorm::init_inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(LAYERNORM_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(LayerNorm)),

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -264,9 +264,9 @@ void Linear::init_inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(LINEAR_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Linear)),

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -304,7 +304,7 @@ void Linear::init_inference(FFModel const &ff,
   }
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 /*
@@ -427,11 +427,12 @@ void Linear::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_forward(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "Linear op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "Linear op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(LINEAR_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -427,6 +427,8 @@ void Linear::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "Linear op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(LINEAR_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(nullptr, 0),

--- a/src/ops/noop.cc
+++ b/src/ops/noop.cc
@@ -97,9 +97,12 @@ OpMeta *NoOp::init_task(Task const *task,
 
 void NoOp::init_inference(FFModel const &ff,
                           std::vector<ParallelTensor> const &batch_inputs,
-                          std::vector<ParallelTensor> const &batch_outputs) {
+                          std::vector<ParallelTensor> const &batch_outputs,
+                          MachineView const *mv) {
   parallel_is = batch_outputs[0]->parallel_is;
   assert(parallel_is != IndexSpace::NO_SPACE);
+  size_t machine_view_hash =
+      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   if (op_type == OP_INPUT && batch_outputs[0]->initializer != nullptr) {
     ConstantInitializer *initializer =
         (ConstantInitializer *)batch_outputs[0]->initializer;
@@ -114,7 +117,7 @@ void NoOp::init_inference(FFModel const &ff,
         Predicate::TRUE_PRED,
         false /*must*/,
         0 /*mapper_id*/,
-        batch_outputs[0]->machine_view.hash());
+        machine_view_hash);
     launcher.add_region_requirement(
         RegionRequirement(batch_outputs[0]->part,
                           0 /*projection id*/,
@@ -148,7 +151,7 @@ void NoOp::init_inference(FFModel const &ff,
         Predicate::TRUE_PRED,
         false /*must*/,
         0 /*mapper_id*/,
-        batch_outputs[0]->machine_view.hash());
+        machine_view_hash);
     launcher.add_region_requirement(
         RegionRequirement(batch_outputs[0]->part,
                           0 /*projection id*/,
@@ -169,7 +172,7 @@ void NoOp::init_inference(FFModel const &ff,
                            Predicate::TRUE_PRED,
                            false /*must*/,
                            0 /*mapper_id*/,
-                           batch_outputs[0]->machine_view.hash());
+                           machine_view_hash);
     FutureMap fm = runtime->execute_index_space(ctx, launcher);
     fm.wait_all_results();
     set_opmeta_from_futuremap(ff, fm);

--- a/src/ops/noop.cc
+++ b/src/ops/noop.cc
@@ -101,8 +101,8 @@ void NoOp::init_inference(FFModel const &ff,
                           MachineView const *mv) {
   parallel_is = batch_outputs[0]->parallel_is;
   assert(parallel_is != IndexSpace::NO_SPACE);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
   if (op_type == OP_INPUT && batch_outputs[0]->initializer != nullptr) {
     ConstantInitializer *initializer =
         (ConstantInitializer *)batch_outputs[0]->initializer;
@@ -164,7 +164,7 @@ void NoOp::init_inference(FFModel const &ff,
     ArgumentMap argmap;
     Context ctx = ff.config.lg_ctx;
     Runtime *runtime = ff.config.lg_hlr;
-    set_argumentmap_for_init(ff, argmap);
+    set_argumentmap_for_init_inference(ff, argmap, view);
     IndexLauncher launcher(NOOP_INIT_TASK_ID,
                            parallel_is,
                            TaskArgument(NULL, 0),

--- a/src/ops/noop.cc
+++ b/src/ops/noop.cc
@@ -175,7 +175,7 @@ void NoOp::init_inference(FFModel const &ff,
                            machine_view_hash);
     FutureMap fm = runtime->execute_index_space(ctx, launcher);
     fm.wait_all_results();
-    set_opmeta_from_futuremap(ff, fm);
+    set_opmeta_from_futuremap_inference(ff, fm, view);
   }
 }
 

--- a/src/ops/softmax.cc
+++ b/src/ops/softmax.cc
@@ -149,7 +149,7 @@ void Softmax::init_inference(FFModel const &ff,
   launcher.add_field(1, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 void Softmax::init(FFModel const &ff) {
@@ -232,11 +232,12 @@ void Softmax::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_forward(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "Softmax op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "Softmax op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(SOFTMAX_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/softmax.cc
+++ b/src/ops/softmax.cc
@@ -232,6 +232,8 @@ void Softmax::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "Softmax op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(SOFTMAX_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/softmax.cc
+++ b/src/ops/softmax.cc
@@ -117,13 +117,16 @@ Softmax::Softmax(FFModel &model,
 
 void Softmax::init_inference(FFModel const &ff,
                              std::vector<ParallelTensor> const &batch_inputs,
-                             std::vector<ParallelTensor> const &batch_outputs) {
+                             std::vector<ParallelTensor> const &batch_outputs,
+                             MachineView const *mv) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = batch_outputs[0]->parallel_is;
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   set_argumentmap_for_init(ff, argmap);
+  size_t machine_view_hash =
+      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   IndexLauncher launcher(SOFTMAX_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Softmax)),
@@ -131,7 +134,7 @@ void Softmax::init_inference(FFModel const &ff,
                          Predicate::TRUE_PRED,
                          false /*must*/,
                          0 /*mapper_id*/,
-                         batch_outputs[0]->machine_view.hash());
+                         machine_view_hash);
   launcher.add_region_requirement(RegionRequirement(batch_inputs[0]->part,
                                                     0 /*projection id*/,
                                                     READ_ONLY,

--- a/src/ops/softmax.cc
+++ b/src/ops/softmax.cc
@@ -124,9 +124,9 @@ void Softmax::init_inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(SOFTMAX_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Softmax)),

--- a/src/ops/topk.cc
+++ b/src/ops/topk.cc
@@ -138,13 +138,16 @@ TopK::TopK(FFModel &model,
 
 void TopK::init_inference(FFModel const &ff,
                           std::vector<ParallelTensor> const &batch_inputs,
-                          std::vector<ParallelTensor> const &batch_outputs) {
+                          std::vector<ParallelTensor> const &batch_outputs,
+                          MachineView const *mv) {
   assert(check_output_input_weight_same_parallel_is());
   parallel_is = batch_outputs[0]->parallel_is;
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
   set_argumentmap_for_init(ff, argmap);
+  size_t machine_view_hash =
+      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   IndexLauncher launcher(TOPK_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(TopK)),
@@ -152,7 +155,7 @@ void TopK::init_inference(FFModel const &ff,
                          Predicate::TRUE_PRED,
                          false /*must*/,
                          0 /*mapper_id*/,
-                         batch_outputs[0]->machine_view.hash());
+                         machine_view_hash);
   launcher.add_region_requirement(RegionRequirement(batch_inputs[0]->part,
                                                     0 /*projection id*/,
                                                     READ_ONLY,

--- a/src/ops/topk.cc
+++ b/src/ops/topk.cc
@@ -176,7 +176,7 @@ void TopK::init_inference(FFModel const &ff,
   launcher.add_field(2, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap(ff, fm);
+  set_opmeta_from_futuremap_inference(ff, fm, view);
 }
 
 void TopK::init(FFModel const &ff) {
@@ -270,11 +270,12 @@ void TopK::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_forward(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "TopK op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "TopK op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(TOPK_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/ops/topk.cc
+++ b/src/ops/topk.cc
@@ -145,9 +145,9 @@ void TopK::init_inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
-  set_argumentmap_for_init(ff, argmap);
-  size_t machine_view_hash =
-      mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
   IndexLauncher launcher(TOPK_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(TopK)),

--- a/src/ops/topk.cc
+++ b/src/ops/topk.cc
@@ -270,6 +270,8 @@ void TopK::inference(FFModel const &ff,
   set_argumentmap_for_forward(ff, argmap);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "TopK op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(TOPK_FWD_TASK_ID,
                          parallel_is,
                          TaskArgument(NULL, 0),

--- a/src/parallel_ops/partition.cc
+++ b/src/parallel_ops/partition.cc
@@ -209,6 +209,8 @@ void Repartition::inference(FFModel const &ff,
   DataType data_type = batch_inputs[0]->data_type;
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
+  std::cout << "Partition op machine_view: " << *(MachineView const *)mv
+            << std::endl;
   IndexLauncher launcher(REPARTITION_FWD_TASK_ID,
                          batch_outputs[0]->parallel_is,
                          TaskArgument(&data_type, sizeof(DataType)),

--- a/src/parallel_ops/partition.cc
+++ b/src/parallel_ops/partition.cc
@@ -212,8 +212,8 @@ void Repartition::inference(FFModel const &ff,
   DataType data_type = batch_inputs[0]->data_type;
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
-  std::cout << "Partition op machine_view: " << *(MachineView const *)mv
-            << std::endl;
+  /* std::cout << "Partition op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
   IndexLauncher launcher(REPARTITION_FWD_TASK_ID,
                          batch_outputs[0]->parallel_is,
                          TaskArgument(&data_type, sizeof(DataType)),

--- a/src/runtime/graph.cc
+++ b/src/runtime/graph.cc
@@ -1798,6 +1798,18 @@ void FFModel::register_all_machine_views(
       valid_views.push_back(view);
     }
   }
+  // No-parallelism views
+  for (int i = 1; i <= num_nodes * gpus_per_node; i++) {
+    if (num_nodes * gpus_per_node % i == 0) {
+      MachineView view;
+      view.device_type = MachineView::GPU;
+      view.ndims = 1;
+      view.dim[0] = i;
+      view.stride[0] = 0;
+      view.start_device_id = 0;
+      valid_views.push_back(view);
+    }
+  }
   // Two-dimensional views
   /* for (int i = 1; i <= num_nodes; i++) { */
   /*   for (int j = 1; j <= gpus_per_node; j++) { */

--- a/src/runtime/inference_manager.cc
+++ b/src/runtime/inference_manager.cc
@@ -98,17 +98,19 @@ void InferenceManager::inference(int index, int device_index) {
     if (op->op_type == OP_WEIGHT) {
       continue;
     }
-    //create mv w startdeviceid = device_index
+    // create mv w startdeviceid = device_index
     MachineView view;
     view.device_type = MachineView::GPU;
     view.ndims = 1;
     view.dim[0] = 1;
     view.stride[0] = 0;
     view.start_device_id = device_index;
-    // if (op->op_type == OP_EXPERTS) {
-    //   view.start_device_id = expert_device_index;
-    //   expert_device_index = (expert_device_index + 1) % (model->config.workersPerNode * model->config.numNodes);
-    // }
+    if (op->op_type == OP_EXPERTS) {
+      view.start_device_id = expert_device_index;
+      expert_device_index =
+          (expert_device_index + 1) %
+          (model->config.workersPerNode * model->config.numNodes);
+    }
 
     std::vector<ParallelTensor> inputs(op->numInputs);
     std::vector<ParallelTensor> outputs(op->numOutputs);

--- a/src/runtime/inference_manager.cc
+++ b/src/runtime/inference_manager.cc
@@ -24,7 +24,19 @@ InferenceManager::InferenceManager(FFModel *_model,
                                    int _max_num_requests_per_batch,
                                    int _max_num_inflight_batches)
     : model(_model), max_num_requests_per_batch(_max_num_requests_per_batch),
-      max_num_inflight_batches(_max_num_inflight_batches) {}
+      max_num_inflight_batches(_max_num_inflight_batches) {
+  // populate array of valid single-device machine views
+  num_devices = model->config.workersPerNode * model->config.numNodes;
+  for (int i = 0; i < num_devices; i++) {
+    MachineView view;
+    view.device_type = MachineView::GPU;
+    view.ndims = 1;
+    view.dim[0] = 1;
+    view.stride[0] = 0;
+    view.start_device_id = i;
+    machine_views.push_back(view);
+  }
+}
 
 void InferenceManager::compile_model_and_allocate_buffer(void) {
   std::vector<MetricsType> metrics;
@@ -60,56 +72,64 @@ void InferenceManager::compile_model_and_allocate_buffer(void) {
 
 void InferenceManager::init_operators_inference() {
   for (int index = 0; index < max_num_inflight_batches; index++) {
+    int batch_index = index % max_num_inflight_batches;
+    int device_index = index % num_devices;
+    int expert_device_index = 0;
     for (size_t o = 0; o < model->operators.size(); o++) {
       Op *op = model->operators[o];
       if (op->op_type == OP_WEIGHT) {
         continue;
+      }
+      MachineView *view;
+      if (op->op_type == OP_EXPERTS) {
+        view = &machine_views[expert_device_index];
+        expert_device_index = (expert_device_index + 1) % num_devices;
+      } else {
+        // pick mv w startdeviceid = device_index
+        view = &machine_views[device_index];
       }
       std::vector<ParallelTensor> inputs(op->numInputs);
       std::vector<ParallelTensor> outputs(op->numOutputs);
       for (int i = 0; i < op->numInputs; i++) {
         assert(op->inputs[i] != nullptr);
         assert(op->inputs[i]->parallel_is != IndexSpace::NO_SPACE);
-        assert(tensor_buffer[op->inputs[i]].size() > index);
-        inputs[i] = tensor_buffer[op->inputs[i]][index];
+        assert(tensor_buffer[op->inputs[i]].size() > batch_index);
+        inputs[i] = tensor_buffer[op->inputs[i]][batch_index];
         assert(inputs[i]->parallel_is != IndexSpace::NO_SPACE);
       }
       for (int i = 0; i < op->numOutputs; i++) {
         assert(op->outputs[i] != nullptr);
         assert(op->outputs[i]->parallel_is != IndexSpace::NO_SPACE);
-        assert(tensor_buffer[op->outputs[i]].size() > index);
-        outputs[i] = tensor_buffer[op->outputs[i]][index];
+        assert(tensor_buffer[op->outputs[i]].size() > batch_index);
+        outputs[i] = tensor_buffer[op->outputs[i]][batch_index];
         assert(outputs[i]->parallel_is != IndexSpace::NO_SPACE);
       }
       if (op->is_parallel_op()) {
         ((ParallelOp *)op)
             ->create_input_partition_inference(*model, inputs, outputs);
       }
-      op->init_inference(*model, inputs, outputs);
+      op->init_inference(*model, inputs, outputs, view);
     }
   }
 }
 
-void InferenceManager::inference(int index, int device_index) {
-  assert(index < max_num_inflight_batches);
+void InferenceManager::inference(int index) {
+  int batch_index = index % max_num_inflight_batches;
+  int device_index = index % num_devices;
   int expert_device_index = 0;
   for (size_t o = 0; o < model->operators.size(); o++) {
     Op *op = model->operators[o];
     if (op->op_type == OP_WEIGHT) {
       continue;
     }
-    // create mv w startdeviceid = device_index
-    MachineView view;
-    view.device_type = MachineView::GPU;
-    view.ndims = 1;
-    view.dim[0] = 1;
-    view.stride[0] = 0;
-    view.start_device_id = device_index;
+
+    MachineView *view;
     if (op->op_type == OP_EXPERTS) {
-      view.start_device_id = expert_device_index;
-      expert_device_index =
-          (expert_device_index + 1) %
-          (model->config.workersPerNode * model->config.numNodes);
+      view = &machine_views[expert_device_index];
+      expert_device_index = (expert_device_index + 1) % num_devices;
+    } else {
+      // pick mv w startdeviceid = device_index
+      view = &machine_views[device_index];
     }
 
     std::vector<ParallelTensor> inputs(op->numInputs);
@@ -117,18 +137,18 @@ void InferenceManager::inference(int index, int device_index) {
     for (int i = 0; i < op->numInputs; i++) {
       assert(op->inputs[i] != nullptr);
       assert(op->inputs[i]->parallel_is != IndexSpace::NO_SPACE);
-      assert(tensor_buffer[op->inputs[i]].size() > index);
-      inputs[i] = tensor_buffer[op->inputs[i]][index];
+      assert(tensor_buffer[op->inputs[i]].size() > batch_index);
+      inputs[i] = tensor_buffer[op->inputs[i]][batch_index];
       assert(inputs[i]->parallel_is != IndexSpace::NO_SPACE);
     }
     for (int i = 0; i < op->numOutputs; i++) {
       assert(op->outputs[i] != nullptr);
       assert(op->outputs[i]->parallel_is != IndexSpace::NO_SPACE);
-      assert(tensor_buffer[op->outputs[i]].size() > index);
-      outputs[i] = tensor_buffer[op->outputs[i]][index];
+      assert(tensor_buffer[op->outputs[i]].size() > batch_index);
+      outputs[i] = tensor_buffer[op->outputs[i]][batch_index];
       assert(outputs[i]->parallel_is != IndexSpace::NO_SPACE);
     }
-    op->inference(*model, inputs, outputs, &view);
+    op->inference(*model, inputs, outputs, view);
   }
 };
 

--- a/src/runtime/inference_manager.cc
+++ b/src/runtime/inference_manager.cc
@@ -71,44 +71,48 @@ void InferenceManager::compile_model_and_allocate_buffer(void) {
 }
 
 void InferenceManager::init_operators_inference() {
-  for (int index = 0; index < max_num_inflight_batches; index++) {
-    int batch_index = index % max_num_inflight_batches;
-    int device_index = index % num_devices;
-    int expert_device_index = 0;
-    for (size_t o = 0; o < model->operators.size(); o++) {
-      Op *op = model->operators[o];
-      if (op->op_type == OP_WEIGHT) {
-        continue;
-      }
-      MachineView *view;
-      if (op->op_type == OP_EXPERTS) {
-        view = &machine_views[expert_device_index];
-        expert_device_index = (expert_device_index + 1) % num_devices;
-      } else {
-        // pick mv w startdeviceid = device_index
+  for (int batch_index = 0; batch_index < max_num_inflight_batches;
+       batch_index++) {
+    for (int device_index = 0; device_index < num_devices; device_index++) {
+      // int fused_experts_index = 0;
+      for (size_t o = 0; o < model->operators.size(); o++) {
+        Op *op = model->operators[o];
+        if (op->op_type == OP_WEIGHT) {
+          continue;
+        }
+        MachineView *view;
+        // if (op->op_type == OP_EXPERTS) {
+        //   if (fused_experts_index != device_index) {
+        //     fused_experts_index++;
+        //     continue;
+        //   }
+        //   view = &machine_views[fused_experts_index];
+        //   fused_experts_index++;
+        // } else {
         view = &machine_views[device_index];
+        //}
+        std::vector<ParallelTensor> inputs(op->numInputs);
+        std::vector<ParallelTensor> outputs(op->numOutputs);
+        for (int i = 0; i < op->numInputs; i++) {
+          assert(op->inputs[i] != nullptr);
+          assert(op->inputs[i]->parallel_is != IndexSpace::NO_SPACE);
+          assert(tensor_buffer[op->inputs[i]].size() > batch_index);
+          inputs[i] = tensor_buffer[op->inputs[i]][batch_index];
+          assert(inputs[i]->parallel_is != IndexSpace::NO_SPACE);
+        }
+        for (int i = 0; i < op->numOutputs; i++) {
+          assert(op->outputs[i] != nullptr);
+          assert(op->outputs[i]->parallel_is != IndexSpace::NO_SPACE);
+          assert(tensor_buffer[op->outputs[i]].size() > batch_index);
+          outputs[i] = tensor_buffer[op->outputs[i]][batch_index];
+          assert(outputs[i]->parallel_is != IndexSpace::NO_SPACE);
+        }
+        if (op->is_parallel_op()) {
+          ((ParallelOp *)op)
+              ->create_input_partition_inference(*model, inputs, outputs);
+        }
+        op->init_inference(*model, inputs, outputs, view);
       }
-      std::vector<ParallelTensor> inputs(op->numInputs);
-      std::vector<ParallelTensor> outputs(op->numOutputs);
-      for (int i = 0; i < op->numInputs; i++) {
-        assert(op->inputs[i] != nullptr);
-        assert(op->inputs[i]->parallel_is != IndexSpace::NO_SPACE);
-        assert(tensor_buffer[op->inputs[i]].size() > batch_index);
-        inputs[i] = tensor_buffer[op->inputs[i]][batch_index];
-        assert(inputs[i]->parallel_is != IndexSpace::NO_SPACE);
-      }
-      for (int i = 0; i < op->numOutputs; i++) {
-        assert(op->outputs[i] != nullptr);
-        assert(op->outputs[i]->parallel_is != IndexSpace::NO_SPACE);
-        assert(tensor_buffer[op->outputs[i]].size() > batch_index);
-        outputs[i] = tensor_buffer[op->outputs[i]][batch_index];
-        assert(outputs[i]->parallel_is != IndexSpace::NO_SPACE);
-      }
-      if (op->is_parallel_op()) {
-        ((ParallelOp *)op)
-            ->create_input_partition_inference(*model, inputs, outputs);
-      }
-      op->init_inference(*model, inputs, outputs, view);
     }
   }
 }

--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -2630,7 +2630,8 @@ Op *FFModel::create_operator_from_layer(
       assert(tensor->parallel_tensor == nullptr);
       tensor->parallel_tensor = pt;
       // start from data parllel tensor
-      if (config.only_data_parallel && config.computationMode == COMP_MODE_TRAINING) {
+      if (config.only_data_parallel &&
+          config.computationMode == COMP_MODE_TRAINING) {
         Repartition *part = new Repartition(
             *this, pt, num_dims - 1, config.numNodes * config.workersPerNode);
         operators.push_back(part);

--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -2630,7 +2630,7 @@ Op *FFModel::create_operator_from_layer(
       assert(tensor->parallel_tensor == nullptr);
       tensor->parallel_tensor = pt;
       // start from data parllel tensor
-      if (config.only_data_parallel) {
+      if (config.only_data_parallel && config.computationMode == COMP_MODE_TRAINING) {
         Repartition *part = new Repartition(
             *this, pt, num_dims - 1, config.numNodes * config.workersPerNode);
         operators.push_back(part);


### PR DESCRIPTION
**Goal**
Place tasks (operators) on different devices according to the following criteria
- Expert operators: fix one expert batch on each device
- Other operators: round robin per inference request

In other words, each inference call() will have a "home" device (assigned in round robin) where all operators run on, except expert operators that go on their allocated devices.

**Device Placement theory**
- Each inference operator is executed as an Index Task and the launching of an Index Task takes in a machine view
- This machine view will be passed on to the flewflow task mapping function in mapper.cc and used to map the task onto its `machine_view.start_device_id`

**Description of changes**
Main changes are in the inference manager which processes each inference call.
- Create machine views with different `start_device_id`
- Run op init on every device
- On inference call, choose the home device by selecting a machine view and passing it to the operators
- For expert operators, assign each of them on a device in sequential order

Other changes
- Allow ops to take in a machine view
- Allow FFHandler and set_argumentmap to work with machine view

**Notes**
- trace: We changed the trace id to be different for each trace so that flexflow doesn't memorize the mapping. Else, mapping of the first inference call() will be used for all inference calls.
- mapper: Pay attention to the domain space being passed, ensure that there is no parallelism implied. Otherwise, task will be split into task slices starting from `machine_view.start_device_id` across some number of devices.