### PR TITLE
Fix a potential link error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,8 @@ list(APPEND FF_NVCC_FLAGS
 list(APPEND FF_LD_FLAGS
   -lrt
   -ldl
-  -rdynamic)
+  -rdynamic
+  -lstdc++fs)
 
 # Set FF FLAGS
 add_compile_options(${FF_CC_FLAGS})


### PR DESCRIPTION
**Description of changes:**

This PR fixes a lib link error we encountered on the Catalyst cluster

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
