### PR TITLE
reload the weight if set_tensor, fix the index

### DIFF
--- a/include/flexflow/ops/inc_multihead_self_attention.h
+++ b/include/flexflow/ops/inc_multihead_self_attention.h
@@ -119,6 +119,7 @@ public:
   size_t weights_params, weightSize, reserveSpaceSize;
   int qSize, kSize, vSize, qProjSize, kProjSize, vProjSize, oProjSize;
   int num_heads;
+  bool has_load_weights;
 #ifdef INFERENCE_TESTS
   float *kcache, *vcache;
 #endif

--- a/src/ops/inc_multihead_self_attention.cu
+++ b/src/ops/inc_multihead_self_attention.cu
@@ -495,18 +495,22 @@ void IncMultiHeadSelfAttention::inference_kernel_wrapper(
     cudaEventRecord(t_start, stream);
   }
   // reload the weight_o
-  int parallelism = m->vProjSize * m->oProjSize * m->num_heads;
-  build_w_out_tensor<<<GET_BLOCKS(parallelism),
-                       min(CUDA_NUM_THREADS, parallelism),
-                       0,
-                       stream>>>(weight_ptr,
-                                 m->W_out_contiguous,
-                                 m->vProjSize,
-                                 m->oProjSize,
-                                 m->num_heads,
-                                 (m->qSize * m->qProjSize +
-                                  m->kSize * m->kProjSize +
-                                  m->vSize * m->vProjSize));
+
+  if (!m->has_load_weights) {
+    int parallelism = m->vProjSize * m->oProjSize * m->num_heads;
+    build_w_out_tensor<<<GET_BLOCKS(parallelism),
+                         min(CUDA_NUM_THREADS, parallelism),
+                         0,
+                         stream>>>(weight_ptr,
+                                   m->W_out_contiguous,
+                                   m->vProjSize,
+                                   m->oProjSize,
+                                   m->num_heads,
+                                   (m->qSize * m->qProjSize +
+                                    m->kSize * m->kProjSize +
+                                    m->vSize * m->vProjSize));
+    m->has_load_weights = true;
+  }
 
   // phase 1: Implement kernel to compute KQV for input tokens
   inference_kernel1(m, bc, input_ptr, weight_ptr, m->devQKVProjArray, stream);
@@ -565,7 +569,7 @@ IncMultiHeadSelfAttentionMeta::IncMultiHeadSelfAttentionMeta(
   weights_params = (qSize * qProjSize + kSize * kProjSize + vSize * vProjSize +
                     oProjSize * (vProjSize > 0 ? vProjSize : vSize));
   weightSize = weights_params * num_heads * sizeof(float);
-
+  has_load_weights = false;
   // Currently do not support adding bias to key/value projection
   assert(!attn->add_bias_kv);
 


### PR DESCRIPTION
**Description of changes:**


reload the weights because the origin weights is set before set_tensor
fix the index in weight_O
**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
