### PR TITLE
[Inference] - Pass generated tokens to next batch

### DIFF
--- a/examples/cpp/inference/data_generator.cc
+++ b/examples/cpp/inference/data_generator.cc
@@ -21,14 +21,14 @@
 using namespace std;
 
 DataGenerator::DataGenerator(size_t _num_requests,
-                             size_t _token_dim,
+                             size_t _vocab_size,
                              size_t _min_input_tokens,
                              size_t _max_input_tokens,
                              size_t _min_tokens_to_generate,
                              size_t _max_tokens_to_generate,
                              bool _poisson_distr,
                              double _lambda)
-    : num_requests(_num_requests), token_dim(_token_dim),
+    : num_requests(_num_requests), vocab_size(_vocab_size),
       min_input_tokens(_min_input_tokens), max_input_tokens(_max_input_tokens),
       min_tokens_to_generate(_min_tokens_to_generate),
       max_tokens_to_generate(_max_tokens_to_generate),
@@ -73,7 +73,7 @@ void DataGenerator::generate_requests_meta() {
   // cout << "]" << endl;
 };
 
-void DataGenerator::generate_requests(float *req_ptr) {
+void DataGenerator::generate_requests(int *req_ptr) {
   assert(req_ptr != nullptr);
   /* for (size_t i=0; i<num_requests; i++) {
     for (size_t j=0; j<max_sequence_length; j++) {
@@ -88,12 +88,15 @@ void DataGenerator::generate_requests(float *req_ptr) {
   random_device rnd_device;
   mt19937 mersenne_engine{rnd_device()};
 
-  uniform_real_distribution<float> float_dist{0, 1.0};
-  auto gen = [&float_dist, &mersenne_engine]() {
-    return float_dist(mersenne_engine);
+  // uniform_real_distribution<float> float_dist{0, 1.0};
+  //  auto gen = [&float_dist, &mersenne_engine]() {
+  //    return float_dist(mersenne_engine);
+  //  };
+  std::uniform_int_distribution<int> int_dist(0, vocab_size - 1);
+  auto gen = [&int_dist, &mersenne_engine]() {
+    return int_dist(mersenne_engine);
   };
-  std::generate(
-      req_ptr, req_ptr + token_dim * max_input_tokens * num_requests, gen);
+  std::generate(req_ptr, req_ptr + max_input_tokens * num_requests, gen);
 };
 
 void DataGenerator::start_timer(void) {

--- a/examples/cpp/inference/data_generator.cpp
+++ b/examples/cpp/inference/data_generator.cpp
@@ -19,7 +19,7 @@ int main(int argc, char const *argv[]) {
 
   // DataGenerator parameters
   size_t total_requests = 2560;
-  size_t token_dim = 16;
+  size_t vocab_size = 50257;
   size_t max_sequence_length = 512 + 128;
   bool use_poisson_distr = true;
   // average number of request arrivals per second
@@ -28,11 +28,11 @@ int main(int argc, char const *argv[]) {
   size_t min_input_tokens = 32, max_input_tokens = 512,
          min_tokens_to_generate = 1, max_tokens_to_generate = 128;
 
-  float *requests = (float *)calloc(
-      token_dim * max_sequence_length * total_requests, sizeof(float));
+  int *requests =
+      (int *)calloc(max_sequence_length * total_requests, sizeof(int));
 
   DataGenerator data_generator(total_requests,
-                               token_dim,
+                               vocab_size,
                                min_input_tokens,
                                max_input_tokens,
                                min_tokens_to_generate,

--- a/examples/cpp/inference/data_generator.h
+++ b/examples/cpp/inference/data_generator.h
@@ -33,7 +33,7 @@ typedef std::chrono::milliseconds milliseconds;
 class DataGenerator {
 public:
   DataGenerator(size_t _num_requests,
-                size_t _token_dim,
+                size_t _vocab_size,
                 size_t _min_input_tokens,
                 size_t _max_input_tokens,
                 size_t _min_tokens_to_generate,
@@ -41,17 +41,15 @@ public:
                 bool _poisson_distr,
                 double _lambda);
 
-  // Generate random requests by filling each token with random data. For now,
-  // assume all requests have the same sequence length. Also generate random
-  // labels (if label_ptr != nullptr and num_labels >0).
-  void generate_requests(float *req_ptr);
+  // Generate random requests by filling each tensor with random tokens. For
+  // now, assume all requests have the same sequence length.
+  void generate_requests(int *req_ptr);
   void start_timer(void);
   // Get number of requests that have arrived since the last time this function
   // was called
   std::pair<size_t, size_t> get_requests(size_t max_requests,
                                          size_t max_tokens);
   std::pair<size_t, size_t> get_request_length(size_t guid);
-  // size_t max_sequence_length; // dimension of one request tensor
 
 private:
   // Compute the arrival times of each request and save them in the arrivals
@@ -60,7 +58,7 @@ private:
   void generate_requests_meta();
 
   size_t num_requests; // total number of requests
-  size_t token_dim;    // embedding dim of each token
+  size_t vocab_size;   // number of words in the vocab
   size_t min_input_tokens;
   size_t max_input_tokens;
   size_t min_tokens_to_generate;

--- a/examples/cpp/inference/dataloader.cc
+++ b/examples/cpp/inference/dataloader.cc
@@ -58,7 +58,7 @@ DataLoader::DataLoader(FFModel &ff,
     dims[batch_idx].size = num_samples;
 
     full_input =
-        ff.create_parallel_tensor_legion_ordering(numdims, dims, DT_FLOAT);
+        ff.create_parallel_tensor_legion_ordering(numdims, dims, DT_INT32);
     ff.map_tensor(full_input, NULL /*parallel_op*/);
   }
 
