### PR TITLE
Fix Code Color in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ fx.torch_to_flexflow(model, "mymodel.ff")
 
 Second, a FlexFlow program can directly import a previously saved PyTorch model and [autotune](https://www.usenix.org/conference/osdi22/presentation/unger) the parallelization performance for a given parallel machine.
 
-```
+```python
 from flexflow.pytorch.model import PyTorchModel
 
 def top_level_task():


### PR DESCRIPTION
**Description of changes:**
Specify that second code block is Python to have correct code color in README.md

**Related Issues:**

Linked Issues:
- Issue #818 

Issues closed by this PR:
- Closes #818

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
