### PR TITLE
Fixed implicit closure in sorting comparator

### DIFF
--- a/lib/utils/include/utils/containers.h
+++ b/lib/utils/include/utils/containers.h
@@ -526,11 +526,13 @@ std::vector<T> sorted_by(std::unordered_set<T> const &s, F const &f) {
 
 template <typename T, typename F>
 void inplace_sorted_by(std::vector<T> &v, F const &f) {
-  struct {
+  struct custom_comparator {
+    F const f; 
+    custom_comparator(F const &f) : f(f) {}; 
     bool operator()(T const &lhs, T const &rhs) { return f(lhs, rhs); }
-  } custom_comparator;
+  };
   
-  std::sort(v.begin(), v.end(), custom_comparator);
+  std::sort(v.begin(), v.end(), custom_comparator(f));
 }
 
 template <typename C, typename F>


### PR DESCRIPTION
**Description of changes:**
Existing code requires implicit closure over f, which appears to be invalid C++ and fails with g++. 

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
