### PR TITLE
Add option to use external tl::expected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ set(FF_MAX_NUM_TASK_REGIONS "20" CACHE STRING
 set(FF_MAX_NUM_TASK_ARGUMENTS "5" CACHE STRING
   "Maximum number of arguments that can be declared in a TaskSignature")
 option(FF_USE_NCCL "Run FlexFlow with NCCL" OFF)
-option(FF_USE_EXTERNAL_NCCL "Enable use of NCCL pre-compiled library, if available" ON)
 option(FF_USE_PREBUILT_LEGION "Enable use of Legion pre-compiled library, if available" ON)
 option(FF_USE_ALL_PREBUILT_LIBRARIES "Enable use of all pre-compiled libraries, if available" OFF)
 option(FF_USE_PYTHON "Enable Python" ON)
@@ -49,6 +48,14 @@ set(FF_GPU_BACKEND "cuda" CACHE STRING "Select GPU Backend ${FF_GPU_BACKENDS}")
 set_property(CACHE FF_GPU_BACKEND PROPERTY STRINGS ${FF_GPU_BACKENDS})
 
 option(FF_USE_EXTERNAL_LEGION "Use pre-installed Legion" OFF)
+option(FF_USE_EXTERNAL_NCCL "Use pre-installed NCCL" OFF)
+option(FF_USE_EXTERNAL_JSON "Use pre-installed nlohmann::json" OFF)
+option(FF_USE_EXTERNAL_FMT "Use pre-installed fmt" OFF)
+option(FF_USE_EXTERNAL_SPDLOG "Use pre-installed spdlog" OFF)
+option(FF_USE_EXTERNAL_DOCTEST "Use pre-installed doctest" OFF)
+option(FF_USE_EXTERNAL_RAPIDCHECK "Use pre-installed rapidcheck" OFF)
+option(FF_USE_EXTERNAL_EXPECTED "Use pre-installed tl::expected" OFF)
+
 option(FF_BUILD_RESNET "build resnet example" OFF)
 option(FF_BUILD_RESNEXT "build resnext example" OFF)
 option(FF_BUILD_ALEXNET "build alexnet example" OFF)

--- a/cmake/expected.cmake
+++ b/cmake/expected.cmake
@@ -1,4 +1,9 @@
-set(EXPECTED_BUILD_TESTS OFF)
-set(EXPECTED_BUILD_PACKAGE OFF)
-
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/deps/expected)
+include(aliasing)
+if (FF_USE_EXTERNAL_EXPECTED)
+  find_package(tl-expected REQUIRED)
+  alias_library(expected tl::expected)
+else()
+  set(EXPECTED_BUILD_TESTS OFF)
+  set(EXPECTED_BUILD_PACKAGE OFF)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/deps/expected)
+endif()

--- a/flake.lock
+++ b/flake.lock
@@ -33,10 +33,34 @@
         "type": "indirect"
       }
     },
+    "proj-repo": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1711832134,
+        "narHash": "sha256-2KceZmXOOELnFiVH/wjndH2QtKro+B0W2SEkjkzuDD0=",
+        "owner": "lockshaw",
+        "repo": "proj",
+        "rev": "1c7c809a6cab8360620bb27470a615a1a0b03a17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lockshaw",
+        "repo": "proj",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "proj-repo": "proj-repo"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,15 @@
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-23.11";
     flake-utils.url = "github:numtide/flake-utils";
+
+    proj-repo = {
+      url = "github:lockshaw/proj";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }: flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: 
+  outputs = { self, nixpkgs, flake-utils, proj-repo, ... }: flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: 
     let 
       pkgs = import nixpkgs {
         inherit system;
@@ -54,7 +60,7 @@
       devShells = rec {
         ci = mkShell {
           shellHook = ''
-            export PATH="$HOME/ff/.scripts/:$HOME/ff/.modules/proj/bin/:$PATH"
+            export PATH="$HOME/ff/.scripts/:$PATH"
           '';
           
           CMAKE_FLAGS = lib.strings.concatStringsSep " " [
@@ -65,6 +71,7 @@
             "-DFF_USE_EXTERNAL_SPDLOG=ON"
             "-DFF_USE_EXTERNAL_DOCTEST=ON"
             "-DFF_USE_EXTERNAL_RAPIDCHECK=ON"
+            "-DFF_USE_EXTERNAL_EXPECTED=ON"
             "-DFF_USE_EXTERNAL_RANGEV3=ON"
             "-DFF_USE_EXTERNAL_BOOST_PREPROCESSOR=ON"
             "-DFF_USE_EXTERNAL_TYPE_INDEX=ON"
@@ -88,6 +95,7 @@
               cudaPackages.nccl
               cudaPackages.libcublas
               cudaPackages.cuda_cudart
+              tl-expected
             ])
             (with self.packages.${system}; [
               legion
@@ -112,6 +120,9 @@
               compdb
               jq
               gh
+            ])
+            (with proj-repo.packages.${system}; [
+              proj
             ])
             (with pkgs.python3Packages; [
               gitpython


### PR DESCRIPTION
**Description of changes:**

Add option to use external tl::expected

Add `proj` directly as a flake instead of through a submodule

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/FlexFlow/1347)
<!-- Reviewable:end -->
