### PR TITLE
Update the data layout of m->attn_heads

### DIFF
--- a/src/ops/inc_multihead_self_attention.cu
+++ b/src/ops/inc_multihead_self_attention.cu
@@ -650,19 +650,19 @@ void compute_attention_kernel(IncMultiHeadSelfAttentionMeta const *m,
                                    C_softmax));
     // Matmul softmax(QK^T/sqrt(d_k)) by V
     alpha = 1.0f, beta = 0.0f;
-    m_ = num_new_tokens;
-    n = m->vProjSize;
+    m_ = m->vProjSize;
+    n = num_new_tokens;
     k = total_tokens;
-    lda = m_, ldb = n * m->num_q_heads, ldc = m_;
-    strideA = num_new_tokens * total_tokens;
-    strideB = vt_block_size;
-    strideC = num_new_tokens * m->vProjSize;
-    // To get A, skip over softmax(QK^T/sqrt(d_k)) entries from previous
-    // requests (all heads)
-    A = C_softmax;
-    // To get B, skip over V^T entries from previous requests (all heads +
+    lda = m_ * m->num_q_heads, ldb = n, ldc = m_ * m->num_q_heads;
+    strideA = vt_block_size;
+    strideB = num_new_tokens * total_tokens;
+    strideC = m->vProjSize;
+    // To get A, skip over V^T entries from previous requests (all heads +
     // padding)
-    B = static_cast<DT *>(m->valueCache) + i * vt_req_block_size;
+    A = static_cast<DT *>(m->valueCache) + i * vt_req_block_size;
+    // To get B, skip over softmax(QK^T/sqrt(d_k)) entries from previous
+    // requests (all heads)
+    B = C_softmax;
     // To get C, skip over softmax(QK^T/sqrt(d_k))V products from previous
     // requests
     C = static_cast<DT *>(m->attn_heads) +
