### PR TITLE
[Bug] Fix edge case when we have exactly MAX_NUM_TOKENS in the first verify batch

### DIFF
--- a/include/flexflow/batch_config.h
+++ b/include/flexflow/batch_config.h
@@ -54,8 +54,7 @@ public:
   static BatchConfig const *from_future(BatchConfigFuture const &future);
   static int const MAX_NUM_REQUESTS = 1;
   static int const MAX_NUM_TOKENS = 64;
-  static int const MAX_PROMPT_LENGTH =
-      63; // should be MAX_NUM_TOKENS - 1 for SpecInfer
+  static int const MAX_PROMPT_LENGTH = 62;
   static int const MAX_SEQ_LENGTH = 256;
 
   //  These are set by update

--- a/inference/models/configs/llama_68M.json
+++ b/inference/models/configs/llama_68M.json
@@ -1,0 +1,11 @@
+{
+    "n_layers": 2,
+    "vocab_size": 32000,
+    "n_heads": 12,
+    "dim": 768,
+    "multiple_of": 256,
+    "norm_eps": 1e-06,
+    "total_requests": 2560,
+    "hidden_dim": 3072,
+    "incremental_mode": true
+}

--- a/inference/utils/convert_llama_config.py
+++ b/inference/utils/convert_llama_config.py
@@ -1,0 +1,32 @@
+import argparse
+import json
+
+def convert_json(input_file, output_file):
+    # Load the input JSON data from the file
+    with open(input_file, 'r') as file:
+        input_data = json.load(file)
+
+    # Extract the required fields and create the output JSON object
+    output_data = {
+        "n_layers": input_data["num_hidden_layers"],
+        "vocab_size": input_data["vocab_size"],
+        "n_heads": input_data["num_attention_heads"],
+        "dim": input_data["hidden_size"],
+        "multiple_of": 256,
+        "norm_eps": input_data["rms_norm_eps"],
+        "total_requests": 2560,
+        "hidden_dim": input_data["intermediate_size"],
+        "incremental_mode": input_data["use_cache"]
+    }
+
+    # Save the output JSON data to the file
+    with open(output_file, 'w') as file:
+        json.dump(output_data, file, indent=4)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert JSON file to a different format.")
+    parser.add_argument("input_file", help="Path to the input JSON file.")
+    parser.add_argument("output_file", help="Path to the output JSON file.")
+    args = parser.parse_args()
+
+    convert_json(args.input_file, args.output_file)

--- a/src/runtime/request_manager.cc
+++ b/src/runtime/request_manager.cc
@@ -1094,7 +1094,7 @@ TreeVerifyBatchConfig RequestManager::prepare_next_batch_verify(
       new_bc.num_tokens++;
       new_bc.requestsInfo[i].num_tokens_in_batch++;
 
-      if (new_bc.num_tokens == BatchConfig::MAX_NUM_TOKENS) {
+      if (new_bc.num_tokens == BatchConfig::MAX_NUM_TOKENS - 1) {
         break;
       }
     }
@@ -1148,6 +1148,7 @@ void RequestManager::store_beam_metadata(BeamSearchBatchConfig const &old_bc,
         std::cout << "i = " << i << ", result index = " << result_index
                   << ", value: " << result.token_ids[result_index] << "\n";
       }
+
       int index = old_bc.tokensInfo[i - 1].request_index;
       int beam_size = old_bc.beamRequestsInfo[index].beam_size;
       int depth = old_bc.beamRequestsInfo[index].current_depth;


### PR DESCRIPTION
**Description of changes:**
In the edge case of exactly `MAX_NUM_TOKENS` in the first verify batch, the extra token generated by the large model will overflow and mess up the depth.
Also added the config file of llama_68M to inference/model/configs and a tool to convert the hugging face LLaMA config to SpecInfer LLaMA config.

**Related Issues:**

Linked Issues:
- Issue #900 

Issues closed by this PR:
- Closes #900 

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
