### PR TITLE
[SpecInfer] Reduce single request per batch overhead

### DIFF
--- a/include/flexflow/batch_config.h
+++ b/include/flexflow/batch_config.h
@@ -46,7 +46,7 @@ public:
   void print() const;
   virtual InferenceMode get_mode() const;
   static BatchConfig const *from_future(BatchConfigFuture const &future);
-  static int const MAX_NUM_REQUESTS = 8;
+  static int const MAX_NUM_REQUESTS = 7;
   static int const MAX_NUM_TOKENS = 64;
   static int const MAX_SEQ_LENGTH = 256;
 
@@ -111,7 +111,7 @@ public:
   size_t beam_width;
   size_t target_iterations;
   inline static int const MAX_BEAM_WIDTH = 1;
-  inline static int const MAX_BEAM_DEPTH = 7;
+  inline static int const MAX_BEAM_DEPTH = 8;
 
   int model_id;
 

--- a/include/flexflow/batch_config.h
+++ b/include/flexflow/batch_config.h
@@ -46,9 +46,8 @@ public:
   void print() const;
   virtual InferenceMode get_mode() const;
   static BatchConfig const *from_future(BatchConfigFuture const &future);
-  static int const MAX_NUM_REQUESTS = 4;
+  static int const MAX_NUM_REQUESTS = 8;
   static int const MAX_NUM_TOKENS = 64;
-  static int const MAX_PROMPT_LENGTH = 62;
   static int const MAX_SEQ_LENGTH = 256;
 
   //  These are set by update
@@ -112,7 +111,7 @@ public:
   size_t beam_width;
   size_t target_iterations;
   inline static int const MAX_BEAM_WIDTH = 1;
-  inline static int const MAX_BEAM_DEPTH = 8;
+  inline static int const MAX_BEAM_DEPTH = 7;
 
   int model_id;
 

--- a/src/runtime/request_manager.cc
+++ b/src/runtime/request_manager.cc
@@ -1264,7 +1264,7 @@ TreeVerifyBatchConfig RequestManager::prepare_next_batch_verify(
 
           std::cout << "new_bc.requestsInfo[i].num_tokens_in_batch: "
                     << new_bc.requestsInfo[i].num_tokens_in_batch << std::endl;
-          
+
           dfs_tree_inputs[guid] =
               std::vector<std::pair<BatchConfig::TokenId, int>>{std::make_pair(
                   request.tokens.back(), request.tokens.size() - 1)};


### PR DESCRIPTION
**Description of changes:**
Minimize token loading overhead for small requests in batches. Reduce the decoding step of the loading prompt to 1 step.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

