### PR TITLE
[Inference] Fixed parallel_tensor equals

### DIFF
--- a/examples/cpp/inference/dataloader.cc
+++ b/examples/cpp/inference/dataloader.cc
@@ -110,7 +110,10 @@ void DataLoader::load_entire_dataset(Task const *task,
   }
 }
 
-void DataLoader::next_batch(FFModel &ff, int bid, BatchConfig *bc, MachineView const *mv) {
+void DataLoader::next_batch(FFModel &ff,
+                            int bid,
+                            BatchConfig *bc,
+                            MachineView const *mv) {
   size_t num_active_tokens = bc->num_active_tokens();
   if (num_active_tokens == 0) {
     return;

--- a/examples/cpp/inference/dataloader.h
+++ b/examples/cpp/inference/dataloader.h
@@ -43,7 +43,10 @@ public:
                                   std::vector<PhysicalRegion> const &regions,
                                   Context ctx,
                                   Runtime *runtime);
-  void next_batch(FFModel &ff, int bid, BatchConfig *bc, MachineView const *mv = nullptr);
+  void next_batch(FFModel &ff,
+                  int bid,
+                  BatchConfig *bc,
+                  MachineView const *mv = nullptr);
 
 public:
   size_t num_samples;

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -218,10 +218,10 @@ void FlexFlow::top_level_task(Task const *task,
       bc->prepare_next_batch();
       MachineView *view = im.get_machine_view(bid % im.num_devices);
 
-      //runtime->begin_trace(ctx, 111 + bid % num_devices /*trace_id*/);
+      // runtime->begin_trace(ctx, 111 + bid % num_devices /*trace_id*/);
       data_loader.next_batch(ff, bid, bc, view);
       FutureMap fm = im.inference(bid, *bc);
-      //runtime->end_trace(ctx, 111 + bid % num_devices /*trace_id*/);
+      // runtime->end_trace(ctx, 111 + bid % num_devices /*trace_id*/);
 
       assert(fm.get_future_map_domain().get_volume() == 1);
       future_handlers[bid] = fm.get_future(0);

--- a/examples/cpp/inference/transformers/transformers.cc
+++ b/examples/cpp/inference/transformers/transformers.cc
@@ -199,10 +199,10 @@ void FlexFlow::top_level_task(Task const *task,
       bc->prepare_next_batch();
       MachineView *view = im.get_machine_view(bid % im.num_devices);
 
-      //runtime->begin_trace(ctx, 111 + bid % num_devices /*trace_id*/);
+      // runtime->begin_trace(ctx, 111 + bid % num_devices /*trace_id*/);
       data_loader.next_batch(ff, bid, bc, view);
       FutureMap fm = im.inference(bid, *bc);
-      //runtime->end_trace(ctx, 111 + bid % num_devices /*trace_id*/);
+      // runtime->end_trace(ctx, 111 + bid % num_devices /*trace_id*/);
 
       assert(fm.get_future_map_domain().get_volume() == 1);
       future_handlers[bid] = fm.get_future(0);

--- a/src/ops/experts.cu
+++ b/src/ops/experts.cu
@@ -457,6 +457,13 @@ void Experts::forward_kernel_wrapper(ExpertsMeta const *m,
   assert(gemm_batch_count <= num_valid_assignments);
 
   if (num_valid_assignments == 0) {
+    if (m->profiling) {
+      cudaEventRecord(t_end, stream);
+      cudaEventSynchronize(t_end);
+      float milliseconds = 0;
+      cudaEventElapsedTime(&milliseconds, t_start, t_end);
+      printf("forward_kernel_wrapper: %f ms\n", milliseconds);
+    }
     return;
   }
 

--- a/src/runtime/inference_manager.cc
+++ b/src/runtime/inference_manager.cc
@@ -136,11 +136,11 @@ FutureMap InferenceManager::inference(int index, BatchConfig const &bc) {
     MachineView *view;
     if (op->op_type == OP_EXPERTS) {
       view = get_machine_view(expert_device_index);
-      //view = &machine_views[expert_device_index];
+      // view = &machine_views[expert_device_index];
       expert_device_index = (expert_device_index + 1) % num_devices;
     } else {
       // pick mv w startdeviceid = device_index
-      //view = &machine_views[device_index];
+      // view = &machine_views[device_index];
       view = get_machine_view(device_index);
     }
 

--- a/src/runtime/parallel_tensor.cc
+++ b/src/runtime/parallel_tensor.cc
@@ -762,6 +762,7 @@ bool ParallelTensorBase::tensor_equal(FFConfig &config,
   launcher.add_field(1, FID_DATA);
   Future result = runtime->execute_task(ctx, launcher);
   bool equals = result.get_result<bool>();
+  return equals;
 }
 
 bool ParallelTensorBase::tensor_equal_task(


### PR DESCRIPTION
**Description of changes:**
Fixed an issue with the parallel_tensor equals and applied clang format.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
