### PR TITLE
[Inference init] create multiple OpMeta, one for each batch

### DIFF
--- a/include/flexflow/operator.h
+++ b/include/flexflow/operator.h
@@ -259,19 +259,19 @@ protected:
   void set_argumentmap_for_init(FFModel const &ff, Legion::ArgumentMap &argmap);
   void set_argumentmap_for_init_inference(FFModel const &ff,
                                           Legion::ArgumentMap &argmap,
-                                          MachineView const *view);
+                                          ParallelTensor const output0);
   void set_argumentmap_for_forward(FFModel const &ff,
                                    Legion::ArgumentMap &argmap);
   void set_argumentmap_for_inference(FFModel const &ff,
                                      Legion::ArgumentMap &argmap,
-                                     MachineView const *view);
+                                     ParallelTensor const output0);
   void set_argumentmap_for_backward(FFModel const &ff,
                                     Legion::ArgumentMap &argmap);
   void set_opmeta_from_futuremap(FFModel const &ff,
                                  Legion::FutureMap const &fm);
   void set_opmeta_from_futuremap_inference(FFModel const &ff,
                                            Legion::FutureMap const &fm,
-                                           MachineView const *view);
+                                           ParallelTensor const output0);
   void solve_parallel_dim_mappings(
       std::vector<ParallelDim const *> const &inputs,
       std::vector<ParallelDim *> const &weights,
@@ -291,7 +291,7 @@ public:
   ParallelParameter weights[MAX_NUM_WEIGHTS];
   bool trainableInputs[MAX_NUM_INPUTS];
   OpMeta *meta[MAX_NUM_WORKERS];
-  std::map<size_t, OpMeta *[MAX_NUM_WORKERS]> inference_meta;
+  std::map<ParallelTensor, OpMeta *[MAX_NUM_WORKERS]> inference_meta;
   int numInputs, numWeights, numOutputs;
   bool profiling;
 #ifdef FF_USE_NCCL

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -193,7 +193,7 @@ void Aggregate::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(AGGREGATE_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Aggregate)),
@@ -204,7 +204,7 @@ void Aggregate::init_inference(FFModel const &ff,
                          machine_view_hash);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void Aggregate::init(FFModel const &ff) {
@@ -294,7 +294,7 @@ FutureMap Aggregate::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "Aggregate op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/ops/aggregate_spec.cc
+++ b/src/ops/aggregate_spec.cc
@@ -167,7 +167,7 @@ void AggregateSpec::init_inference(
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(AGG_SPEC_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(AggregateSpec)),
@@ -178,7 +178,7 @@ void AggregateSpec::init_inference(
                          machine_view_hash);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void AggregateSpec::init(FFModel const &ff) {
@@ -269,7 +269,7 @@ FutureMap
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "AggregateSpec op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/ops/arg_topk.cc
+++ b/src/ops/arg_topk.cc
@@ -157,7 +157,7 @@ void ArgTopK::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(ARG_TOPK_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(ArgTopK)),
@@ -186,7 +186,7 @@ void ArgTopK::init_inference(FFModel const &ff,
   //   launcher.add_field(2, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void ArgTopK::init(FFModel const &ff) {
@@ -254,7 +254,7 @@ FutureMap ArgTopK::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "ArgTopK op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/ops/attention.cc
+++ b/src/ops/attention.cc
@@ -384,7 +384,7 @@ void MultiHeadAttention::init_inference(
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(ATTENTION_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(MultiHeadAttention)),
@@ -425,7 +425,7 @@ void MultiHeadAttention::init_inference(
   launcher.add_field(4, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void MultiHeadAttention::init(FFModel const &ff) {
@@ -590,7 +590,7 @@ FutureMap MultiHeadAttention::inference(
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "MultiHeadAttention op machine_view: " << *(MachineView const
      *)mv

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -274,7 +274,7 @@ void ElementBinary::init_inference(
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(ELEMENTBINARY_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(ElementBinary)),
@@ -325,7 +325,7 @@ void ElementBinary::init_inference(
   //}
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void ElementBinary::init(FFModel const &ff) {
@@ -517,7 +517,7 @@ FutureMap
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "ElementBinary op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/ops/embedding.cc
+++ b/src/ops/embedding.cc
@@ -380,7 +380,7 @@ void Embedding::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
 
   IndexLauncher launcher(EMBED_INIT_TASK_ID,
                          parallel_is,
@@ -406,7 +406,7 @@ void Embedding::init_inference(FFModel const &ff,
   launcher.add_field(1, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 OpMeta *Embedding::init_task(Task const *task,
@@ -470,7 +470,7 @@ FutureMap Embedding::inference(FFModel const &ff,
 
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
 
   IndexLauncher launcher(EMBED_FWD_TASK_ID,

--- a/src/ops/experts.cc
+++ b/src/ops/experts.cc
@@ -454,7 +454,7 @@ void Experts::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(EXPERTS_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Experts)),
@@ -510,7 +510,7 @@ void Experts::init_inference(FFModel const &ff,
   }
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void Experts::init(FFModel const &ff) {
@@ -672,7 +672,7 @@ FutureMap Experts::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "Experts op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/ops/group_by.cc
+++ b/src/ops/group_by.cc
@@ -175,7 +175,7 @@ void Group_by::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(GROUP_BY_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Group_by)),
@@ -211,7 +211,7 @@ void Group_by::init_inference(FFModel const &ff,
   }
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void Group_by::init(FFModel const &ff) {
@@ -319,6 +319,7 @@ FutureMap Group_by::inference(FFModel const &ff,
   ArgumentMap argmap;
   Context ctx = ff.config.lg_ctx;
   Runtime *runtime = ff.config.lg_hlr;
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash =
       mv ? mv->hash() : batch_outputs[0]->machine_view.hash();
   /* std::cout << "GroupBy op machine_view: " << *(MachineView const *)mv

--- a/src/ops/inc_multihead_self_attention.cc
+++ b/src/ops/inc_multihead_self_attention.cc
@@ -360,7 +360,7 @@ void IncMultiHeadSelfAttention::init_inference(
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(INC_MULTIHEAD_SELF_ATTENTION_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(IncMultiHeadSelfAttention)),
@@ -389,7 +389,7 @@ void IncMultiHeadSelfAttention::init_inference(
   launcher.add_field(2, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void IncMultiHeadSelfAttention::init(FFModel const &ff) {
@@ -484,7 +484,7 @@ FutureMap IncMultiHeadSelfAttention::inference(
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   int idx = 0;
 

--- a/src/ops/inc_multihead_self_attention.cu
+++ b/src/ops/inc_multihead_self_attention.cu
@@ -536,7 +536,7 @@ IncMultiHeadSelfAttentionMeta::IncMultiHeadSelfAttentionMeta(
     : OpMeta(handler, attn) {
   cudaStream_t stream;
   checkCUDA(get_legion_stream(&stream));
-  // checkCUDNN(cudnnSetStream(handler.dnn, stream));
+  checkCUDNN(cudnnSetStream(handler.dnn, stream));
 
   qSize = attn->qSize;
   kSize = attn->kSize;

--- a/src/ops/layer_norm.cc
+++ b/src/ops/layer_norm.cc
@@ -205,7 +205,7 @@ void LayerNorm::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(LAYERNORM_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(LayerNorm)),
@@ -228,7 +228,7 @@ void LayerNorm::init_inference(FFModel const &ff,
   launcher.add_field(1, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void LayerNorm::init(FFModel const &ff) {
@@ -325,7 +325,7 @@ FutureMap LayerNorm::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "LayerNorm op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -266,7 +266,7 @@ void Linear::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(LINEAR_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Linear)),
@@ -304,7 +304,7 @@ void Linear::init_inference(FFModel const &ff,
   }
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 /*
@@ -430,7 +430,7 @@ FutureMap Linear::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "Linear op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/ops/noop.cc
+++ b/src/ops/noop.cc
@@ -164,7 +164,7 @@ void NoOp::init_inference(FFModel const &ff,
     ArgumentMap argmap;
     Context ctx = ff.config.lg_ctx;
     Runtime *runtime = ff.config.lg_hlr;
-    set_argumentmap_for_init_inference(ff, argmap, view);
+    set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
     IndexLauncher launcher(NOOP_INIT_TASK_ID,
                            parallel_is,
                            TaskArgument(NULL, 0),
@@ -175,7 +175,7 @@ void NoOp::init_inference(FFModel const &ff,
                            machine_view_hash);
     FutureMap fm = runtime->execute_index_space(ctx, launcher);
     fm.wait_all_results();
-    set_opmeta_from_futuremap_inference(ff, fm, view);
+    set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
   }
 }
 

--- a/src/ops/softmax.cc
+++ b/src/ops/softmax.cc
@@ -126,7 +126,7 @@ void Softmax::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(SOFTMAX_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(Softmax)),
@@ -149,7 +149,7 @@ void Softmax::init_inference(FFModel const &ff,
   launcher.add_field(1, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void Softmax::init(FFModel const &ff) {
@@ -235,7 +235,7 @@ FutureMap Softmax::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "Softmax op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/ops/topk.cc
+++ b/src/ops/topk.cc
@@ -147,7 +147,7 @@ void TopK::init_inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
   size_t machine_view_hash = view->hash();
-  set_argumentmap_for_init_inference(ff, argmap, view);
+  set_argumentmap_for_init_inference(ff, argmap, batch_outputs[0]);
   IndexLauncher launcher(TOPK_INIT_TASK_ID,
                          parallel_is,
                          TaskArgument(this, sizeof(TopK)),
@@ -176,7 +176,7 @@ void TopK::init_inference(FFModel const &ff,
   launcher.add_field(2, FID_DATA);
   FutureMap fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  set_opmeta_from_futuremap_inference(ff, fm, view);
+  set_opmeta_from_futuremap_inference(ff, fm, batch_outputs[0]);
 }
 
 void TopK::init(FFModel const &ff) {
@@ -273,7 +273,7 @@ FutureMap TopK::inference(FFModel const &ff,
   Runtime *runtime = ff.config.lg_hlr;
   parallel_is = batch_outputs[0]->parallel_is;
   MachineView const *view = mv ? mv : &batch_outputs[0]->machine_view;
-  set_argumentmap_for_inference(ff, argmap, view);
+  set_argumentmap_for_inference(ff, argmap, batch_outputs[0]);
   size_t machine_view_hash = view->hash();
   /* std::cout << "TopK op machine_view: " << *(MachineView const *)mv
             << std::endl; */

--- a/src/runtime/inference_manager.cc
+++ b/src/runtime/inference_manager.cc
@@ -73,46 +73,44 @@ void InferenceManager::compile_model_and_allocate_buffer(void) {
 void InferenceManager::init_operators_inference() {
   for (int batch_index = 0; batch_index < max_num_inflight_batches;
        batch_index++) {
-    for (int device_index = 0; device_index < num_devices; device_index++) {
-      // int fused_experts_index = 0;
-      for (size_t o = 0; o < model->operators.size(); o++) {
-        Op *op = model->operators[o];
-        if (op->op_type == OP_WEIGHT) {
-          continue;
-        }
-        MachineView *view;
-        // if (op->op_type == OP_EXPERTS) {
-        //   if (fused_experts_index != device_index) {
-        //     fused_experts_index++;
-        //     continue;
-        //   }
-        //   view = &machine_views[fused_experts_index];
-        //   fused_experts_index++;
-        // } else {
-        view = &machine_views[device_index];
-        //}
-        std::vector<ParallelTensor> inputs(op->numInputs);
-        std::vector<ParallelTensor> outputs(op->numOutputs);
-        for (int i = 0; i < op->numInputs; i++) {
-          assert(op->inputs[i] != nullptr);
-          assert(op->inputs[i]->parallel_is != IndexSpace::NO_SPACE);
-          assert(tensor_buffer[op->inputs[i]].size() > batch_index);
-          inputs[i] = tensor_buffer[op->inputs[i]][batch_index];
-          assert(inputs[i]->parallel_is != IndexSpace::NO_SPACE);
-        }
-        for (int i = 0; i < op->numOutputs; i++) {
-          assert(op->outputs[i] != nullptr);
-          assert(op->outputs[i]->parallel_is != IndexSpace::NO_SPACE);
-          assert(tensor_buffer[op->outputs[i]].size() > batch_index);
-          outputs[i] = tensor_buffer[op->outputs[i]][batch_index];
-          assert(outputs[i]->parallel_is != IndexSpace::NO_SPACE);
-        }
-        if (op->is_parallel_op()) {
-          ((ParallelOp *)op)
-              ->create_input_partition_inference(*model, inputs, outputs);
-        }
-        op->init_inference(*model, inputs, outputs, view);
+    int expert_device_index = 0;
+    int device_index = batch_index % num_devices;
+    for (size_t o = 0; o < model->operators.size(); o++) {
+      Op *op = model->operators[o];
+      if (op->op_type == OP_WEIGHT) {
+        continue;
       }
+      MachineView *view;
+      if (op->op_type == OP_EXPERTS) {
+        view = get_machine_view(expert_device_index);
+        // view = &machine_views[expert_device_index];
+        expert_device_index = (expert_device_index + 1) % num_devices;
+      } else {
+        // pick mv w startdeviceid = device_index
+        // view = &machine_views[device_index];
+        view = get_machine_view(device_index);
+      }
+      std::vector<ParallelTensor> inputs(op->numInputs);
+      std::vector<ParallelTensor> outputs(op->numOutputs);
+      for (int i = 0; i < op->numInputs; i++) {
+        assert(op->inputs[i] != nullptr);
+        assert(op->inputs[i]->parallel_is != IndexSpace::NO_SPACE);
+        assert(tensor_buffer[op->inputs[i]].size() > batch_index);
+        inputs[i] = tensor_buffer[op->inputs[i]][batch_index];
+        assert(inputs[i]->parallel_is != IndexSpace::NO_SPACE);
+      }
+      for (int i = 0; i < op->numOutputs; i++) {
+        assert(op->outputs[i] != nullptr);
+        assert(op->outputs[i]->parallel_is != IndexSpace::NO_SPACE);
+        assert(tensor_buffer[op->outputs[i]].size() > batch_index);
+        outputs[i] = tensor_buffer[op->outputs[i]][batch_index];
+        assert(outputs[i]->parallel_is != IndexSpace::NO_SPACE);
+      }
+      if (op->is_parallel_op()) {
+        ((ParallelOp *)op)
+            ->create_input_partition_inference(*model, inputs, outputs);
+      }
+      op->init_inference(*model, inputs, outputs, view);
     }
   }
 }
@@ -123,8 +121,10 @@ MachineView *InferenceManager::get_machine_view(int mv_id) {
 }
 
 FutureMap InferenceManager::inference(int index, BatchConfig const &bc) {
+  // We currently assume that the index-th batch will be placed
+  // on the device_index-th device (except for the experts layers)
   int batch_index = index % max_num_inflight_batches;
-  int device_index = index % num_devices;
+  int device_index = batch_index % num_devices;
   int expert_device_index = 0;
   FutureMap fm;
   for (size_t o = 0; o < model->operators.size(); o++) {

--- a/src/runtime/inference_manager.cc
+++ b/src/runtime/inference_manager.cc
@@ -90,7 +90,8 @@ void InferenceManager::compile_model_and_allocate_buffer(void) {
       }
       for (int i = 0; i < op->numOutputs; i++) {
         tensor_buffer[op->outputs[i]][batch_index]->machine_view = *view;
-        Domain part_domain = runtime->get_index_space_domain(ctx, op->outputs[i]->parallel_is);
+        Domain part_domain =
+            runtime->get_index_space_domain(ctx, op->outputs[i]->parallel_is);
         assert(view->get_domain() == part_domain);
       }
     }
@@ -122,8 +123,9 @@ void InferenceManager::init_operators_inference() {
         assert(op->outputs[i]->parallel_is != IndexSpace::NO_SPACE);
         assert(tensor_buffer[op->outputs[i]].size() > batch_index);
         outputs[i] = tensor_buffer[op->outputs[i]][batch_index];
-        if (i > 0)
+        if (i > 0) {
           assert(outputs[0]->machine_view == outputs[i]->machine_view);
+        }
         assert(outputs[i]->parallel_is != IndexSpace::NO_SPACE);
       }
       if (op->is_parallel_op()) {


### PR DESCRIPTION
**Description of changes:**

This PR fixes an issue where multiple branches may share the same OpMeta. After the fix, each branch now has it's own OpMeta for each operator.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
