### PR TITLE
Enable legion tracing for incr_decoding and spec_infer

### DIFF
--- a/src/runtime/request_manager.cc
+++ b/src/runtime/request_manager.cc
@@ -1593,6 +1593,9 @@ GenerationResult RequestManager::generate_incr_decoding(FFModel *llm,
     if (is_request_completed(guid)) {
       break;
     }
+    Runtime *runtime = Runtime::get_runtime();
+    Context ctx = Runtime::get_context();
+    runtime->begin_trace(ctx, 12346 /*trace_id*/);
     auto const &next_batch = batch_pipeline.back();
     BatchConfigFuture bcf =
         prepare_next_batch(next_batch.first, next_batch.second);
@@ -1602,6 +1605,7 @@ GenerationResult RequestManager::generate_incr_decoding(FFModel *llm,
     batch_pipeline.push(std::make_pair(bcf, irf));
     last_bcf = bcf;
     last_irf = irf;
+    runtime->end_trace(ctx, 12346 /*trace_id*/);
   }
   GenerationResult gr = get_generation_result(guid);
   assert(gr.output_tokens.size() >= max_seq_length);
@@ -1649,6 +1653,9 @@ GenerationResult RequestManager::generate_spec_infer(FFModel *llm,
     // if (is_request_completed(guid)) {
     //   break;
     // }
+    Runtime *runtime = Runtime::get_runtime();
+    Context ctx = Runtime::get_context();
+    runtime->begin_trace(ctx, 12345 /*trace_id*/);
 
     for (size_t i = 0; i < get_num_ssms(); i++) {
       for (int depth = 0; depth < BeamSearchBatchConfig::MAX_BEAM_DEPTH;
@@ -1672,6 +1679,7 @@ GenerationResult RequestManager::generate_spec_infer(FFModel *llm,
       last_tree_bcf = tree_bcf;
       last_tree_irf = tree_irf;
     }
+    runtime->end_trace(ctx, 12345 /*trace_id*/);
   }
 
   GenerationResult gr = get_generation_result(guid);


### PR DESCRIPTION
**Description of changes:**

This PR enables Legion's tracing optimization for FlexFlow Serve.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
