### PR TITLE
[Inference] Fixed parallel_tensor equals

### DIFF
--- a/src/runtime/parallel_tensor.cc
+++ b/src/runtime/parallel_tensor.cc
@@ -762,6 +762,7 @@ bool ParallelTensorBase::tensor_equal(FFConfig &config,
   launcher.add_field(1, FID_DATA);
   Future result = runtime->execute_task(ctx, launcher);
   bool equals = result.get_result<bool>();
+  return equals;
 }
 
 bool ParallelTensorBase::tensor_equal_task(


### PR DESCRIPTION
**Description of changes:**
Fixed an issue with the parallel_tensor equals.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