@@ -695,7 +695,7 @@ void compute_attention_kernel(IncMultiHeadSelfAttentionMeta const *m,
     m_ = m->oProjSize;
     k = m->vProjSize * m->num_q_heads;
     n = num_new_tokens;
-    lda = k, ldb = n, ldc = m_;
+    lda = k, ldb = k, ldc = m_;
     A = weight_ptr + m->qSize * (m->qProjSize * m->num_q_heads +
                                  m->kProjSize * m->num_q_heads +
                                  m->vProjSize * m->num_q_heads);
@@ -704,7 +704,7 @@ void compute_attention_kernel(IncMultiHeadSelfAttentionMeta const *m,
 
     checkCUDA(cublasGemmEx(m->handle.blas,
                            CUBLAS_OP_T,
-                           CUBLAS_OP_T,
+                           CUBLAS_OP_N,
                            m_,
                            n,
                            k,

--- a/src/ops/inc_multihead_self_attention.cu
+++ b/src/ops/inc_multihead_self_attention.cu
@@ -690,39 +690,40 @@ void compute_attention_kernel(IncMultiHeadSelfAttentionMeta const *m,
                                          m->num_q_heads,
                                          compute_type,
                                          CUBLAS_GEMM_DEFAULT_TENSOR_OP));
-    // Project to output, save result directly on output tensor
-    alpha = 1.0f, beta = 0.0f;
-    m_ = m->oProjSize;
-    k = m->vProjSize * m->num_q_heads;
-    n = num_new_tokens;
-    lda = k, ldb = k, ldc = m_;
-    A = weight_ptr + m->qSize * (m->qProjSize * m->num_q_heads +
-                                 m->kProjSize * m->num_q_heads +
-                                 m->vProjSize * m->num_q_heads);
-    B = C;
-    C = static_cast<DT *>(output_ptr) + tokens_previous_requests * m->oProjSize;
-
-    checkCUDA(cublasGemmEx(m->handle.blas,
-                           CUBLAS_OP_T,
-                           CUBLAS_OP_N,
-                           m_,
-                           n,
-                           k,
-                           &alpha,
-                           A,
-                           cublas_data_type,
-                           lda,
-                           B,
-                           cublas_data_type,
-                           ldb,
-                           &beta,
-                           C,
-                           cublas_data_type,
-                           ldc,
-                           compute_type,
-                           CUBLAS_GEMM_DEFAULT_TENSOR_OP));
     tokens_previous_requests += num_new_tokens;
   }
+
+  // Project to output, save result directly on output tensor
+  DT alpha = 1.0f, beta = 0.0f;
+  int m_ = m->oProjSize;
+  int k = m->vProjSize * m->num_q_heads;
+  int n = bc->num_active_tokens();
+  int lda = k, ldb = k, ldc = m_;
+  DT const *A = weight_ptr + m->qSize * (m->qProjSize * m->num_q_heads +
+                                         m->kProjSize * m->num_q_heads +
+                                         m->vProjSize * m->num_q_heads);
+  DT const *B = static_cast<DT *>(m->attn_heads);
+  DT *C = static_cast<DT *>(output_ptr);
+
+  checkCUDA(cublasGemmEx(m->handle.blas,
+                         CUBLAS_OP_T,
+                         CUBLAS_OP_N,
+                         m_,
+                         n,
+                         k,
+                         &alpha,
+                         A,
+                         cublas_data_type,
+                         lda,
+                         B,
+                         cublas_data_type,
+                         ldb,
+                         &beta,
+                         C,
+                         cublas_data_type,
+                         ldc,
+                         compute_type,
+                         CUBLAS_GEMM_DEFAULT_TENSOR_OP));
 
   if (*m->final_bias && shard_id == 0) {
     int parallelism = m->oProjSize * num_tokens;

--- a/src/ops/spec_inc_multihead_self_attention.cu
+++ b/src/ops/spec_inc_multihead_self_attention.cu
@@ -420,42 +420,42 @@ void compute_attention_kernel(SpecIncMultiHeadSelfAttentionMeta const *m,
                                            compute_type,
                                            CUBLAS_GEMM_DEFAULT_TENSOR_OP));
 
-      // Project to output, save result directly on output tensor
-      alpha = 1.0f, beta = 0.0f;
-      m_ = m->oProjSize;
-      k = m->vProjSize * m->num_q_heads;
-      n = num_new_tokens;
-      lda = k, ldb = k, ldc = m_;
-      A = weight_ptr + m->qSize * (m->qProjSize * m->num_q_heads +
-                                   m->kProjSize * m->num_q_heads +
-                                   m->vProjSize * m->num_q_heads);
-      B = C;
-      C = static_cast<DT *>(output_ptr) +
-          bc->requestsInfo[i].first_token_offset_in_batch * m->oProjSize;
-
-      checkCUDA(cublasGemmEx(m->handle.blas,
-                             CUBLAS_OP_T,
-                             CUBLAS_OP_N,
-                             m_,
-                             n,
-                             k,
-                             &alpha,
-                             A,
-                             cublas_data_type,
-                             lda,
-                             B,
-                             cublas_data_type,
-                             ldb,
-                             &beta,
-                             C,
-                             cublas_data_type,
-                             ldc,
-                             compute_type,
-                             CUBLAS_GEMM_DEFAULT_TENSOR_OP));
       // tokens_previous_requests += num_new_tokens;
       tokens_prev_requests_squares += num_new_tokens * total_tokens;
     }
   }