@@ -93,7 +93,7 @@ void DataLoader::load_entire_dataset(Task const *task,
   assert(task->regions.size() == regions.size());
 
   // get input pointer
-  float *input_ptr = helperGetTensorPointerWO<float>(
+  int *input_ptr = helperGetTensorPointerWO<int>(
       regions[0], task->regions[0], FID_DATA, ctx, runtime);
   Domain input_domain = runtime->get_index_space_domain(
       ctx, task->regions[0].region.get_index_space());
@@ -113,6 +113,7 @@ void DataLoader::load_entire_dataset(Task const *task,
 void DataLoader::next_batch(FFModel &ff,
                             int bid,
                             BatchConfig *bc,
+                            std::map<size_t, int> &batch_predictions,
                             MachineView const *mv) {
   size_t num_active_tokens = bc->num_active_tokens();
   if (num_active_tokens == 0) {
@@ -140,16 +141,23 @@ void DataLoader::next_batch(FFModel &ff,
        num_active_tokens); */
     assert(ff.config.batchSize == batch_size &&
            batch_size * seq_len >= num_active_tokens);
-    for (Domain::DomainPointIterator it(domain); it; it++) {
-      // SampleIdxs meta = bc->token2ids;
-      argmap.set_point(
-          *it, TaskArgument(&bc->token2ids, sizeof(BatchConfig::SampleIdxs)));
-    }
+
+    /* std::cout << "About to call next_batch function..." << std::endl;
+    bc->print();
+    std::cout << "batch_predictions: ";
+    for (const auto& elem : batch_predictions){
+        std::cout << elem.first << ":" << elem.second << ", ";
+    } */
+    DataLoaderNextBatchInput next_batch_input = {bc->token2ids,
+                                                 batch_predictions};
+    DataLoaderNextBatchInput const *ptr = &next_batch_input;
+    size_t next_batch_input_sz = sizeof(next_batch_input);
+    assert(ptr->prev_batch_preds.size() == batch_predictions.size());
     MachineView const *view = mv ? mv : &batch_input[bid]->machine_view;
     size_t machine_view_hash = view->hash();
     IndexLauncher launcher(CUSTOM_GPU_TASK_ID_1,
                            batch_input[bid]->parallel_is,
-                           TaskArgument(NULL, 0),
+                           TaskArgument(ptr, next_batch_input_sz),
                            argmap,
                            Predicate::TRUE_PRED,
                            false /*must*/,
@@ -173,9 +181,13 @@ void DataLoader::next_batch(FFModel &ff,
   }
 }
 
-void DataLoader::store_outputs(BatchConfig *bc, InferenceResult const &ir) {
+void DataLoader::store_outputs(BatchConfig *bc,
+                               InferenceResult const &ir,
+                               std::map<size_t, int> &batch_predictions) {
   assert(bc->token2ids.num_samples == bc->num_active_tokens() &&
          bc->token2ids.num_samples <= bc->MAX_NUM_TOKENS);
+  batch_predictions.clear();
+  // bc->print();
   for (size_t i = 0; i < bc->token2ids.num_samples; i++) {
     if (i == bc->token2ids.num_samples - 1 ||
         bc->token2ids.guids[i] != bc->token2ids.guids[i + 1]) {
@@ -188,8 +200,28 @@ void DataLoader::store_outputs(BatchConfig *bc, InferenceResult const &ir) {
       } else {
         outputs[bc->token2ids.guids[i]].push_back(ir.results[i]);
       }
+      /* std::cout << "outputs: ";
+      for(const auto& elem : outputs){
+        std::cout << elem.first << ": [";
+        for (const auto &vel : elem.second) {
+          std::cout << vel << " ";
+        }
+        std::cout << "]" << std::endl;
+      } */
+      // std::cout << "outputs[bc->token2ids.guids[i]].size(): " <<
+      // outputs[bc->token2ids.guids[i]].size() << std::endl; std::cout << "i: "
+      // << i << std::endl; std::cout <<
+      // "bc->token2ids.token_indexes[i].token_position: " <<
+      // bc->token2ids.token_indexes[i].token_position << std::endl; std::cout
+      // << "bc->token2ids.token_indexes[i].initial_length: " <<
+      // bc->token2ids.token_indexes[i].initial_length << std::endl;
+      assert(outputs[bc->token2ids.guids[i]].size() ==
+             (bc->token2ids.token_indexes[i].token_position + 1) -
+                 (bc->token2ids.token_indexes[i].initial_length - 1));
+      batch_predictions[bc->token2ids.guids[i]] = ir.results[i];
     }
   }
+  assert(batch_predictions.size() == bc->num_active_requests());
 }
 
 void FlexFlow::register_custom_tasks() {

--- a/examples/cpp/inference/dataloader.h
+++ b/examples/cpp/inference/dataloader.h
@@ -47,11 +47,13 @@ public:
                   int bid,
                   BatchConfig *bc,
                   MachineView const *mv = nullptr);
+  void store_outputs(BatchConfig *bc, InferenceResult const &ir);
 
 public:
   size_t num_samples;
   ParallelTensor full_input;
   std::vector<ParallelTensor> batch_input;
+  std::map<size_t, std::vector<int>> outputs;
   struct DataLoaderInput {
     InferenceConfig const &_inferenceConfig;
     DataGenerator &_data_generator;

--- a/examples/cpp/inference/dataloader.h
+++ b/examples/cpp/inference/dataloader.h
@@ -46,8 +46,11 @@ public:
   void next_batch(FFModel &ff,
                   int bid,
                   BatchConfig *bc,
+                  std::map<size_t, int> &batch_predictions,
                   MachineView const *mv = nullptr);
-  void store_outputs(BatchConfig *bc, InferenceResult const &ir);
+  void store_outputs(BatchConfig *bc,
+                     InferenceResult const &ir,
+                     std::map<size_t, int> &batch_predictions);
 
 public:
   size_t num_samples;
@@ -57,5 +60,9 @@ public:
   struct DataLoaderInput {
     InferenceConfig const &_inferenceConfig;
     DataGenerator &_data_generator;
+  };
+  struct DataLoaderNextBatchInput {
+    BatchConfig::SampleIdxs const &meta;
+    std::map<size_t, int> const &prev_batch_preds;
   };
 };

--- a/examples/cpp/inference/inference_config.h
+++ b/examples/cpp/inference/inference_config.h
@@ -32,6 +32,10 @@ struct InferenceConfig {
     out_dim = DATA_DIM;
     num_labels = out_dim;
     num_layers = 3;
+
+    vocab_size = 50257;
+    block_size = 1024;
+
     //----------------------- Inference parameters ---------------------
     // total number of requests processed as part of the simulation
     total_requests = 2560;
@@ -55,6 +59,10 @@ struct InferenceConfig {
   int out_dim;
   int num_labels;
   int num_layers;
+
+  int vocab_size;
+  int block_size;
+
   std::string dataset_path;
   // Inference parameters
   int total_requests;

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -127,6 +127,8 @@ void FlexFlow::top_level_task(Task const *task,
   // Tensor t = create_moe(&ff, &moeConfig, input);
   t = ff.dense(t, moeConfig.out_dim, AC_MODE_RELU);
   t = ff.softmax(t);
+  // select most likely next token
+  Tensor output = ff.arg_top_k(t, /*k=*/1, /*sorted=*/false);
 
   //------------------- Initialize the inference manager ------------------
   InferenceManager im(

--- a/examples/cpp/inference/mixture_of_experts/moe.cc
+++ b/examples/cpp/inference/mixture_of_experts/moe.cc
@@ -131,7 +131,7 @@ void FlexFlow::top_level_task(Task const *task,
                    embed_init);
 
   //----------------------- Define the model ------------------------------
-  t = create_moe_encoder(&ff, &moeConfig, input);
+  t = create_moe_encoder(&ff, &moeConfig, t);
   // Tensor t = create_moe(&ff, &moeConfig, input);
   t = ff.dense(t, moeConfig.out_dim, AC_MODE_RELU);
   t = ff.softmax(t);

--- a/examples/cpp/inference/transformers/transformers.cc
+++ b/examples/cpp/inference/transformers/transformers.cc
@@ -102,6 +102,8 @@ void FlexFlow::top_level_task(Task const *task,
   }
   t = ff.dense(t, transformerConfig.out_dim, AC_MODE_RELU);
   t = ff.softmax(t);
+  // select most likely next token
+  Tensor output = ff.arg_top_k(t, /*k=*/1, false);
 
   //------------------- Initialize the inference manager ------------------
   InferenceManager im(&ff,

--- a/examples/cpp/inference/transformers/transformers.cc
+++ b/examples/cpp/inference/transformers/transformers.cc
@@ -175,6 +175,7 @@ void FlexFlow::top_level_task(Task const *task,
         }
         InferenceResult ir = future.get_result<InferenceResult>();
         bc = batch_configs[bid];
+        data_loader.store_outputs(bc, ir);
         processed_requests += bc->update_results(ir);
         max_reqs = transformerConfig.incremental_mode
                        ? bc->MAX_NUM_REQUESTS - bc->num_active_requests()

--- a/examples/cpp/inference/transformers/transformers.cc
+++ b/examples/cpp/inference/transformers/transformers.cc
@@ -89,14 +89,22 @@ void FlexFlow::top_level_task(Task const *task,
   //----------------------- Create inputs --------------------------------
   Tensor input;
   {
-    int const dims[] = {ffConfig.batchSize,
-                        transformerConfig.sequence_length,
-                        transformerConfig.token_dim};
-    input = ff.create_tensor<3>(dims, DT_FLOAT);
+    int const dims[] = {ffConfig.batchSize, transformerConfig.sequence_length};
+    input = ff.create_tensor<2>(dims, DT_INT32);
   }
 
   //----------------------- Define the model ------------------------------
   Tensor t = input;
+
+  Initializer *embed_init = new UniformInitializer(std::rand(), 0, 0);
+  t = ff.embedding(t,
+                   transformerConfig.vocab_size,
+                   transformerConfig.token_dim,
+                   AGGR_MODE_NONE,
+                   DT_FLOAT,
+                   NULL,
+                   embed_init);
+
   for (int i = 0; i < transformerConfig.num_layers; i++) {
     t = create_inc_multihead_attention_decoder(&ff, &transformerConfig, t);
   }
@@ -119,7 +127,7 @@ void FlexFlow::top_level_task(Task const *task,
          min_tokens_to_generate = 1,
          max_tokens_to_generate = MAX_SEQ_LEN - max_input_tokens;
   DataGenerator data_generator(transformerConfig.total_requests,
-                               transformerConfig.token_dim,
+                               transformerConfig.vocab_size,
                                min_input_tokens,
                                max_input_tokens,
                                min_tokens_to_generate,
@@ -143,7 +151,6 @@ void FlexFlow::top_level_task(Task const *task,
   double ts_start = Realm::Clock::current_time_in_microseconds();
 
   //----------------------- Begin inference! -------------------------------
-  //----------------------- Begin inference! -------------------------------
   int index = 0;
   int processed_requests = 0;
   int num_devices = ffConfig.workersPerNode * ffConfig.numNodes;
@@ -152,6 +159,7 @@ void FlexFlow::top_level_task(Task const *task,
   std::map<int, BatchConfig *> batch_configs;
   std::pair<size_t, size_t> new_prompts;
   BatchConfig *bc = nullptr;
+  std::map<size_t, int> batch_predictions[im.max_num_inflight_batches];
 
   assert(im.max_num_requests_per_batch == transformerConfig.batch_size);
   // assert(transformerConfig.batch_size <= BatchConfig::MAX_NUM_REQUESTS);
@@ -175,7 +183,7 @@ void FlexFlow::top_level_task(Task const *task,
         }
         InferenceResult ir = future.get_result<InferenceResult>();
         bc = batch_configs[bid];
-        data_loader.store_outputs(bc, ir);
+        data_loader.store_outputs(bc, ir, batch_predictions[bid]);
         processed_requests += bc->update_results(ir);
         max_reqs = transformerConfig.incremental_mode
                        ? bc->MAX_NUM_REQUESTS - bc->num_active_requests()
@@ -203,7 +211,7 @@ void FlexFlow::top_level_task(Task const *task,
       MachineView *view = im.get_machine_view(bid % im.num_devices);
 
       // runtime->begin_trace(ctx, 111 + bid % num_devices /*trace_id*/);
-      data_loader.next_batch(ff, bid, bc, view);
+      data_loader.next_batch(ff, bid, bc, batch_predictions[bid], view);
       FutureMap fm = im.inference(bid, *bc);
       // runtime->end_trace(ctx, 111 + bid % num_devices /*trace_id*/);
 

--- a/include/flexflow/batch_config.h
+++ b/include/flexflow/batch_config.h
@@ -34,7 +34,7 @@ class BatchConfig {
 public:
   BatchConfig();
   bool register_new_request(size_t guid,
-                            int initial_length,
+                            int initial_len,
                             int tokens_to_generate);
   void prepare_next_batch();
   int update_results(InferenceResult const &ir);
@@ -57,6 +57,7 @@ public:
   int num_processing_tokens[MAX_NUM_REQUESTS]; // a request's number of tokens
                                                // being processed in the current
                                                // batch/iteration
+  size_t initial_length[MAX_NUM_REQUESTS];
   size_t max_sequence_length[MAX_NUM_REQUESTS];
 
   struct token_idxs {
@@ -64,6 +65,7 @@ public:
                            // that the token belongs to
     size_t token_position; // the index indicating the position of each token
                            // within its request
+    size_t initial_length;
   };
 
   struct SampleIdxs {

--- a/include/flexflow/ffconst.h
+++ b/include/flexflow/ffconst.h
@@ -123,6 +123,7 @@ enum OperatorType {
   OP_SHAPE, // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Shape
   OP_SIZE,  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Size
   OP_TOPK,  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#TopK
+  OP_ARG_TOPK,
   OP_WHERE, // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Where
   OP_CEIL,  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Ceil
   OP_CAST,  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Cast

--- a/include/flexflow/model.h
+++ b/include/flexflow/model.h
@@ -132,6 +132,8 @@ enum TaskIDs {
   TOPK_INIT_TASK_ID,
   TOPK_FWD_TASK_ID,
   TOPK_BWD_TASK_ID,
+  ARG_TOPK_INIT_TASK_ID,
+  ARG_TOPK_INF_TASK_ID,
   TRANSPOSE_INIT_TASK_ID,
   TRANSPOSE_FWD_TASK_ID,
   TRANSPOSE_BWD_TASK_ID,
@@ -284,6 +286,7 @@ class Reshape;
 class Softmax;
 class Split;
 class TopK;
+class ArgTopK;
 class Transpose;
 class Combine;
 class Repartition;
@@ -560,6 +563,11 @@ public:
              int k,
              bool sorted,
              char const *name = NULL);
+  Tensor arg_top_k(const Tensor input,
+                   // Tensor *outputs,
+                   int k,
+                   bool sorted,
+                   char const *name = NULL);
   Tensor multihead_attention(const Tensor query,
                              const Tensor key,
                              const Tensor value,
@@ -953,6 +961,8 @@ public:
       std::unordered_map<std::pair<ParallelTensorShape, SoftmaxParams>,
                          Softmax *>,
       std::unordered_map<std::pair<ParallelTensorShape, TopKParams>, TopK *>,
+      std::unordered_map<std::pair<ParallelTensorShape, ArgTopKParams>,
+                         ArgTopK *>,
       std::unordered_map<std::pair<ParallelTensorShape, TransposeParams>,
                          Transpose *>,
       std::unordered_map<std::pair<ParallelTensorShape, RepartitionParams>,

--- a/include/flexflow/operator_params.h
+++ b/include/flexflow/operator_params.h
@@ -3,6 +3,7 @@
 
 #include "flexflow/ops/aggregate_params.h"
 #include "flexflow/ops/aggregate_spec_params.h"
+#include "flexflow/ops/arg_topk_params.h"
 #include "flexflow/ops/attention_params.h"
 #include "flexflow/ops/batch_matmul_params.h"
 #include "flexflow/ops/cast_params.h"
@@ -59,6 +60,7 @@ using OperatorParameters = mp::variant<AggregateParams,
                                        ReshapeParams,
                                        SplitParams,
                                        TopKParams,
+                                       ArgTopKParams,
                                        SoftmaxParams,
                                        TransposeParams,
                                        RepartitionParams,

--- a/include/flexflow/ops/arg_topk.h
+++ b/include/flexflow/ops/arg_topk.h
@@ -1,0 +1,97 @@
+#ifndef _FLEXFLOW_ARG_TOPK_H_
+#define _FLEXFLOW_ARG_TOPK_H_
+
+#include "flexflow/inference.h"
+#include "flexflow/model.h"
+#include "flexflow/node.h"
+#include "flexflow/ops/arg_topk_params.h"
+
+namespace FlexFlow {
+
+class ArgTopKMeta : public OpMeta {
+public:
+  ArgTopKMeta(FFHandler handle);
+  bool sorted;
+};
+
+class ArgTopK : public Op {
+public:
+  using Params = ArgTopKParams;
+  using Input = ParallelTensor;
+  ArgTopK(FFModel &model,
+          const ParallelTensor input,
+          int k,
+          bool sorted,
+          char const *name);
+  ArgTopK(FFModel &model, ArgTopK const &other, const ParallelTensor input);
+  ArgTopK(FFModel &model,
+          Params const &params,
+          Input const input,
+          char const *name = nullptr);
+  void init(FFModel const &) override;
+  void init_inference(FFModel const &,
+                      std::vector<ParallelTensor> const &,
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
+  void forward(FFModel const &) override;
+  void backward(FFModel const &) override;
+  Legion::FutureMap inference(FFModel const &,
+                              BatchConfig const &,
+                              std::vector<ParallelTensor> const &,
+                              std::vector<ParallelTensor> const &,
+                              MachineView const *mv = nullptr) override;
+  void print_layer(FFModel const &model) override {
+    assert(0);
+  }
+  static Op *
+      create_operator_from_layer(FFModel &model,
+                                 Layer const *layer,
+                                 std::vector<ParallelTensor> const &inputs);
+
+  static OpMeta *init_task(Legion::Task const *task,
+                           std::vector<Legion::PhysicalRegion> const &regions,
+                           Legion::Context ctx,
+                           Legion::Runtime *runtime);
+  static InferenceResult
+      inference_task(Legion::Task const *task,
+                     std::vector<Legion::PhysicalRegion> const &regions,
+                     Legion::Context ctx,
+                     Legion::Runtime *runtime);
+  void serialize(Legion::Serializer &s) const override;
+  static PCG::Node deserialize(FFModel &ff,
+                               Legion::Deserializer &d,
+                               ParallelTensor inputs[],
+                               int num_inputs);
+  Op *materialize(FFModel &ff,
+                  ParallelTensor inputs[],
+                  int num_inputs) const override;
+  bool measure_operator_cost(Simulator *sim,
+                             MachineView const &pc,
+                             CostMetrics &cost_metrics) const override;
+  static void forward_kernel(ArgTopKMeta const *m,
+                             float const *input_ptr,
+                             // float *output_ptr,
+                             int *indices_ptr,
+                             size_t batch_size,
+                             int length,
+                             int k,
+                             bool sorted,
+                             ffStream_t stream);
+  static void forward_kernel_wrapper(ArgTopKMeta const *m,
+                                     float const *input_ptr,
+                                     // float *output_ptr,
+                                     int *indices_ptr,
+                                     size_t batch_size,
+                                     int length,
+                                     int k,
+                                     bool sorted);
+  Params get_params() const;
+
+public:
+  int k;
+  bool sorted;
+};
+
+}; // namespace FlexFlow
+
+#endif

--- a/include/flexflow/ops/arg_topk_params.h
+++ b/include/flexflow/ops/arg_topk_params.h
@@ -1,0 +1,25 @@
+#ifndef _FLEXFLOW_ARG_TOPK_PARAMS_H
+#define _FLEXFLOW_ARG_TOPK_PARAMS_H
+
+#include "flexflow/ffconst.h"
+#include "flexflow/parallel_tensor.h"
+
+namespace FlexFlow {
+
+struct ArgTopKParams {
+  int k;
+  bool sorted;
+  bool is_valid(ParallelTensorShape const &) const;
+};
+bool operator==(ArgTopKParams const &, ArgTopKParams const &);
+
+} // namespace FlexFlow
+
+namespace std {
+template <>
+struct hash<FlexFlow::ArgTopKParams> {
+  size_t operator()(FlexFlow::ArgTopKParams const &) const;
+};
+} // namespace std
+
+#endif // _FLEXFLOW_ARG_TOPK_PARAMS_H

--- a/include/flexflow/ops/embedding.h
+++ b/include/flexflow/ops/embedding.h
@@ -49,8 +49,17 @@ public:
             bool allocate_weights = false,
             char const *name = nullptr);
   void init(FFModel const &) override;
+  void init_inference(FFModel const &,
+                      std::vector<ParallelTensor> const &,
+                      std::vector<ParallelTensor> const &,
+                      MachineView const *mv = nullptr) override;
   void forward(FFModel const &) override;
   void backward(FFModel const &) override;
+  Legion::FutureMap inference(FFModel const &,
+                              BatchConfig const &,
+                              std::vector<ParallelTensor> const &,
+                              std::vector<ParallelTensor> const &,
+                              MachineView const *mv = nullptr) override;
   // void update(const FFModel&);
   void print_layer(FFModel const &model) override {
     assert(0);

--- a/include/flexflow/utils/cuda_helper.h
+++ b/include/flexflow/utils/cuda_helper.h
@@ -136,6 +136,9 @@ void print_tensor(T const *ptr, size_t num_elements, char const *prefix);
 template <typename T>
 T *download_tensor(T const *ptr, size_t num_elements);
 
+template <typename T>
+bool download_tensor(T const *ptr, T *dst, size_t num_elements);
+
 cudnnStatus_t cudnnSetTensorDescriptorFromDomain(cudnnTensorDescriptor_t tensor,
                                                  Legion::Domain domain);
 

--- a/src/ops/arg_topk.cc
+++ b/src/ops/arg_topk.cc
@@ -1,0 +1,380 @@
+/* Copyright 2023 CMU, Facebook, LANL, MIT, NVIDIA, and Stanford (alphabetical)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flexflow/ops/arg_topk.h"
+#include "flexflow/model.h"
+#include "flexflow/utils/hash_utils.h"
+#include "legion/legion_utilities.h"
+
+namespace FlexFlow {
+// declare Legion names
+using Legion::ArgumentMap;
+using Legion::Context;
+using Legion::coord_t;
+using Legion::Domain;
+using Legion::FutureMap;
+using Legion::IndexLauncher;
+using Legion::InlineLauncher;
+using Legion::Machine;
+using Legion::Memory;
+using Legion::PhysicalRegion;
+using Legion::Predicate;
+using Legion::Rect;
+using Legion::RegionRequirement;
+using Legion::Runtime;
+using Legion::Task;
+using Legion::TaskArgument;
+using Legion::TaskLauncher;
+using PCG::Node;
+
+// For an input tensor, computes the top k entries in each row
+// (resp. vector along the last dimension). Thus,
+// values.shape = indices.shape = input.shape[:-1] + [k]
+Tensor FFModel::arg_top_k(const Tensor input,
+                          int k,
+                          bool sorted,
+                          char const *name) {
+  Layer *li = new Layer(this,
+                        OP_ARG_TOPK,
+                        input->data_type,
+                        name,
+                        1 /*inputs*/,
+                        0 /*weights*/,
+                        1 /*outputs*/,
+                        input);
+  {
+    int numdims = input->num_dims;
+    int dims[MAX_TENSOR_DIM];
+    for (int i = 0; i < numdims; i++) {
+      dims[i] = input->dims[i];
+    }
+    dims[0] = k;
+    // li->outputs[0] = create_tensor_legion_ordering(
+    //     numdims, dims, input->data_type, li, 0, true /*create_grad*/);
+    li->outputs[0] = create_tensor_legion_ordering(
+        numdims, dims, DT_INT32, li, 0, false /*create_grad*/);
+  }
+  li->add_int_property("k", k);
+  li->add_int_property("sorted", sorted);
+  layers.push_back(li);
+  // outputs[0] = li->outputs[0];
+  // outputs[1] = li->outputs[1];
+  return li->outputs[0];
+}
+
+Op *ArgTopK::create_operator_from_layer(
+    FFModel &model,
+    Layer const *layer,
+    std::vector<ParallelTensor> const &inputs) {
+  long long value;
+  layer->get_int_property("k", value);
+  int k = value;
+  layer->get_int_property("sorted", value);
+  bool sorted = (bool)value;
+  return new ArgTopK(model, inputs[0], k, sorted, layer->name);
+}
+
+ArgTopKParams ArgTopK::get_params() const {
+  ArgTopKParams params;
+  params.k = this->k;
+  params.sorted = this->sorted;
+  return params;
+}
+
+bool ArgTopKParams::is_valid(ParallelTensorShape const &) const {
+  // topk is always valid
+  return true;
+}
+
+bool operator==(ArgTopKParams const &lhs, ArgTopKParams const &rhs) {
+  return lhs.k == rhs.k && lhs.sorted == rhs.sorted;
+}
+
+ArgTopK::ArgTopK(FFModel &model,
+                 const ParallelTensor _input,
+                 int _k,
+                 bool _sorted,
+                 char const *name)
+    : Op(model,
+         OP_ARG_TOPK,
+         _input->data_type,
+         name,
+         1 /*inputs*/,
+         0 /*weights*/,
+         1 /*outputs*/,
+         _input),
+      k(_k), sorted(_sorted) {
+  int numdim = inputs[0]->num_dims;
+  ParallelDim dims[MAX_TENSOR_DIM];
+  for (int i = 0; i < numdim; i++) {
+    dims[i] = inputs[0]->dims[i];
+  }
+  dims[0].size = k;
+  assert(inputs[0]->dims[0].degree == 1);
+  assert(inputs[0]->dims[0].parallel_idx == -1);
+  //   outputs[0] = model.create_parallel_tensor_legion_ordering(
+  //       numdim, dims, _input->data_type, this, 0 /*owner_idx*/);
+  outputs[0] = model.create_parallel_tensor_legion_ordering(
+      numdim, dims, DT_INT32, this, 0 /*owner_idx*/);
+}
+
+ArgTopK::ArgTopK(FFModel &model,
+                 ArgTopK const &other,
+                 const ParallelTensor input)
+    : ArgTopK(model, input, other.k, other.sorted, other.name) {}
+
+ArgTopK::ArgTopK(FFModel &model,
+                 ArgTopKParams const &params,
+                 const ParallelTensor input,
+                 char const *name)
+    : ArgTopK(model, input, params.k, params.sorted, name) {}
+
+void ArgTopK::init_inference(FFModel const &ff,
+                             std::vector<ParallelTensor> const &batch_inputs,
+                             std::vector<ParallelTensor> const &batch_outputs,
+                             MachineView const *mv) {
+  assert(check_output_input_weight_same_parallel_is());
+  parallel_is = batch_outputs[0]->parallel_is;
+  ArgumentMap argmap;
+  Context ctx = ff.config.lg_ctx;
+  Runtime *runtime = ff.config.lg_hlr;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
+  IndexLauncher launcher(ARG_TOPK_INIT_TASK_ID,
+                         parallel_is,
+                         TaskArgument(this, sizeof(ArgTopK)),
+                         argmap,
+                         Predicate::TRUE_PRED,
+                         false /*must*/,
+                         0 /*mapper_id*/,
+                         machine_view_hash);
+  launcher.add_region_requirement(RegionRequirement(batch_inputs[0]->part,
+                                                    0 /*projection id*/,
+                                                    READ_ONLY,
+                                                    EXCLUSIVE,
+                                                    batch_inputs[0]->region));
+  launcher.add_field(0, FID_DATA);
+  launcher.add_region_requirement(RegionRequirement(batch_outputs[0]->part,
+                                                    0 /*projection id*/,
+                                                    WRITE_ONLY,
+                                                    EXCLUSIVE,
+                                                    batch_outputs[0]->region));
+  launcher.add_field(1, FID_DATA);
+  //   launcher.add_region_requirement(RegionRequirement(batch_outputs[1]->part,
+  //                                                     0 /*projection id*/,
+  //                                                     WRITE_ONLY,
+  //                                                     EXCLUSIVE,
+  //                                                     batch_outputs[1]->region));
+  //   launcher.add_field(2, FID_DATA);
+  FutureMap fm = runtime->execute_index_space(ctx, launcher);
+  fm.wait_all_results();
+  set_opmeta_from_futuremap_inference(ff, fm, view);
+}
+
+void ArgTopK::init(FFModel const &ff) {
+  assert(check_output_input_weight_same_parallel_is());
+  parallel_is = outputs[0]->parallel_is;
+  ArgumentMap argmap;
+  Context ctx = ff.config.lg_ctx;
+  Runtime *runtime = ff.config.lg_hlr;
+  set_argumentmap_for_init(ff, argmap);
+  IndexLauncher launcher(ARG_TOPK_INIT_TASK_ID,
+                         parallel_is,
+                         TaskArgument(this, sizeof(ArgTopK)),
+                         argmap,
+                         Predicate::TRUE_PRED,
+                         false /*must*/,
+                         0 /*mapper_id*/,
+                         outputs[0]->machine_view.hash());
+  launcher.add_region_requirement(RegionRequirement(inputs[0]->part,
+                                                    0 /*projection id*/,
+                                                    READ_ONLY,
+                                                    EXCLUSIVE,
+                                                    inputs[0]->region));
+  launcher.add_field(0, FID_DATA);
+  launcher.add_region_requirement(RegionRequirement(outputs[0]->part,
+                                                    0 /*projection id*/,
+                                                    WRITE_ONLY,
+                                                    EXCLUSIVE,
+                                                    outputs[0]->region));
+  launcher.add_field(1, FID_DATA);
+  //   launcher.add_region_requirement(RegionRequirement(outputs[1]->part,
+  //                                                     0 /*projection id*/,
+  //                                                     WRITE_ONLY,
+  //                                                     EXCLUSIVE,
+  //                                                     outputs[1]->region));
+  //   launcher.add_field(2, FID_DATA);
+  FutureMap fm = runtime->execute_index_space(ctx, launcher);
+  fm.wait_all_results();
+  set_opmeta_from_futuremap(ff, fm);
+}
+
+OpMeta *ArgTopK::init_task(Task const *task,
+                           std::vector<PhysicalRegion> const &regions,
+                           Context ctx,
+                           Runtime *runtime) {
+  ArgTopK *topk = (ArgTopK *)task->args;
+  FFHandler handle = *((FFHandler *)task->local_args);
+  ArgTopKMeta *m = new ArgTopKMeta(handle);
+  m->profiling = topk->profiling;
+  m->sorted = topk->sorted;
+  return m;
+}
+
+void ArgTopK::forward(FFModel const &ff) {
+  // ArgTopK does not support forward
+  assert(false);
+}
+
+FutureMap ArgTopK::inference(FFModel const &ff,
+                             BatchConfig const &bc,
+                             std::vector<ParallelTensor> const &batch_inputs,
+                             std::vector<ParallelTensor> const &batch_outputs,
+                             MachineView const *mv) {
+  ArgumentMap argmap;
+  Context ctx = ff.config.lg_ctx;
+  Runtime *runtime = ff.config.lg_hlr;
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+  /* std::cout << "ArgTopK op machine_view: " << *(MachineView const *)mv
+            << std::endl; */
+  IndexLauncher launcher(ARG_TOPK_INF_TASK_ID,
+                         parallel_is,
+                         TaskArgument(NULL, 0),
+                         argmap,
+                         Predicate::TRUE_PRED,
+                         false /*must*/,
+                         0 /*mapper_id*/,
+                         machine_view_hash);
+  launcher.add_region_requirement(RegionRequirement(batch_inputs[0]->part,
+                                                    0 /*projection id*/,
+                                                    READ_ONLY,
+                                                    EXCLUSIVE,
+                                                    batch_inputs[0]->region));
+  launcher.add_field(0, FID_DATA);
+  launcher.add_region_requirement(RegionRequirement(batch_outputs[0]->part,
+                                                    0 /*projection id*/,
+                                                    WRITE_ONLY,
+                                                    EXCLUSIVE,
+                                                    batch_outputs[0]->region));
+  launcher.add_field(1, FID_DATA);
+  //   launcher.add_region_requirement(RegionRequirement(batch_outputs[1]->part,
+  //                                                     0 /*projection id*/,
+  //                                                     WRITE_ONLY,
+  //                                                     EXCLUSIVE,
+  //                                                     batch_outputs[1]->region));
+  //   launcher.add_field(2, FID_DATA);
+  return runtime->execute_index_space(ctx, launcher);
+}
+
+InferenceResult
+    ArgTopK::inference_task(Task const *task,
+                            std::vector<PhysicalRegion> const &regions,
+                            Context ctx,
+                            Runtime *runtime) {
+  assert(regions.size() == 3);
+  assert(task->regions.size() == 3);
+  // const ArgTopK* topk = (const ArgTopK*) task->args;
+  ArgTopKMeta const *m = *((ArgTopKMeta **)task->local_args);
+  Domain in1_domain = runtime->get_index_space_domain(
+      ctx, task->regions[0].region.get_index_space());
+  //   Domain out1_domain = runtime->get_index_space_domain(
+  //       ctx, task->regions[1].region.get_index_space());
+  Domain out2_domain = runtime->get_index_space_domain(
+      ctx, task->regions[2].region.get_index_space());
+
+  int in_cols = in1_domain.hi()[0] - in1_domain.lo()[0] + 1;
+  // int out1_cols = out1_domain.hi()[0] - out1_domain.lo()[0] + 1;
+  int out2_cols = out2_domain.hi()[0] - out2_domain.lo()[0] + 1;
+
+  // assert(out1_domain == out2_domain);
+  for (int i = 1; i < in1_domain.get_dim(); i++) {
+    assert(in1_domain.lo()[i] == out2_domain.lo()[i]);
+    assert(in1_domain.hi()[i] == out2_domain.hi()[i]);
+  }
+  float const *in_ptr = helperGetTensorPointerRO<float>(
+      regions[0], task->regions[0], FID_DATA, ctx, runtime);
+  //   float *value_ptr = helperGetTensorPointerWO<float>(
+  //       regions[1], task->regions[1], FID_DATA, ctx, runtime);
+  int *index_ptr = helperGetTensorPointerWO<int>(
+      regions[2], task->regions[2], FID_DATA, ctx, runtime);
+
+  int length = in1_domain.hi()[0] - in1_domain.lo()[0] + 1;
+  int k =
+      out2_domain.hi()[0] - out2_domain.lo()[0] + 1; /*TODO: This prints to 5*/
+  size_t batch_size = in1_domain.get_volume() / length;
+
+  ArgTopK::forward_kernel_wrapper(
+      m, in_ptr, index_ptr, batch_size, length, k, m->sorted);
+
+  InferenceResult ir;
+  assert(!ir.done);
+  ir.done = true;
+  assert(ir.done);
+  return ir;
+}
+
+void ArgTopK::backward(FFModel const &ff) {
+  // ArgTopK does not support backward
+  assert(false);
+}
+
+void ArgTopK::serialize(Legion::Serializer &sez) const {
+  sez.serialize(this->k);
+  sez.serialize(this->sorted);
+}
+
+Node ArgTopK::deserialize(FFModel &ff,
+                          Legion::Deserializer &dez,
+                          ParallelTensor inputs[],
+                          int num_inputs) {
+  assert(num_inputs == 1);
+  int k;
+  bool sorted;
+  dez.deserialize(k);
+  dez.deserialize(sorted);
+  ArgTopKParams params;
+  params.k = k;
+  params.sorted = sorted;
+  return ff.get_or_create_node<ArgTopK>(inputs[0], params);
+}
+
+Op *ArgTopK::materialize(FFModel &ff,
+                         ParallelTensor inputs[],
+                         int num_inputs) const {
+  ArgTopKParams params = get_params();
+  return new ArgTopK(ff, params, inputs[0], this->name);
+}
+
+bool ArgTopK::measure_operator_cost(Simulator *sim,
+                                    MachineView const &mv,
+                                    CostMetrics &cost_metrics) const {
+  return false;
+}
+
+}; // namespace FlexFlow
+
+namespace std {
+size_t hash<FlexFlow::ArgTopKParams>::operator()(
+    FlexFlow::ArgTopKParams const &params) const {
+  size_t key = 0;
+  hash_combine(key, params.k);
+  hash_combine(key, params.sorted);
+  return key;
+}
+}; // namespace std

--- a/src/ops/arg_topk.cpp
+++ b/src/ops/arg_topk.cpp
@@ -1,0 +1,450 @@
+/* Copyright 2023 CMU, Facebook, LANL, MIT, NVIDIA, and Stanford (alphabetical)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flexflow/ops/arg_topk.h"
+#include "flexflow/utils/hip_helper.h"
+#include <hip/hip_runtime.h>
+
+namespace FlexFlow {
+// declare Legion names
+using Legion::coord_t;
+
+enum class HeapType { kMinHeap, kMaxHeap };
+enum class PreferIndices { kLower, kHigher };
+
+template <typename T>
+struct Entry {
+  int index;
+  T value;
+};
+
+template <typename T>
+struct LinearData {
+  typedef Entry<T> Entry;
+
+  __device__ Entry &operator[](std::size_t index) const {
+    return data[index];
+  }
+
+  __device__ int get_index(int i) const {
+    return data[i].index;
+  }
+  __device__ T get_value(int i) const {
+    return data[i].value;
+  }
+
+  Entry *const data;
+};
+
+template <typename T>
+struct IndirectLinearData {
+  typedef Entry<T> Entry;
+
+  __device__ Entry &operator[](std::size_t index) const {
+    return data[index];
+  }
+
+  __device__ int get_index(int i) const {
+    return backing_data[data[i].index].index;
+  }
+  __device__ T get_value(int i) const {
+    return data[i].value;
+  }
+
+  Entry *const data;
+  Entry *const backing_data;
+};
+
+template <typename T>
+struct StridedData {
+  typedef Entry<T> Entry;
+
+  __device__ Entry &operator[](std::size_t index) const {
+    return data[index * blockDim.x + threadIdx.x];
+  }
+
+  __device__ int get_index(int i) const {
+    return (*this)[i].index;
+  }
+  __device__ T get_value(int i) const {
+    return (*this)[i].value;
+  }
+
+  Entry *const data;
+};
+
+// A heap of Entry<T> that can either work as a min-heap or as a max-heap.
+template <HeapType heapType,
+          PreferIndices preferIndices,
+          template <typename>
+          class Data,
+          typename T>
+struct IndexedHeap {
+  typedef typename Data<T>::Entry Entry;
+  Data<T> const data;
+  __device__ IndexedHeap(Data<T> const &d) : data(d) {}
+
+  __device__ bool is_above(int left, int right) {
+    T left_value = data.get_value(left);
+    T right_value = data.get_value(right);
+    if (left_value == right_value) {
+      if (preferIndices == PreferIndices::kLower) {
+        return data.get_index(left) < data.get_index(right);
+      } else {
+        return data.get_index(left) > data.get_index(right);
+      }
+    }
+    if (heapType == HeapType::kMinHeap) {
+      return left_value < right_value;
+    } else {
+      return left_value > right_value;
+    }
+  }
+
+  __device__ void assign(int i, Entry const &entry) {
+    data[i] = entry;
+  }
+
+  __device__ void push_up(int i) {
+    int child = i;
+    int parent;
+    for (; child > 0; child = parent) {
+      parent = (child - 1) / 2;
+      if (!is_above(child, parent)) {
+        // Heap property satisfied.
+        break;
+      }
+      swap(child, parent);
+    }
+  }
+
+  __device__ void swap(int a, int b) {
+    auto tmp = data[b];
+    data[b] = data[a];
+    data[a] = tmp;
+  }
+
+  __device__ void push_root_down(int k) {
+    push_down(0, k);
+  }
+
+  // MAX-HEAPIFY in Cormen
+  __device__ void push_down(int node, int k) {
+    while (true) {
+      int const left = 2 * node + 1;
+      int const right = left + 1;
+      int smallest = node;
+      if (left < k && is_above(left, smallest)) {
+        smallest = left;
+      }
+      if (right < k && is_above(right, smallest)) {
+        smallest = right;
+      }
+      if (smallest == node) {
+        break;
+      }
+      swap(smallest, node);
+      node = smallest;
+    }
+  }
+
+  // BUILD-MAX-HEAPIFY in Cormen
+  __device__ void build(int k) {
+    for (int node = (k - 1) / 2; node >= 0; node--) {
+      push_down(node, k);
+    }
+  }
+
+  // HEAP-EXTRACT-MAX in Cormen
+  __device__ void remove_root(int k) {
+    data[0] = data[k - 1];
+    push_root_down(k - 1);
+  }
+
+  // in-place HEAPSORT in Cormen
+  // This method destroys the heap property.
+  __device__ void sort(int k) {
+    for (int slot = k - 1; slot > 0; slot--) {
+      // This is like remove_root but we insert the element at the end.
+      swap(slot, 0);
+      // Heap is now an element smaller.
+      push_root_down(/*k=*/slot);
+    }
+  }
+
+  __device__ void replace_root(Entry const &entry, int k) {
+    data[0] = entry;
+    push_root_down(k);
+  }
+
+  __device__ Entry const &root() {
+    return data[0];
+  }
+};
+
+template <HeapType heapType,
+          PreferIndices preferIndices,
+          template <typename>
+          class Data,
+          typename T>
+__device__ IndexedHeap<heapType, preferIndices, Data, T>
+    make_indexed_heap(typename Data<T>::Entry *data) {
+  return IndexedHeap<heapType, preferIndices, Data, T>{Data<T>{data}};
+}
+
+// heapArgTopK walks over [input, input+length) with `step_size` stride starting
+// at `start_index`. It builds a top-`k` heap that is stored in `heap_entries`
+// using `Accessor` to access elements in `heap_entries`. If sorted=true, the
+// elements will be sorted at the end.
+template <typename T, template <typename> class Data = LinearData>
+__device__ void heapArgTopK(T const *__restrict__ input,
+                            int length,
+                            int k,
+                            Entry<T> *__restrict__ heap_entries,
+                            bool sorted = false,
+                            int start_index = 0,
+                            int step_size = 1) {
+  assert(k <= length);
+
+  auto heap =
+      make_indexed_heap<HeapType::kMinHeap, PreferIndices::kHigher, Data, T>(
+          heap_entries);
+
+  int heap_end_index = start_index + k * step_size;
+  if (heap_end_index > length) {
+    heap_end_index = length;
+  }
+  // Initialize the min-heap.
+  for (int index = start_index, slot = 0; index < heap_end_index;
+       index += step_size, slot++) {
+    heap.assign(slot, {index, input[index]});
+  }
+
+  heap.build(k);
+
+  // Now iterate over the remaining items.
+  // If an item is smaller than the min element, it is not amongst the top k.
+  // Otherwise, replace the min element with it and push upwards.
+  for (int index = heap_end_index; index < length; index += step_size) {
+    // We prefer elements with lower indices. This is given here.
+    // Later elements automatically have higher indices, so can be discarded.
+    if (input[index] > heap.root().value) {
+      // This element should replace the min.
+      heap.replace_root({index, input[index]}, k);
+    }
+  }
+
+  // Sort if wanted.
+  if (sorted) {
+    heap.sort(k);
+  }
+}
+
+// mergeShards performs a top-k merge on `num_shards` many sorted streams that
+// are sorted and stored in `entries` in a strided way:
+// |s_1 1st|s_2 1st|...s_{num_shards} 1st|s_1 2nd|s_2 2nd|...
+// The overall top k elements are written to `top_k_values` and their indices
+// to top_k_indices.
+// `top_k_heap` is used as temporary storage for the merge heap.
+template <typename T>
+__device__ void mergeShards(int num_shards,
+                            int k,
+                            Entry<T> *__restrict__ entries,
+                            Entry<T> *__restrict__ top_k_heap,
+                            // T *top_k_values,
+                            int *top_k_indices) {
+  // If k < num_shards, we can use a min-heap with k elements to get the top k
+  // of the sorted blocks.
+  // If k > num_shards, we can initialize a min-heap with the top element from
+  // each sorted block.
+  int const heap_size = k < num_shards ? k : num_shards;
+
+  // Min-heap part.
+  {
+    auto min_heap = IndexedHeap<HeapType::kMinHeap,
+                                PreferIndices::kHigher,
+                                IndirectLinearData,
+                                T>{IndirectLinearData<T>{top_k_heap, entries}};
+    // Initialize the heap as a min-heap.
+    for (int slot = 0; slot < heap_size; slot++) {
+      min_heap.assign(slot, {slot, entries[slot].value});
+    }
+    min_heap.build(heap_size);
+
+    // Now perform top k with the remaining shards (if num_shards > heap_size).
+    for (int shard = heap_size; shard < num_shards; shard++) {
+      auto const entry = entries[shard];
+      auto const root = min_heap.root();
+      if (entry.value < root.value) {
+        continue;
+      }
+      if (entry.value == root.value &&
+          entry.index > entries[root.index].index) {
+        continue;
+      }
+      // This element should replace the min.
+      min_heap.replace_root({shard, entry.value}, heap_size);
+    }
+  }
+
+  // Max-part.
+  {
+    // Turn the min-heap into a max-heap in-place.
+    auto max_heap = IndexedHeap<HeapType::kMaxHeap,
+                                PreferIndices::kLower,
+                                IndirectLinearData,
+                                T>{IndirectLinearData<T>{top_k_heap, entries}};
+    // Heapify into a max heap.
+    max_heap.build(heap_size);
+
+    // Now extract the minimum k-1 times.
+    // k is treated specially.
+    int const last_k = k - 1;
+    for (int rank = 0; rank < last_k; rank++) {
+      Entry<T> const &max_element = max_heap.root();
+      // top_k_values[rank] = max_element.value;
+      int shard_index = max_element.index;
+      top_k_indices[rank] = entries[shard_index].index;
+      int next_shard_index = shard_index + num_shards;
+      // For rank < k-1, each top k heap still contains at least 1 element,
+      // so we can draw a replacement.
+      max_heap.replace_root({next_shard_index, entries[next_shard_index].value},
+                            heap_size);
+    }
+
+    // rank == last_k.
+    Entry<T> const &max_element = max_heap.root();
+    // top_k_values[last_k] = max_element.value;
+    int shard_index = max_element.index;
+    top_k_indices[last_k] = entries[shard_index].index;
+  }
+}
+
+template <typename T>
+__global__ void arg_topk_forward_kernel(T const *__restrict__ input,
+                                        size_t shared_memory_size,
+                                        int length,
+                                        int k,
+                                        bool sorted,
+                                        // T *__restrict__ output,
+                                        int *__restrict__ indices) {
+  __shared__ char shared_memory[48 << 10];
+  int const batch_index = blockIdx.x;
+  T const *batch_input = input + batch_index * length;
+  int const thread_index = threadIdx.x;
+  int const thread_count = blockDim.x;
+  Entry<T> *shared_entries = (Entry<T> *)shared_memory;
+  heapArgTopK<T, StridedData>(
+      batch_input, length, k, shared_entries, true, thread_index, thread_count);
+  __syncthreads();
+  if (thread_index == 0) {
+    int const offset = batch_index * k;
+    // auto batch_output = output + offset;
+    auto batch_indices = indices + offset;
+    Entry<T> *top_k_heap = shared_entries + thread_count * k;
+    mergeShards(thread_count,
+                k,
+                shared_entries,
+                top_k_heap,
+                // batch_output,
+                batch_indices);
+  }
+}
+
+/*static*/
+void ArgTopK::forward_kernel(ArgTopKMeta const *m,
+                             float const *input_ptr,
+                             // float *output_ptr,
+                             int *indices_ptr,
+                             size_t batch_size,
+                             int length,
+                             int k,
+                             bool sorted,
+                             hipStream_t stream) {
+  // Adopted from TensorFlow's ArgTopK implementation
+  // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/topk_op_gpu.h
+  int num_shards = 0;
+  {
+    constexpr auto shared_memory_size = 48 << 10;
+    auto const heap_size = k * sizeof(Entry<float>);
+    // shared_memory_size = (num_shards + 1) * heap_size <=>
+    num_shards = shared_memory_size / heap_size - 1;
+    assert(num_shards > 0);
+    if (num_shards > CUDA_NUM_THREADS) {
+      num_shards = CUDA_NUM_THREADS;
+    }
+  }
+  // We are limited by the amount of shared memory we have per block.
+  size_t shared_memory_size = (num_shards + 1) * k * sizeof(Entry<float>);
+  // size_t num_blocks = (batch_size + num_shards - 1) / num_shards;
+  size_t num_blocks = batch_size;
+  assert(num_shards >= (size_t)k);
+  num_shards = k;
+  hipLaunchKernelGGL(arg_topk_forward_kernel,
+                     num_blocks,
+                     num_shards,
+                     0,
+                     stream,
+                     input_ptr,
+                     shared_memory_size,
+                     length,
+                     k,
+                     sorted,
+                     // output_ptr,
+                     indices_ptr);
+}
+
+/*static*/
+void ArgTopK::forward_kernel_wrapper(ArgTopKMeta const *m,
+                                     float const *input_ptr,
+                                     // float *output_ptr,
+                                     int *indices_ptr,
+                                     size_t batch_size,
+                                     int length,
+                                     int k,
+                                     bool sorted) {
+  hipStream_t stream;
+  checkCUDA(get_legion_stream(&stream));
+
+  hipEvent_t t_start, t_end;
+  if (m->profiling) {
+    hipEventCreate(&t_start);
+    hipEventCreate(&t_end);
+    hipEventRecord(t_start, stream);
+  }
+
+  ArgTopK::forward_kernel(m,
+                          input_ptr,
+                          // output_ptr,
+                          indices_ptr,
+                          batch_size,
+                          length,
+                          k,
+                          sorted,
+                          stream);
+
+  if (m->profiling) {
+    hipEventRecord(t_end, stream);
+    checkCUDA(hipEventSynchronize(t_end));
+    float elapsed = 0;
+    checkCUDA(hipEventElapsedTime(&elapsed, t_start, t_end));
+    hipEventDestroy(t_start);
+    hipEventDestroy(t_end);
+  }
+}
+
+ArgTopKMeta::ArgTopKMeta(FFHandler handler) : OpMeta(handler) {}
+
+}; // namespace FlexFlow

--- a/src/ops/arg_topk.cu
+++ b/src/ops/arg_topk.cu
@@ -1,0 +1,446 @@
+/* Copyright 2023 CMU, Facebook, LANL, MIT, NVIDIA, and Stanford (alphabetical)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flexflow/ops/arg_topk.h"
+#include "flexflow/utils/cuda_helper.h"
+
+namespace FlexFlow {
+// declare Legion names
+using Legion::coord_t;
+
+enum class HeapType { kMinHeap, kMaxHeap };
+enum class PreferIndices { kLower, kHigher };
+
+template <typename T>
+struct Entry {
+  int index;
+  T value;
+};
+
+template <typename T>
+struct LinearData {
+  typedef Entry<T> Entry;
+
+  __device__ Entry &operator[](std::size_t index) const {
+    return data[index];
+  }
+
+  __device__ int get_index(int i) const {
+    return data[i].index;
+  }
+  __device__ T get_value(int i) const {
+    return data[i].value;
+  }
+
+  Entry *const data;
+};
+
+template <typename T>
+struct IndirectLinearData {
+  typedef Entry<T> Entry;
+
+  __device__ Entry &operator[](std::size_t index) const {
+    return data[index];
+  }
+
+  __device__ int get_index(int i) const {
+    return backing_data[data[i].index].index;
+  }
+  __device__ T get_value(int i) const {
+    return data[i].value;
+  }
+
+  Entry *const data;
+  Entry *const backing_data;
+};
+
+template <typename T>
+struct StridedData {
+  typedef Entry<T> Entry;
+
+  __device__ Entry &operator[](std::size_t index) const {
+    return data[index * blockDim.x + threadIdx.x];
+  }
+
+  __device__ int get_index(int i) const {
+    return (*this)[i].index;
+  }
+  __device__ T get_value(int i) const {
+    return (*this)[i].value;
+  }
+
+  Entry *const data;
+};
+
+// A heap of Entry<T> that can either work as a min-heap or as a max-heap.
+template <HeapType heapType,
+          PreferIndices preferIndices,
+          template <typename>
+          class Data,
+          typename T>
+struct IndexedHeap {
+  typedef typename Data<T>::Entry Entry;
+  Data<T> const data;
+  __device__ IndexedHeap(Data<T> const &d) : data(d) {}
+
+  __device__ bool is_above(int left, int right) {
+    T left_value = data.get_value(left);
+    T right_value = data.get_value(right);
+    if (left_value == right_value) {
+      if (preferIndices == PreferIndices::kLower) {
+        return data.get_index(left) < data.get_index(right);
+      } else {
+        return data.get_index(left) > data.get_index(right);
+      }
+    }
+    if (heapType == HeapType::kMinHeap) {
+      return left_value < right_value;
+    } else {
+      return left_value > right_value;
+    }
+  }
+
+  __device__ void assign(int i, Entry const &entry) {
+    data[i] = entry;
+  }
+
+  __device__ void push_up(int i) {
+    int child = i;
+    int parent;
+    for (; child > 0; child = parent) {
+      parent = (child - 1) / 2;
+      if (!is_above(child, parent)) {
+        // Heap property satisfied.
+        break;
+      }
+      swap(child, parent);
+    }
+  }
+
+  __device__ void swap(int a, int b) {
+    auto tmp = data[b];
+    data[b] = data[a];
+    data[a] = tmp;
+  }
+
+  __device__ void push_root_down(int k) {
+    push_down(0, k);
+  }
+
+  // MAX-HEAPIFY in Cormen
+  __device__ void push_down(int node, int k) {
+    while (true) {
+      int const left = 2 * node + 1;
+      int const right = left + 1;
+      int smallest = node;
+      if (left < k && is_above(left, smallest)) {
+        smallest = left;
+      }
+      if (right < k && is_above(right, smallest)) {
+        smallest = right;
+      }
+      if (smallest == node) {
+        break;
+      }
+      swap(smallest, node);
+      node = smallest;
+    }
+  }
+
+  // BUILD-MAX-HEAPIFY in Cormen
+  __device__ void build(int k) {
+    for (int node = (k - 1) / 2; node >= 0; node--) {
+      push_down(node, k);
+    }
+  }
+
+  // HEAP-EXTRACT-MAX in Cormen
+  __device__ void remove_root(int k) {
+    data[0] = data[k - 1];
+    push_root_down(k - 1);
+  }
+
+  // in-place HEAPSORT in Cormen
+  // This method destroys the heap property.
+  __device__ void sort(int k) {
+    for (int slot = k - 1; slot > 0; slot--) {
+      // This is like remove_root but we insert the element at the end.
+      swap(slot, 0);
+      // Heap is now an element smaller.
+      push_root_down(/*k=*/slot);
+    }
+  }
+
+  __device__ void replace_root(Entry const &entry, int k) {
+    data[0] = entry;
+    push_root_down(k);
+  }
+
+  __device__ Entry const &root() {
+    return data[0];
+  }
+};
+
+template <HeapType heapType,
+          PreferIndices preferIndices,
+          template <typename>
+          class Data,
+          typename T>
+__device__ IndexedHeap<heapType, preferIndices, Data, T>
+    make_indexed_heap(typename Data<T>::Entry *data) {
+  return IndexedHeap<heapType, preferIndices, Data, T>{Data<T>{data}};
+}
+
+// heapArgTopK walks over [input, input+length) with `step_size` stride starting
+// at `start_index`. It builds a top-`k` heap that is stored in `heap_entries`
+// using `Accessor` to access elements in `heap_entries`. If sorted=true, the
+// elements will be sorted at the end.
+template <typename T, template <typename> class Data = LinearData>
+__device__ void heapArgTopK(T const *__restrict__ input,
+                            int length,
+                            int k,
+                            Entry<T> *__restrict__ heap_entries,
+                            bool sorted = false,
+                            int start_index = 0,
+                            int step_size = 1) {
+  assert(k <= length);
+
+  auto heap =
+      make_indexed_heap<HeapType::kMinHeap, PreferIndices::kHigher, Data, T>(
+          heap_entries);
+
+  int heap_end_index = start_index + k * step_size;
+  if (heap_end_index > length) {
+    heap_end_index = length;
+  }
+  // Initialize the min-heap.
+  for (int index = start_index, slot = 0; index < heap_end_index;
+       index += step_size, slot++) {
+    heap.assign(slot, {index, input[index]});
+  }
+
+  heap.build(k);
+
+  // Now iterate over the remaining items.
+  // If an item is smaller than the min element, it is not amongst the top k.
+  // Otherwise, replace the min element with it and push upwards.
+  for (int index = heap_end_index; index < length; index += step_size) {
+    // We prefer elements with lower indices. This is given here.
+    // Later elements automatically have higher indices, so can be discarded.
+    if (input[index] > heap.root().value) {
+      // This element should replace the min.
+      heap.replace_root({index, input[index]}, k);
+    }
+  }
+
+  // Sort if wanted.
+  if (sorted) {
+    heap.sort(k);
+  }
+}
+
+// mergeShards performs a top-k merge on `num_shards` many sorted streams that
+// are sorted and stored in `entries` in a strided way:
+// |s_1 1st|s_2 1st|...s_{num_shards} 1st|s_1 2nd|s_2 2nd|...
+// The overall top k elements are written to `top_k_values` and their indices
+// to top_k_indices.
+// `top_k_heap` is used as temporary storage for the merge heap.
+template <typename T>
+__device__ void mergeShards(int num_shards,
+                            int k,
+                            Entry<T> *__restrict__ entries,
+                            Entry<T> *__restrict__ top_k_heap,
+                            // T *top_k_values,
+                            int *top_k_indices) {
+  // If k < num_shards, we can use a min-heap with k elements to get the top k
+  // of the sorted blocks.
+  // If k > num_shards, we can initialize a min-heap with the top element from
+  // each sorted block.
+  int const heap_size = k < num_shards ? k : num_shards;
+
+  // Min-heap part.
+  {
+    auto min_heap = IndexedHeap<HeapType::kMinHeap,
+                                PreferIndices::kHigher,
+                                IndirectLinearData,
+                                T>{IndirectLinearData<T>{top_k_heap, entries}};
+    // Initialize the heap as a min-heap.
+    for (int slot = 0; slot < heap_size; slot++) {
+      min_heap.assign(slot, {slot, entries[slot].value});
+    }
+    min_heap.build(heap_size);
+
+    // Now perform top k with the remaining shards (if num_shards > heap_size).
+    for (int shard = heap_size; shard < num_shards; shard++) {
+      auto const entry = entries[shard];
+      auto const root = min_heap.root();
+      if (entry.value < root.value) {
+        continue;
+      }
+      if (entry.value == root.value &&
+          entry.index > entries[root.index].index) {
+        continue;
+      }
+      // This element should replace the min.
+      min_heap.replace_root({shard, entry.value}, heap_size);
+    }
+  }
+
+  // Max-part.
+  {
+    // Turn the min-heap into a max-heap in-place.
+    auto max_heap = IndexedHeap<HeapType::kMaxHeap,
+                                PreferIndices::kLower,
+                                IndirectLinearData,
+                                T>{IndirectLinearData<T>{top_k_heap, entries}};
+    // Heapify into a max heap.
+    max_heap.build(heap_size);
+
+    // Now extract the minimum k-1 times.
+    // k is treated specially.
+    int const last_k = k - 1;
+    for (int rank = 0; rank < last_k; rank++) {
+      Entry<T> const &max_element = max_heap.root();
+      // top_k_values[rank] = max_element.value;
+      int shard_index = max_element.index;
+      top_k_indices[rank] = entries[shard_index].index;
+      int next_shard_index = shard_index + num_shards;
+      // For rank < k-1, each top k heap still contains at least 1 element,
+      // so we can draw a replacement.
+      max_heap.replace_root({next_shard_index, entries[next_shard_index].value},
+                            heap_size);
+    }
+
+    // rank == last_k.
+    Entry<T> const &max_element = max_heap.root();
+    // top_k_values[last_k] = max_element.value;
+    int shard_index = max_element.index;
+    top_k_indices[last_k] = entries[shard_index].index;
+  }
+}
+
+template <typename T>
+__global__ void arg_topk_forward_kernel(T const *__restrict__ input,
+                                        size_t shared_memory_size,
+                                        int length,
+                                        int k,
+                                        bool sorted,
+                                        // T *__restrict__ output,
+                                        int *__restrict__ indices) {
+  __shared__ char shared_memory[48 << 10];
+  int const batch_index = blockIdx.x;
+  T const *batch_input = input + batch_index * length;
+  int const thread_index = threadIdx.x;
+  int const thread_count = blockDim.x;
+  Entry<T> *shared_entries = (Entry<T> *)shared_memory;
+  heapArgTopK<T, StridedData>(
+      batch_input, length, k, shared_entries, true, thread_index, thread_count);
+  __syncthreads();
+  if (thread_index == 0) {
+    int const offset = batch_index * k;
+    // auto batch_output = output + offset;
+    auto batch_indices = indices + offset;
+    Entry<T> *top_k_heap = shared_entries + thread_count * k;
+    mergeShards(thread_count,
+                k,
+                shared_entries,
+                top_k_heap,
+                // batch_output,
+                batch_indices);
+  }
+}
+
+/*static*/
+void ArgTopK::forward_kernel(ArgTopKMeta const *m,
+                             float const *input_ptr,
+                             // float *output_ptr,
+                             int *indices_ptr,
+                             size_t batch_size,
+                             int length,
+                             int k,
+                             bool sorted,
+                             cudaStream_t stream) {
+  // Adopted from TensorFlow's ArgTopK implementation
+  // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/topk_op_gpu.h
+  int num_shards = 0;
+  {
+    constexpr auto shared_memory_size = 48 << 10;
+    auto const heap_size = k * sizeof(Entry<float>);
+    // shared_memory_size = (num_shards + 1) * heap_size <=>
+    num_shards = shared_memory_size / heap_size - 1;
+    assert(num_shards > 0);
+    if (num_shards > CUDA_NUM_THREADS) {
+      num_shards = CUDA_NUM_THREADS;
+    }
+  }
+  // We are limited by the amount of shared memory we have per block.
+  size_t shared_memory_size = (num_shards + 1) * k * sizeof(Entry<float>);
+  // size_t num_blocks = (batch_size + num_shards - 1) / num_shards;
+  size_t num_blocks = batch_size;
+  assert(num_shards >= (size_t)k);
+  num_shards = k;
+  arg_topk_forward_kernel<<<num_blocks, num_shards, 0, stream>>>(
+      input_ptr,
+      shared_memory_size,
+      length,
+      k,
+      sorted,
+      // output_ptr,
+      indices_ptr);
+}
+
+/*static*/
+void ArgTopK::forward_kernel_wrapper(ArgTopKMeta const *m,
+                                     float const *input_ptr,
+                                     // float *output_ptr,
+                                     int *indices_ptr,
+                                     size_t batch_size,
+                                     int length,
+                                     int k,
+                                     bool sorted) {
+  cudaStream_t stream;
+  checkCUDA(get_legion_stream(&stream));
+
+  cudaEvent_t t_start, t_end;
+  if (m->profiling) {
+    cudaEventCreate(&t_start);
+    cudaEventCreate(&t_end);
+    cudaEventRecord(t_start, stream);
+  }
+
+  ArgTopK::forward_kernel(m,
+                          input_ptr,
+                          // output_ptr,
+                          indices_ptr,
+                          batch_size,
+                          length,
+                          k,
+                          sorted,
+                          stream);
+
+  if (m->profiling) {
+    cudaEventRecord(t_end, stream);
+    checkCUDA(cudaEventSynchronize(t_end));
+    float elapsed = 0;
+    checkCUDA(cudaEventElapsedTime(&elapsed, t_start, t_end));
+    cudaEventDestroy(t_start);
+    cudaEventDestroy(t_end);
+    printf("[ArgTopK] forward time = %.2lfms\n", elapsed);
+  }
+}
+
+ArgTopKMeta::ArgTopKMeta(FFHandler handler) : OpMeta(handler) {}
+
+}; // namespace FlexFlow

--- a/src/ops/embedding.cc
+++ b/src/ops/embedding.cc
@@ -369,6 +369,46 @@ void Embedding::init(FFModel const &ff) {
   set_opmeta_from_futuremap(ff, fm);
 }
 
+void Embedding::init_inference(FFModel const &ff,
+                               std::vector<ParallelTensor> const &batch_inputs,
+                               std::vector<ParallelTensor> const &batch_outputs,
+                               MachineView const *mv) {
+  assert(check_output_input_weight_same_parallel_is());
+  parallel_is = batch_outputs[0]->parallel_is;
+  ArgumentMap argmap;
+  Context ctx = ff.config.lg_ctx;
+  Runtime *runtime = ff.config.lg_hlr;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  size_t machine_view_hash = view->hash();
+  set_argumentmap_for_init_inference(ff, argmap, view);
+
+  IndexLauncher launcher(EMBED_INIT_TASK_ID,
+                         parallel_is,
+                         TaskArgument(this, sizeof(Embedding)),
+                         argmap,
+                         Predicate::TRUE_PRED,
+                         false /*must*/,
+                         0 /*mapper_id*/,
+                         machine_view_hash);
+
+  launcher.add_region_requirement(RegionRequirement(batch_outputs[0]->part,
+                                                    0 /*projection*/,
+                                                    WRITE_ONLY,
+                                                    EXCLUSIVE,
+                                                    batch_outputs[0]->region));
+  launcher.add_field(0, FID_DATA);
+  // regions[2]: weight
+  launcher.add_region_requirement(RegionRequirement(weights[0]->part,
+                                                    0 /*projection*/,
+                                                    READ_ONLY,
+                                                    EXCLUSIVE,
+                                                    weights[0]->region));
+  launcher.add_field(1, FID_DATA);
+  FutureMap fm = runtime->execute_index_space(ctx, launcher);
+  fm.wait_all_results();
+  set_opmeta_from_futuremap_inference(ff, fm, view);
+}
+
 OpMeta *Embedding::init_task(Task const *task,
                              std::vector<PhysicalRegion> const &regions,
                              Context ctx,
@@ -417,6 +457,53 @@ void Embedding::forward(FFModel const &ff) {
                                                     weights[0]->region));
   launcher.add_field(2, FID_DATA);
   runtime->execute_index_space(ctx, launcher);
+}
+
+FutureMap Embedding::inference(FFModel const &ff,
+                               BatchConfig const &bc,
+                               std::vector<ParallelTensor> const &batch_inputs,
+                               std::vector<ParallelTensor> const &batch_outputs,
+                               MachineView const *mv) {
+  ArgumentMap argmap;
+  Context ctx = ff.config.lg_ctx;
+  Runtime *runtime = ff.config.lg_hlr;
+
+  parallel_is = batch_outputs[0]->parallel_is;
+  MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
+  set_argumentmap_for_inference(ff, argmap, view);
+  size_t machine_view_hash = view->hash();
+
+  IndexLauncher launcher(EMBED_FWD_TASK_ID,
+                         parallel_is,
+                         TaskArgument(NULL, 0),
+                         argmap,
+                         Predicate::TRUE_PRED,
+                         false /*must*/,
+                         0 /*mapper_id*/,
+                         machine_view_hash);
+  // regions[0]: input
+  launcher.add_region_requirement(RegionRequirement(batch_inputs[0]->part,
+                                                    0 /*projection*/,
+                                                    READ_ONLY,
+                                                    EXCLUSIVE,
+                                                    batch_inputs[0]->region));
+  launcher.add_field(0, FID_DATA);
+  // regions[1]: output
+  launcher.add_region_requirement(RegionRequirement(batch_outputs[0]->part,
+                                                    0 /*projection*/,
+                                                    WRITE_ONLY,
+                                                    EXCLUSIVE,
+                                                    batch_outputs[0]->region,
+                                                    MAP_TO_ZC_MEMORY));
+  launcher.add_field(1, FID_DATA);
+  // regions[2]: weight
+  launcher.add_region_requirement(RegionRequirement(weights[0]->part,
+                                                    0 /*projection*/,
+                                                    READ_ONLY,
+                                                    EXCLUSIVE,
+                                                    weights[0]->region));
+  launcher.add_field(2, FID_DATA);
+  return runtime->execute_index_space(ctx, launcher);
 }
 
 /*

--- a/src/runtime/cuda_helper.cu
+++ b/src/runtime/cuda_helper.cu
@@ -238,6 +238,17 @@ __host__ T *download_tensor(T const *ptr, size_t num_elements) {
   return host_ptr;
 }
 
+template <typename T>
+__host__ bool download_tensor(T const *ptr, T *dst, size_t num_elements) {
+  // device synchronize to make sure the data are ready
+  // checkCUDA(cudaDeviceSynchronize());
+  assert(dst != nullptr);
+  checkCUDA(
+      cudaMemcpy(dst, ptr, sizeof(T) * num_elements, cudaMemcpyDeviceToHost));
+  // checkCUDA(cudaDeviceSynchronize());
+  return true;
+}
+
 cudnnStatus_t cudnnSetTensorDescriptorFromDomain(cudnnTensorDescriptor_t tensor,
                                                  Domain domain) {
   int dims[MAX_TENSOR_DIM];
@@ -421,3 +432,14 @@ template __host__ int32_t *download_tensor<int32_t>(int32_t const *ptr,
                                                     size_t num_elements);
 template __host__ int64_t *download_tensor<int64_t>(int64_t const *ptr,
                                                     size_t num_elements);
+template __host__ bool
+    download_tensor<float>(float const *ptr, float *dst, size_t num_elements);
+template __host__ bool download_tensor<double>(double const *ptr,
+                                               double *dst,
+                                               size_t num_elements);
+template __host__ bool download_tensor<int32_t>(int32_t const *ptr,
+                                                int32_t *dst,
+                                                size_t num_elements);
+template __host__ bool download_tensor<int64_t>(int64_t const *ptr,
+                                                int64_t *dst,
+                                                size_t num_elements);

--- a/src/runtime/ffconst_utils.cc
+++ b/src/runtime/ffconst_utils.cc
@@ -113,6 +113,8 @@ std::string get_operator_type_name(OperatorType type) {
       return "Size";
     case OP_TOPK:
       return "TopK";
+    case OP_ARG_TOPK:
+      return "ArgTopK";
     case OP_WHERE:
       return "Where";
     case OP_CEIL:

--- a/src/runtime/graph.cc
+++ b/src/runtime/graph.cc
@@ -16,6 +16,7 @@
 #include "flexflow/dominators.h"
 #include "flexflow/ffconst_utils.h"
 #include "flexflow/ops/aggregate.h"
+#include "flexflow/ops/arg_topk.h"
 #include "flexflow/ops/attention.h"
 #include "flexflow/ops/batch_matmul.h"
 #include "flexflow/ops/cast.h"
@@ -2662,6 +2663,10 @@ void FFModel::deserialize_graph_optimal_view(
       }
       case OP_TOPK: {
         node = TopK::deserialize(*this, dez, inputs, num_inputs);
+        break;
+      }
+      case OP_ARG_TOPK: {
+        node = ArgTopK::deserialize(*this, dez, inputs, num_inputs);
         break;
       }
       case OP_GROUP_BY: {

--- a/src/runtime/hip_helper.cpp
+++ b/src/runtime/hip_helper.cpp
@@ -248,6 +248,31 @@ __host__ void
   checkCUDA(hipHostFree(host_ptr));
 }
 
+template <typename T>
+__host__ T *download_tensor(T const *ptr, size_t num_elements) {
+  // device synchronize to make sure the data are ready
+  // checkCUDA(hipDeviceSynchronize());
+  T *host_ptr;
+  checkCUDA(hipHostMalloc(&host_ptr,
+                          sizeof(T) * num_elements,
+                          hipHostMallocPortable | hipHostMallocMapped));
+  checkCUDA(hipMemcpy(
+      host_ptr, ptr, sizeof(T) * num_elements, hipMemcpyDeviceToHost));
+  // checkCUDA(hipDeviceSynchronize());
+  return host_ptr;
+}
+
+template <typename T>
+__host__ bool download_tensor(T const *ptr, T *dst, size_t num_elements) {
+  // device synchronize to make sure the data are ready
+  // checkCUDA(hipDeviceSynchronize());
+  assert(dst != nullptr);
+  checkCUDA(
+      hipMemcpy(dst, ptr, sizeof(T) * num_elements, hipMemcpyDeviceToHost));
+  // checkCUDA(hipDeviceSynchronize());
+  return true;
+}
+
 miopenStatus_t
     cudnnSetTensorDescriptorFromDomain(miopenTensorDescriptor_t tensor,
                                        Domain domain) {
@@ -382,3 +407,23 @@ template __host__ void
     print_tensor<int32_t>(int32_t const *ptr, size_t rect, char const *prefix);
 template __host__ void
     print_tensor<int64_t>(int64_t const *ptr, size_t rect, char const *prefix);
+
+template __host__ float *download_tensor<float>(float const *ptr,
+                                                size_t num_elements);
+template __host__ double *download_tensor<double>(double const *ptr,
+                                                  size_t num_elements);
+template __host__ int32_t *download_tensor<int32_t>(int32_t const *ptr,
+                                                    size_t num_elements);
+template __host__ int64_t *download_tensor<int64_t>(int64_t const *ptr,
+                                                    size_t num_elements);
+template __host__ bool
+    download_tensor<float>(float const *ptr, float *dst, size_t num_elements);
+template __host__ bool download_tensor<double>(double const *ptr,
+                                               double *dst,
+                                               size_t num_elements);
+template __host__ bool download_tensor<int32_t>(int32_t const *ptr,
+                                                int32_t *dst,
+                                                size_t num_elements);
+template __host__ bool download_tensor<int64_t>(int64_t const *ptr,
+                                                int64_t *dst,
+                                                size_t num_elements);

--- a/src/runtime/model.cc
+++ b/src/runtime/model.cc
@@ -24,6 +24,7 @@
 #include "flexflow/mapper.h"
 #include "flexflow/ops/aggregate.h"
 #include "flexflow/ops/aggregate_spec.h"
+#include "flexflow/ops/arg_topk.h"
 #include "flexflow/ops/attention.h"
 #include "flexflow/ops/batch_matmul.h"
 #include "flexflow/ops/batch_norm.h"
@@ -2862,6 +2863,11 @@ Op *FFModel::create_operator_from_layer(
       operators.push_back(op);
       return op;
     }
+    case OP_ARG_TOPK: {
+      Op *op = ArgTopK::create_operator_from_layer(*this, layer, inputs);
+      operators.push_back(op);
+      return op;
+    }
     case OP_GROUP_BY: {
       Op *op = Group_by::create_operator_from_layer(*this, layer, inputs);
       operators.push_back(op);
@@ -4472,6 +4478,21 @@ void register_flexflow_internal_tasks() {
     registrar.set_leaf();
     Runtime::preregister_task_variant<TopK::backward_task>(
         registrar, "TopK Backward Task");
+  }
+  // ArgTopk task
+  {
+    TaskVariantRegistrar registrar(ARG_TOPK_INIT_TASK_ID, "ArgTopK Init");
+    registrar.add_constraint(ProcessorConstraint(Processor::TOC_PROC));
+    registrar.set_leaf();
+    Runtime::preregister_task_variant<OpMeta *, ArgTopK::init_task>(
+        registrar, "ArgTopK Init Task");
+  }
+  {
+    TaskVariantRegistrar registrar(ARG_TOPK_INF_TASK_ID, "ArgTopK Inference");
+    registrar.add_constraint(ProcessorConstraint(Processor::TOC_PROC));
+    registrar.set_leaf();
+    Runtime::preregister_task_variant<InferenceResult, ArgTopK::inference_task>(
+        registrar, "ArgTopK Inference Task");
   }
   // Transpose task
   {

--- a/triton/src/types.h
+++ b/triton/src/types.h
@@ -137,7 +137,6 @@ enum OperatorType {
   OP_SHAPE,  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Shape
   OP_SIZE,   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Size
   OP_TOPK,   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#TopK
-  OP_ARG_TOPK,
   OP_WHERE,  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Where
   OP_CEIL,   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Ceil
   OP_CAST,   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Cast

--- a/triton/src/types.h
+++ b/triton/src/types.h
@@ -137,6 +137,7 @@ enum OperatorType {
   OP_SHAPE,  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Shape
   OP_SIZE,   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Size
   OP_TOPK,   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#TopK
+  OP_ARG_TOPK,
   OP_WHERE,  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Where
   OP_CEIL,   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Ceil
   OP_CAST,   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Cast


### PR DESCRIPTION
**Description of changes:**

This PR completes the implementation of the autoregressive inference functionalities, by obtaining the new token generated at each iteration of the inference process, and saving it into memory, as well as passing it to the next iteration's batch.

In addition, we update the transformer & MoE models to take integers as inputs, and apply the embedding.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
