### PR TITLE
Fixes #906. Capture variables in lambda by copy.

### DIFF
--- a/src/ops/attention.cc
+++ b/src/ops/attention.cc
@@ -824,7 +824,7 @@ bool MultiHeadAttention::measure_operator_cost(
     cost_metrics.outputs_memory +=
         cost_metrics.total_mem_diff_from(sim->offset);
 
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(m,
                               query_ptr,
                               query_grad_ptr,

--- a/src/ops/batch_norm.cc
+++ b/src/ops/batch_norm.cc
@@ -286,7 +286,7 @@ bool BatchNorm::measure_operator_cost(Simulator *sim,
     cost_metrics.weights_memory +=
         cost_metrics.total_mem_diff_from(sim->offset);
 
-    backward = [&] {
+    backward = [=] {
       backward_kernel(m,
                       input_ptr,
                       output_grad_ptr,

--- a/src/ops/concat.cc
+++ b/src/ops/concat.cc
@@ -426,7 +426,7 @@ bool Concat::measure_operator_cost(Simulator *sim,
       cost_metrics.backward_time = Simulator::MAXIMUM_TASK_RUN_TIME;
       return true;
     }
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(
           m, output_grad_acc, input_grad_accs, numInputs, legion_axis);
     };

--- a/src/ops/dropout.cc
+++ b/src/ops/dropout.cc
@@ -326,7 +326,7 @@ bool Dropout::measure_operator_cost(Simulator *sim,
     cost_metrics.outputs_memory +=
         cost_metrics.total_mem_diff_from(sim->offset);
 
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(m, output_grad_ptr, input_grad_ptr);
     };
   }

--- a/src/ops/element_binary.cc
+++ b/src/ops/element_binary.cc
@@ -764,7 +764,7 @@ bool ElementBinary::measure_operator_cost(Simulator *sim,
     cost_metrics.outputs_memory +=
         cost_metrics.total_mem_diff_from(sim->offset);
 
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(m,
                               output_grad_ptr,
                               input1_ptr,

--- a/src/ops/element_unary.cc
+++ b/src/ops/element_unary.cc
@@ -638,7 +638,7 @@ bool ElementUnary::measure_operator_cost(Simulator *sim,
     cost_metrics.outputs_memory +=
         cost_metrics.total_mem_diff_from(sim->offset);
 
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(m,
                               input_ptr,
                               input_grad_ptr,

--- a/src/ops/flat.cc
+++ b/src/ops/flat.cc
@@ -357,7 +357,7 @@ bool Flat::measure_operator_cost(Simulator *sim,
 
     assert(output_grad_ptr != NULL);
     assert(input_grad_ptr != NULL);
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(input_grad_ptr, output_grad_ptr, num_elements);
     };
   }

--- a/src/ops/layer_norm.cc
+++ b/src/ops/layer_norm.cc
@@ -505,7 +505,7 @@ bool LayerNorm::measure_operator_cost(Simulator *sim,
       return true;
     }
 
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper<float>(m,
                                      out_grad_ptr,
                                      in_ptr,

--- a/src/ops/linear.cc
+++ b/src/ops/linear.cc
@@ -875,7 +875,7 @@ bool Linear::measure_operator_cost(Simulator *sim,
       cost_metrics.backward_time = Simulator::MAXIMUM_TASK_RUN_TIME;
       return true;
     }
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(m,
                               input_ptr,
                               input_grad_ptr,

--- a/src/ops/reduce.cc
+++ b/src/ops/reduce.cc
@@ -344,7 +344,7 @@ bool Reduce::measure_operator_cost(Simulator *sim,
     GenericTensorAccessorR output_grad_acc(
         outputs[0]->data_type, sub_output.get_domain(), output_grad_ptr);
 
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(m, output_grad_acc, input_grad_acc);
     };
   }

--- a/src/ops/reverse.cc
+++ b/src/ops/reverse.cc
@@ -282,7 +282,7 @@ bool Reverse::measure_operator_cost(Simulator *sim,
     cost_metrics.outputs_memory +=
         cost_metrics.total_mem_diff_from(sim->offset);
 
-    backward = [&] {
+    backward = [=] {
       backward_kernel_wrapper(output_grad_ptr,
                               input_grad_ptr,
                               num_out_blks,


### PR DESCRIPTION
**Description of changes:**

The variables captured by std::function go out of scope, resulting in runtime errors. Instead, copy the values so they persist after the lexical block. 

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #906 

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/FlexFlow/958)
<!-- Reviewable:end -->