+
+  // Project to output, save result directly on output tensor
+  DT alpha = 1.0f, beta = 0.0f;
+  int m_ = m->oProjSize;
+  int k = m->vProjSize * m->num_q_heads;
+  int n = bc->num_active_tokens();
+  int lda = k, ldb = k, ldc = m_;
+  DT const *A = weight_ptr + m->qSize * (m->qProjSize * m->num_q_heads +
+                                         m->kProjSize * m->num_q_heads +
+                                         m->vProjSize * m->num_q_heads);
+  DT const *B = static_cast<DT *>(m->attn_heads);
+  DT *C = static_cast<DT *>(output_ptr);
+
+  checkCUDA(cublasGemmEx(m->handle.blas,
+                         CUBLAS_OP_T,
+                         CUBLAS_OP_N,
+                         m_,
+                         n,
+                         k,
+                         &alpha,
+                         A,
+                         cublas_data_type,
+                         lda,
+                         B,
+                         cublas_data_type,
+                         ldb,
+                         &beta,
+                         C,
+                         cublas_data_type,
+                         ldc,
+                         compute_type,
+                         CUBLAS_GEMM_DEFAULT_TENSOR_OP));
   if (*m->final_bias && shard_id == 0) {
     int parallelism = m->oProjSize * num_tokens;
     int qkv_weight_size = m->qProjSize * m->global_num_q_heads +

--- a/src/ops/spec_inc_multihead_self_attention.cu
+++ b/src/ops/spec_inc_multihead_self_attention.cu
@@ -223,7 +223,7 @@ void compute_attention_kernel(SpecIncMultiHeadSelfAttentionMeta const *m,
 #endif
   // int num_requests = bc->num_active_requests();
   int num_tokens = bc->num_active_tokens();
-  int tokens_previous_requests = 0;
+  // int tokens_previous_requests = 0;
   int tokens_prev_requests_squares = 0;
   // int qkv_block_size =
   //     (m->qProjSize + m->kProjSize + m->vProjSize) * num_tokens;
@@ -241,10 +241,7 @@ void compute_attention_kernel(SpecIncMultiHeadSelfAttentionMeta const *m,
     if (bc->request_completed[i]) {
       continue;
     }
-    assert(tokens_previous_requests ==
-           bc->requestsInfo[i].first_token_offset_in_batch);
     for (int sub_req_id = 0; sub_req_id < bc->sub_requests[i]; sub_req_id++) {
-
       // int num_new_tokens = bc->num_processing_tokens[i];
       // int total_tokens = bc->token_last_available_idx[i] + 1;
 
@@ -273,8 +270,8 @@ void compute_attention_kernel(SpecIncMultiHeadSelfAttentionMeta const *m,
       }
       // To get A, skip over Q entries from previous requests (same head)
       DT const *A = static_cast<DT *>(m->devQKVProjArray) +
-                    tokens_previous_requests * m->qProjSize * m->num_q_heads *
-                        QKV_WEIGHT_NUM;
+                    bc->requestsInfo[i].first_token_offset_in_batch *
+                        m->qProjSize * m->num_q_heads * QKV_WEIGHT_NUM;
       // To get B, skip over K entries from previous requests (all heads +
       // padding)
       DT const *B = static_cast<DT *>(m->keyCache) +
@@ -380,24 +377,25 @@ void compute_attention_kernel(SpecIncMultiHeadSelfAttentionMeta const *m,
                                      C_softmax));
       // Matmul softmax(QK^T/sqrt(d_k)) by V
       alpha = 1.0f, beta = 0.0f;
-      m_ = num_new_tokens;
-      n = m->vProjSize;
+      m_ = m->vProjSize;
+      n = num_new_tokens;
       k = total_tokens;
-      lda = m_, ldb = n * m->num_q_heads, ldc = m_;
-      strideA = num_new_tokens * total_tokens;
-      strideB = vt_block_size;
-      strideC = num_new_tokens * m->vProjSize;
-      // To get A, skip over softmax(QK^T/sqrt(d_k)) entries from previous
-      // requests (all heads)
-      A = C_softmax;
-      // To get B, skip over V^T entries from previous requests (all heads +
+      lda = m_ * m->num_q_heads, ldb = n, ldc = m_ * m->num_q_heads;
+      strideA = vt_block_size;
+      strideB = num_new_tokens * total_tokens;
+      strideC = m->vProjSize;
+      // To get A, skip over V^T entries from previous requests (all heads +
       // padding)
-      B = static_cast<DT *>(m->valueCache) +
+      A = static_cast<DT *>(m->valueCache) +
           (i * bc->MAX_BEAM_WIDTH + sub_req_id) * vt_req_block_size;
+      // To get B, skip over softmax(QK^T/sqrt(d_k)) entries from previous
+      // requests (all heads)
+      B = C_softmax;
       // To get C, skip over softmax(QK^T/sqrt(d_k))V products from previous
       // requests
       C = static_cast<DT *>(m->attn_heads) +
-          tokens_previous_requests * m->num_q_heads * m->vProjSize;
+          bc->requestsInfo[i].first_token_offset_in_batch * m->num_q_heads *
+              m->vProjSize;
       checkCUDA(cublasGemmStridedBatchedEx(m->handle.blas,
                                            CUBLAS_OP_N,
                                            CUBLAS_OP_T,
@@ -427,17 +425,17 @@ void compute_attention_kernel(SpecIncMultiHeadSelfAttentionMeta const *m,
       m_ = m->oProjSize;
       k = m->vProjSize * m->num_q_heads;
       n = num_new_tokens;
-      lda = k, ldb = n, ldc = m_;
+      lda = k, ldb = k, ldc = m_;
       A = weight_ptr + m->qSize * (m->qProjSize * m->num_q_heads +
                                    m->kProjSize * m->num_q_heads +
                                    m->vProjSize * m->num_q_heads);
       B = C;
       C = static_cast<DT *>(output_ptr) +
-          tokens_previous_requests * m->oProjSize;
+          bc->requestsInfo[i].first_token_offset_in_batch * m->oProjSize;
 
       checkCUDA(cublasGemmEx(m->handle.blas,
                              CUBLAS_OP_T,
-                             CUBLAS_OP_T,
+                             CUBLAS_OP_N,
                              m_,
                              n,
                              k,
@@ -454,7 +452,7 @@ void compute_attention_kernel(SpecIncMultiHeadSelfAttentionMeta const *m,
                              ldc,
                              compute_type,
                              CUBLAS_GEMM_DEFAULT_TENSOR_OP));
-      tokens_previous_requests += num_new_tokens;
+      // tokens_previous_requests += num_new_tokens;
       tokens_prev_requests_squares += num_new_tokens * total_tokens;
     }
   }

--- a/src/ops/tree_inc_multihead_self_attention.cu
+++ b/src/ops/tree_inc_multihead_self_attention.cu
@@ -378,45 +378,43 @@ void compute_attention_kernel(TreeIncMultiHeadSelfAttentionMeta const *m,
                                            m->num_q_heads,
                                            compute_type,
                                            CUBLAS_GEMM_DEFAULT_TENSOR_OP));
-
-      // Project to output, save result directly on output tensor
-      alpha = 1.0f, beta = 0.0f;
-      m_ = m->oProjSize;
-      k = m->vProjSize * m->num_q_heads;
-      n = num_new_tokens;
-      lda = k, ldb = k, ldc = m_;
-      A = weight_ptr + m->qSize * (m->qProjSize * m->num_q_heads +
-                                   m->kProjSize * m->num_q_heads +
-                                   m->vProjSize * m->num_q_heads);
-      B = C;
-      C = static_cast<DT *>(output_ptr) +
-          processed_tokens_in_batch * m->oProjSize;
-
-      checkCUDA(cublasGemmEx(m->handle.blas,
-                             CUBLAS_OP_T,
-                             CUBLAS_OP_N,
-                             m_,
-                             n,
-                             k,
-                             &alpha,
-                             A,
-                             cublas_data_type,
-                             lda,
-                             B,
-                             cublas_data_type,
-                             ldb,
-                             &beta,
-                             C,
-                             cublas_data_type,
-                             ldc,
-                             compute_type,
-                             CUBLAS_GEMM_DEFAULT_TENSOR_OP));
       processed_tokens_in_batch += num_new_tokens;
     }
     // Before moving to the next request
     // check that we have finished all tokens of the request
     assert(last_token_idx_of_the_request + 1 == processed_tokens_in_batch);
   }
+  // Project to output, save result directly on output tensor
+  DT alpha = 1.0f, beta = 0.0f;
+  int m_ = m->oProjSize;
+  int k = m->vProjSize * m->num_q_heads;
+  int n = processed_tokens_in_batch;
+  int lda = k, ldb = k, ldc = m_;
+  DT const *A = weight_ptr + m->qSize * (m->qProjSize * m->num_q_heads +
+                                         m->kProjSize * m->num_q_heads +
+                                         m->vProjSize * m->num_q_heads);
+  DT const *B = static_cast<DT *>(m->attn_heads);
+  DT *C = static_cast<DT *>(output_ptr);
+
+  checkCUDA(cublasGemmEx(m->handle.blas,
+                         CUBLAS_OP_T,
+                         CUBLAS_OP_N,
+                         m_,
+                         n,
+                         k,
+                         &alpha,
+                         A,
+                         cublas_data_type,
+                         lda,
+                         B,
+                         cublas_data_type,
+                         ldb,
+                         &beta,
+                         C,
+                         cublas_data_type,
+                         ldc,
+                         compute_type,
+                         CUBLAS_GEMM_DEFAULT_TENSOR_OP));
   if (*m->final_bias && shard_id == 0) {
     int parallelism = m->oProjSize * processed_tokens_in_batch;
     int qkv_weight_size = m->qProjSize * m->global_num_q_heads +


### PR DESCRIPTION
**Description of changes:**

This PR updates the layout of `m->attn_heads` from `[num_heads, vProjSize, num_tokens]` to `[num_tokens, num_heads, vProjSize]`. This change makes its layout consistent with other tensors in multihead attention.

This PR also fixes a offset calculation bug in `spec_inc_mha`. We used to assume that requests are ranked in the exact same order as the tokens, which is no longer true after several RequestManager changes. As a result, we may get the following requestsInfo. Note that request 4 uses token 135 - 150. The fix is to remove this assumption and use `first_token_offset_in_batch` to calculate token offsets.

```
(gdb) p bc->requestsInfo
$3 = {{first_token_depth_in_request = 96, first_token_offset_in_batch = 0, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000000}, {
    first_token_depth_in_request = 97, first_token_offset_in_batch = 9, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000001}, {
    first_token_depth_in_request = 84, first_token_offset_in_batch = 18, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000002}, {
    first_token_depth_in_request = 91, first_token_offset_in_batch = 27, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000003}, {
    first_token_depth_in_request = 0, first_token_offset_in_batch = 135, num_tokens_in_batch = 16, max_sequence_length = 128, request_guid = 1000016}, {
    first_token_depth_in_request = 93, first_token_offset_in_batch = 36, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000005}, {
    first_token_depth_in_request = 91, first_token_offset_in_batch = 45, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000006}, {
    first_token_depth_in_request = 82, first_token_offset_in_batch = 54, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000007}, {
    first_token_depth_in_request = 87, first_token_offset_in_batch = 63, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000008}, {
    first_token_depth_in_request = 82, first_token_offset_in_batch = 72, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000009}, {
    first_token_depth_in_request = 83, first_token_offset_in_batch = 81, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000010}, {
    first_token_depth_in_request = 95, first_token_offset_in_batch = 90, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000011}, {
    first_token_depth_in_request = 88, first_token_offset_in_batch = 99, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000012}, {
    first_token_depth_in_request = 62, first_token_offset_in_batch = 108, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000013}, {
    first_token_depth_in_request = 86, first_token_offset_in_batch = 117, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000014}, {
    first_token_depth_in_request = 85, first_token_offset_in_batch = 126, num_tokens_in_batch = 9, max_sequence_length = 128, request_guid = 1000015}, {
    first_token_depth_in_request = 0, first_token_offset_in_batch = 0, num_tokens_in_batch = 0, max_sequence_length = 0, request_guid = 0} <repeats 48 times>}

```

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/FlexFlow/1204)
<!-- Reviewable:end -->
