### PR TITLE
fix compile errors from filter and support_interator_tag

### DIFF
--- a/lib/utils/include/utils/containers.h
+++ b/lib/utils/include/utils/containers.h
@@ -4,7 +4,7 @@
 #include "bidict.h"
 #include "invoke.h"
 #include "optional.h"
-#include "type_traits.h"
+#include "type_traits_core.h"
 #include <algorithm>
 #include <cassert>
 #include <functional>
@@ -530,6 +530,17 @@ template <typename C, typename F>
 C filter(C const &v, F const &f) {
   C result(v);
   inplace_filter(result, f);
+  return result;
+}
+
+template <typename T, typename F>
+std::unordered_set<T> filter(std::unordered_set<T> const &v, F const &f) {
+  std::unordered_set<T> result;
+  for (T const &t : v) {
+    if (f(t)) {
+      result.insert(t);
+    }
+  }
   return result;
 }
 

--- a/lib/utils/include/utils/type_traits.h
+++ b/lib/utils/include/utils/type_traits.h
@@ -113,16 +113,6 @@ struct elements_satisfy<Cond, std::tuple<>> : std::true_type {};
 static_assert(
     elements_satisfy<is_equal_comparable, std::tuple<int, float>>::value, "");
 
-template <typename C, typename Tag>
-struct supports_iterator_tag
-    : std::is_base_of<Tag,
-                      typename std::iterator_traits<
-                          typename C::iterator>::iterator_category> {};
-
-#define CHECK_SUPPORTS_ITERATOR_TAG(TAG, ...)                                  \
-  static_assert(supports_iterator_tag<__VA_ARGS__, TAG>::value,                \
-                #__VA_ARGS__ " does not support required iterator tag " #TAG);
-
 template <typename T>
 using is_default_constructible = std::is_default_constructible<T>;
 

--- a/lib/utils/include/utils/type_traits_core.h
+++ b/lib/utils/include/utils/type_traits_core.h
@@ -93,6 +93,16 @@ struct is_static_castable<
     void_t<decltype(static_cast<To>(std::declval<From>()))>> : std::true_type {
 };
 
+template <typename C, typename Tag>
+struct supports_iterator_tag
+    : std::is_base_of<Tag,
+                      typename std::iterator_traits<
+                          typename C::iterator>::iterator_category> {};
+
+#define CHECK_SUPPORTS_ITERATOR_TAG(TAG, ...)                                  \
+  static_assert(supports_iterator_tag<__VA_ARGS__, TAG>::value,                \
+                #__VA_ARGS__ " does not support required iterator tag " #TAG);
+
 } // namespace FlexFlow
 
 #endif


### PR DESCRIPTION
**Description of changes:**



**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
