### PR TITLE
utils submodule makefile

### DIFF
--- a/lib/utils/Makefile
+++ b/lib/utils/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2023 CMU, Facebook, LANL, MIT, NVIDIA, and Stanford (alphabetical)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Compiler and linker settings
+
+CXX = g++
+
+# TODO remove -Wno-unused-parameter -Wno-infinite-recursion -Wno-delete-abstract-non-virtual-dtor -Wno-sign-compare -Wno-reorder-ctor -Wno-logical-op-parentheses -Wno-delete-non-abstract-non-virtual-dtor once warnings fixed 
+CXXFLAGS = -Wall -Wextra -Werror -pedantic -O2 -std=c++11 -Wno-unused-parameter -Wno-infinite-recursion -Wno-delete-abstract-non-virtual-dtor -Wno-sign-compare -Wno-reorder-ctor -Wno-logical-op-parentheses -Wno-delete-non-abstract-non-virtual-dtor
+
+# Library name and source files
+LIB_NAME = utils
+SRC_DIR = src
+SRCS = $(wildcard $(SRC_DIR)/**/*.cc)
+HDRS = $(wildcard $(INCLUDE_DIR)/**/*.h)
+
+# Object files
+OBJS = $(SRCS:.cc=.o)
+
+# Include directories
+INCLUDE_DIRS = -Iinclude -I../../deps/optional/include -I../../deps/visit_struct/include -I../../deps/variant/include
+
+# Build rules
+all: $(LIB_NAME).so
+
+$(LIB_NAME).so: $(OBJS)
+	$(CXX) -shared $(CXXFLAGS) $^ -o $@
+
+$(SRC_DIR)/%.o: $(SRC_DIR)/%.cc $(HDRS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE_DIRS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(LIB_NAME).so
+
+.PHONY: all clean install

--- a/lib/utils/include/utils/graph/digraph.h
+++ b/lib/utils/include/utils/graph/digraph.h
@@ -5,6 +5,7 @@
 #include "tl/optional.hpp"
 #include <unordered_set>
 #include "utils/visitable.h"
+#include "visit_struct/visit_struct.hpp"
 
 namespace FlexFlow {
 

--- a/lib/utils/include/utils/graph/node.h
+++ b/lib/utils/include/utils/graph/node.h
@@ -7,6 +7,7 @@
 #include "tl/optional.hpp"
 #include <ostream>
 #include "utils/visitable.h"
+#include "visit_struct/visit_struct.hpp"
 
 namespace FlexFlow {
 

--- a/lib/utils/include/utils/visitable_funcs.h
+++ b/lib/utils/include/utils/visitable_funcs.h
@@ -2,6 +2,7 @@
 #define _FLEXFLOW_INCLUDE_UTILS_VISITABLE_FUNCS_H
 
 #include "utils/visitable.h"
+#include "utils/hash-utils.h"
 
 namespace FlexFlow {
 

--- a/lib/utils/src/graph/algorithms.cc
+++ b/lib/utils/src/graph/algorithms.cc
@@ -338,6 +338,18 @@ std::unordered_map<Node, std::unordered_set<Node>> get_dominators(IDiGraphView c
   return result;
 }
 
+std::unordered_set<Node> get_dominators(IDiGraphView const &, Node const &) {
+  // TODO
+  std::unordered_set<Node> result;
+  return result;
+}
+
+std::unordered_set<Node> get_dominators(IDiGraphView const &, std::unordered_set<Node> const &) {
+  // TODO
+  std::unordered_set<Node> result;
+  return result;
+}
+
 std::unordered_map<Node, std::unordered_set<Node>> get_post_dominators(IMultiDiGraphView const &g) {
   return get_post_dominators(*unsafe_view_as_digraph(g));
 }
@@ -412,6 +424,21 @@ MultiDiEdge unsplit_edge(OutputMultiDiEdge const &output_edge, InputMultiDiEdge 
   assert (input_edge.uid.first == output_edge.src.idx);
   assert (input_edge.uid.second == output_edge.srcIdx);
   return { output_edge.src, input_edge.dst, output_edge.srcIdx, input_edge.dstIdx };
+}
+
+bool contains_edge(IMultiDiGraph const &, MultiDiEdge const &) {
+  // TODO
+  return false;
+}
+
+bool contains_edge(IDiGraph const &, DirectedEdge const &) {
+  // TODO
+  return false;
+}
+
+bool contains_edge(IUndirectedGraph const &, UndirectedEdge const &) {
+  // TODO
+  return false;
 }
 
 }

--- a/lib/utils/src/graph/multidigraph.cc
+++ b/lib/utils/src/graph/multidigraph.cc
@@ -75,12 +75,17 @@ MultiDiEdgeQuery MultiDiEdgeQuery::all() {
   return MultiDiEdgeQuery{};
 }
 
+MultiDiEdgeQuery::MultiDiEdgeQuery(tl::optional<std::unordered_set<Node>> const &srcs_, 
+                   tl::optional<std::unordered_set<Node>> const &dsts_, 
+                   tl::optional<std::unordered_set<std::size_t>> const &srcIdxs_, 
+                   tl::optional<std::unordered_set<std::size_t>> const &dstIdxs_): srcs(srcs_), dsts(dsts_), srcIdxs(srcIdxs_), dstIdxs(dstIdxs_) { }
+
 }
 
 namespace std {
 using ::FlexFlow::MultiDiEdge;
 
-std::size_t hash<MultiDiEdge>::operator()(MultiDiEdge const &e) const {
+size_t hash<MultiDiEdge>::operator()(MultiDiEdge const &e) const {
   return visit_hash(e);
 }
 }

--- a/lib/utils/src/graph/serialparallel.cc
+++ b/lib/utils/src/graph/serialparallel.cc
@@ -194,4 +194,13 @@ mpark::variant<Serial, Parallel, Node> to_final_ast(SplitAST const &ast) {
   return mpark::visit(ToFinalAST{}, ast);
 }
 
+SplitASTNode::SplitASTNode(SplitType type) : type(type) {}
+
+SplitASTNode::SplitASTNode(SplitType type, SplitAST const &child1, SplitAST const &child2) : type(type) {
+  children.push_back(child1);
+  children.push_back(child2);
+}
+
+SplitASTNode::SplitASTNode(SplitType type, std::vector<SplitAST> const &children) : type(type), children(children) {}
+
 }

--- a/lib/utils/src/graph/views.cc
+++ b/lib/utils/src/graph/views.cc
@@ -378,4 +378,8 @@ std::unique_ptr<IDiGraphView> unsafe_view_as_contracted(IDiGraphView const &, st
 /*   return result; */
 /* } */
 
+JoinNodeKey::JoinNodeKey(Node const &n, LRDirection d) : node(n), direction(d) { }
+
+ContractNodeView::ContractNodeView(IDiGraphView const & g_, Node const &removed, Node const &into): g(g_), from(removed), to(into) { }
+
 }


### PR DESCRIPTION
utils submodule makefile

Testing:
```sh
cd lib/utils
make
```

There's a few compiler errors todo with undefined implementations. It does seem like some of them are missing so the errors shouldn't be due to issues with the makefile vs the cmake scripts (lmk if I'm missing something here).

This will be integrated into a top level makefile in the root directory that will run commands and build submodules as such

```
utils:
	$(MAKE) -C lib/utils

clean:
	$(MAKE) -C lib/utils clean
	$(MAKE) -C <other submodule> clean
```

Let's not commit the root makefile until we have makefiles for all submodules
