### PR TITLE
Docker Inspect Error Msg Prinitng Fix

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -59,7 +59,7 @@ else
 fi
 
 # Check that image exists, if fails, print the default error message.
-if [[ "$(docker images -q ${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest 2> /dev/null)" == "" ]]; then
+if (docker images -q "${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest" 2> /dev/null) == "" ; then
   echo ""
   echo "To download the docker image, run:"
   echo "    FF_GPU_BACKEND=${FF_GPU_BACKEND} cuda_version=${cuda_version} $(pwd)/pull.sh $image"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -59,7 +59,7 @@ else
 fi
 
 # Check that image exists, if fails, print the default error message.
-if (docker images -q "${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest" 2> /dev/null) == "" ; then
+if (docker images -q "${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest" 2> /dev/null) == ""; then
   echo ""
   echo "To download the docker image, run:"
   echo "    FF_GPU_BACKEND=${FF_GPU_BACKEND} cuda_version=${cuda_version} $(pwd)/pull.sh $image"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -58,8 +58,8 @@ else
   cuda_version_hyphen=""
 fi
 
-# Check that image exists
-if docker image inspect "${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}":latest > /dev/null || true ; then
+# Check that image exists, if fails, print the default error message.
+if [[ "$(docker images -q ${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest 2> /dev/null)" == "" ]]; then
   echo ""
   echo "To download the docker image, run:"
   echo "    FF_GPU_BACKEND=${FF_GPU_BACKEND} cuda_version=${cuda_version} $(pwd)/pull.sh $image"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -59,7 +59,7 @@ else
 fi
 
 # Check that image exists, if fails, print the default error message.
-if [[ docker images -q "${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest" 2> /dev/null == "" ]]; then
+if [[ "$(docker images -q ${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest 2> /dev/null)" == "" ]]; then
   echo ""
   echo "To download the docker image, run:"
   echo "    FF_GPU_BACKEND=${FF_GPU_BACKEND} cuda_version=${cuda_version} $(pwd)/pull.sh $image"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -59,7 +59,7 @@ else
 fi
 
 # Check that image exists, if fails, print the default error message.
-if [[ "$(docker images -q ${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest 2> /dev/null)" == "" ]]; then
+if [[ "$(docker images -q "$image"-"$FF_GPU_BACKEND""$cuda_version_hyphen":latest 2> /dev/null)" == "" ]]; then
   echo ""
   echo "To download the docker image, run:"
   echo "    FF_GPU_BACKEND=${FF_GPU_BACKEND} cuda_version=${cuda_version} $(pwd)/pull.sh $image"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -59,7 +59,7 @@ else
 fi
 
 # Check that image exists, if fails, print the default error message.
-if (docker images -q "${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest" 2> /dev/null) == ""; then
+if [[ docker images -q "${image}-${FF_GPU_BACKEND}${cuda_version_hyphen}:latest" 2> /dev/null == "" ]]; then
   echo ""
   echo "To download the docker image, run:"
   echo "    FF_GPU_BACKEND=${FF_GPU_BACKEND} cuda_version=${cuda_version} $(pwd)/pull.sh $image"


### PR DESCRIPTION
**Description of changes:**
Fix the `docker inspect` error message printing issue.
Modify the original way to check the existence of the docker image so that run a command `the docker images -q ... ` and check if it exists or not (you can check if the exit code is 0 or something else) and in case it doesn't exist, print our error message, otherwise, just continue without doing anything.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
