### PR TITLE
Fix `cuda_fp16.h` not found issue

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -81,6 +81,9 @@ if(CUDA_FOUND)
   list(APPEND FLEXFLOW_INCLUDE_DIRS
     ${CUDA_INCLUDE_DIRS})
 
+  add_library(cuda INTERFACE)
+  target_include_directories(cuda SYSTEM INTERFACE "${CUDA_INCLUDE_DIRS}")
+
 else()
   message( FATAL_ERROR "CUDA package not found -> specify search path via CUDA_ROOT variable")
 endif()

--- a/lib/utils/CMakeLists.txt
+++ b/lib/utils/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(
   invoke
   json
   any
+  cuda
 )
 define_ff_vars(${project_target})
 ff_set_cxx_properties(${project_target})


### PR DESCRIPTION
**Description of changes:**

On machines where the cuda headers were not automatically being searched, a build error would result in `utils/fp16.h`. This fixes that by explicitly adding the found cuda include directories to the requirements of `utils`.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #825

**Before merging:**

- [x] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
