### PR TITLE
Compare file paths reliably

### DIFF
--- a/python/flexflow_python_build.py
+++ b/python/flexflow_python_build.py
@@ -43,7 +43,7 @@ lines = [
     f'BUILD_FOLDER="{build_dir}"',
     'SCRIPT_DIR="$(realpath "${BASH_SOURCE[0]%/*}")"',
     'legion_python_args=("$@" "-ll:py" "1")',
-    'if [[ "$SCRIPT_DIR" == "$BUILD_FOLDER" ]]; then',
+    'if [[ "$SCRIPT_DIR" -ef "$BUILD_FOLDER" ]]; then',
     f'\tPYTHON_FOLDER="{script_dir}"',
     '\tPYLIB_PATH="$("$PYTHON_FOLDER"/flexflow/findpylib.py)"',
     '\tPYLIB_DIR="$(dirname "$PYLIB_PATH")"',


### PR DESCRIPTION
**Description of changes:**

`-ef` is "True if file1 and file2 refer to the same device and inode numbers."

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #957

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/FlexFlow/1173)
<!-- Reviewable:end -->
