### PR TITLE
Allow FlexFlow Serve to stop when EOS token is generated

### DIFF
--- a/include/flexflow/request_manager.h
+++ b/include/flexflow/request_manager.h
@@ -219,7 +219,7 @@ private:
                                                   {ModelType::STARCODER, 0}};
   const std::map<ModelType, int> model_eos_map = {{ModelType::LLAMA, 1},
                                                   {ModelType::OPT, 2},
-                                                  {ModelType::LLAMA2, 13},
+                                                  {ModelType::LLAMA2, 2},
                                                   {ModelType::FALCON, 11},
                                                   {ModelType::STARCODER, 0}};
 

--- a/include/flexflow/request_manager.h
+++ b/include/flexflow/request_manager.h
@@ -51,9 +51,15 @@ public:
 };
 
 struct Request {
+  enum Status {
+    PENDING = 101,
+    RUNNING = 102,
+    COMPLETED = 103,
+  };
   BatchConfig::RequestGuid guid;
   int max_sequence_length;
   int initial_len;
+  Status status = PENDING;
   std::vector<BatchConfig::TokenId> tokens;
 
   std::vector<struct BeamTree> beam_trees;
@@ -206,8 +212,16 @@ private:
   InferenceResultFuture last_irf;
   TreeVerifyBatchConfigFuture last_tree_bcf;
   InferenceResultFuture last_tree_irf;
-  const std::map<ModelType, int> model_bos_map = {
-      {ModelType::LLAMA, 0}, {ModelType::OPT, 2}, {ModelType::LLAMA2, 1}};
+  const std::map<ModelType, int> model_bos_map = {{ModelType::LLAMA, 0},
+                                                  {ModelType::OPT, 2},
+                                                  {ModelType::LLAMA2, 1},
+                                                  {ModelType::FALCON, 11},
+                                                  {ModelType::STARCODER, 0}};
+  const std::map<ModelType, int> model_eos_map = {{ModelType::LLAMA, 1},
+                                                  {ModelType::OPT, 2},
+                                                  {ModelType::LLAMA2, 13},
+                                                  {ModelType::FALCON, 11},
+                                                  {ModelType::STARCODER, 0}};
 
   // TODO: Move this two vector to request struct
   std::unordered_map<RequestGuid,

--- a/python/flexflow/serve/serve.py
+++ b/python/flexflow/serve/serve.py
@@ -82,7 +82,7 @@ class LLM:
         :type output_file: str, optional
         """
         self.supported_models = {
-            "LlamaForCausalLM": (ModelType.LLAMA, FlexFlowLLAMA),
+            "LlamaForCausalLM": (ModelType.LLAMA2, FlexFlowLLAMA),
             "LLaMAForCausalLM": (ModelType.LLAMA, FlexFlowLLAMA),
             "OPTForCausalLM": (ModelType.OPT, FlexFlowOPT),
             "RWForCausalLM": (ModelType.FALCON, FlexFlowFalcon),

--- a/python/flexflow/serve/serve.py
+++ b/python/flexflow/serve/serve.py
@@ -82,7 +82,7 @@ class LLM:
         :type output_file: str, optional
         """
         self.supported_models = {
-            "LlamaForCausalLM": (ModelType.LLAMA2, FlexFlowLLAMA),
+            "LlamaForCausalLM": (ModelType.LLAMA, FlexFlowLLAMA),
             "LLaMAForCausalLM": (ModelType.LLAMA, FlexFlowLLAMA),
             "OPTForCausalLM": (ModelType.OPT, FlexFlowOPT),
             "RWForCausalLM": (ModelType.FALCON, FlexFlowFalcon),


### PR DESCRIPTION
**Description of changes:**

This PR enables early stop, which will allow `llm.generate` to return immediately when an EOS token is generated.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #1013 

