### PR TITLE
Serialize jobs in `per-lib-checks` workflow

### DIFF
--- a/.github/workflows/per-lib-check.yml
+++ b/.github/workflows/per-lib-check.yml
@@ -12,6 +12,7 @@ jobs:
       run:
         shell: bash -l {0} # required to use an activated conda environment
     strategy:
+      max-parallel: 1
       matrix:
         gpu_backend: ["cuda","hip_rocm"]
         library: ["runtime", "ffi","compiler","kernels","op-attrs","pcg","substitutions","utils"]


### PR DESCRIPTION
**Description of changes:**
The `per-lib-check` workflow from the repo refactor branches uses 16 runners at a time (for each commit / PR), out of the 20 in total that we have available for the repo. This PR serializes the jobs so that workflows from other branches / users / PRs do not starve


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

