### PR TITLE
add optional flag ann test with 11.8 cuda version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,11 +47,11 @@ jobs:
           else
             export FF_CUDA_ARCH=70
           fi
-          ./docker/build.sh flexflow
+          ./docker/build.sh --image_name flexflow --cuda_version 11.8
 
       - name: Check availability of Python flexflow.core module
         if: ${{ matrix.gpu_backend == 'cuda' }}
-        run: docker run --entrypoint python flexflow-cuda:latest -c "import flexflow.core; exit()"
+        run: docker run --entrypoint python flexflow-cuda-11.8.0:latest -c "import flexflow.core; exit()"
 
       - name: Publish Docker environment image (on push to master)
         if: github.repository_owner == 'flexflow'
@@ -60,8 +60,8 @@ jobs:
           FF_GPU_BACKEND: ${{ matrix.gpu_backend }}
         run: |
           if [[ ( ${{ github.event_name }} == 'push' || ${{ github.event_name }} == 'schedule' ) && ${GITHUB_REF#refs/heads/} == "master" ]]; then
-            ./docker/publish.sh "flexflow-environment-${FF_GPU_BACKEND}"
-            ./docker/publish.sh "flexflow-${FF_GPU_BACKEND}"
+            ./docker/publish.sh --image_name "flexflow-environment-${FF_GPU_BACKEND}" --cuda_version 11.8 
+            ./docker/publish.sh --image_name "flexflow-${FF_GPU_BACKEND}" --cuda_version 11.8
           else
             echo "No need to update Docker containers in ghrc.io registry at this time."
           fi

--- a/docker/flexflow-environment/Dockerfile
+++ b/docker/flexflow-environment/Dockerfile
@@ -1,4 +1,6 @@
-FROM nvidia/cuda:11.7.0-cudnn8-devel-ubuntu20.04
+ARG cuda_version 
+
+FROM nvidia/cuda:${cuda_version}-cudnn8-devel-ubuntu20.04
 
 LABEL org.opencontainers.image.source=https://github.com/flexflow/FlexFlow
 LABEL org.opencontainers.image.description="FlexFlow environment container"

--- a/docker/flexflow/Dockerfile
+++ b/docker/flexflow/Dockerfile
@@ -1,5 +1,6 @@
 ARG FF_GPU_BACKEND "cuda"
-FROM flexflow-environment-$FF_GPU_BACKEND:latest
+ARG cuda_version
+FROM flexflow-environment-$FF_GPU_BACKEND-$cuda_version:latest
 
 LABEL org.opencontainers.image.source=https://github.com/flexflow/FlexFlow
 LABEL org.opencontainers.image.description="FlexFlow container"

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -4,14 +4,59 @@ set -euo pipefail
 # Cd into directory holding this script
 cd "${BASH_SOURCE[0]%/*}"
 
-image=${1:-"flexflow-cuda"}
+cuda_version="empty"
+image="flexflow-cuda"
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    --cuda_version)
+      cuda_version="$2"
+      shift 2
+      ;;
+    --image_name)
+      image="$2"
+      shift 2
+      ;;
+    *)
+      echo "Invalid option: $key"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ $cuda_version == "empty" ]]; then
+  cuda_version=$(command -v nvcc >/dev/null 2>&1 && nvcc --version | grep "release" | awk '{print $NF}')
+  # Change cuda_version eg. V11.7.99 to 11.7
+  cuda_version=${cuda_version:1:4}
+fi
+
+if [[ "$cuda_version" != @(11.1|11.3|11.5|11.6|11.7|11.8) ]]; then
+  # validate the verison of CUDA against a list of supported ones
+  # 11.1, 11.3, 11.5, 11.6, 11.7, 11.8
+  echo "cuda_version is not supported, please choose among {11.1,11.3,11.5,11.6,11.7,11.8}"
+  exit 1
+fi
+
+# modify cuda version to available versions
+if [[ "$cuda_version" == @(11.1|11.3|11.7) ]]; then
+  cuda_version=${cuda_version}.1
+elif [[ "$cuda_version" == @(11.2|11.5|11.6) ]]; then 
+  cuda_version=${cuda_version}.2
+elif [[ "$cuda_version" == @(11.8) ]]; then 
+  cuda_version=${cuda_version}.0
+fi
+
+
 if [[ "${image}" != @(flexflow-environment-cuda|flexflow-environment-hip_cuda|flexflow-environment-hip_rocm|flexflow-environment-intel|flexflow-cuda|flexflow-hip_cuda|flexflow-hip_rocm|flexflow-intel) ]]; then
   echo "Error, image name ${image} is invalid. Choose between 'flexflow-environment-{cuda,hip_cuda,hip_rocm,intel}' and 'flexflow-{cuda,hip_cuda,hip_rocm,intel}'."
   exit 1
 fi
 
 # Check that image exists
-docker image inspect "${image}":latest > /dev/null
+docker image inspect "${image}-${cuda_version}":latest > /dev/null
 
 # Log into container registry
 FLEXFLOW_CONTAINER_TOKEN=${FLEXFLOW_CONTAINER_TOKEN:-}
@@ -21,7 +66,7 @@ echo "$FLEXFLOW_CONTAINER_TOKEN" | docker login ghcr.io -u flexflow --password-s
 # Tag image to be uploaded
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
 if [ -z "$git_sha" ]; then echo "Commit hash cannot be detected, cannot publish the docker image to ghrc.io"; exit; fi
-docker tag "$image":latest ghcr.io/flexflow/"$image":latest
+docker tag "$image":latest ghcr.io/flexflow/"$image-$cuda_version":latest
 
 # Upload image
-docker push ghcr.io/flexflow/"$image":latest
+docker push ghcr.io/flexflow/"$image-$cuda_version":latest


### PR DESCRIPTION
**Description of changes:**

Add optional flag for cuda version and build docker images based on the corresponding cuda version input. This PR takes `cuda_version=11.8` as input. 

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
