### PR TITLE
fix: 'model_configs' AttributeError

### DIFF
--- a/python/flexflow/serve/serve.py
+++ b/python/flexflow/serve/serve.py
@@ -373,9 +373,9 @@ class LLM:
         model_configs = self.config_class(self.hf_config)
 
         self.rm.set_max_spec_tree_token_num(
-            self.model_configs.max_spec_tree_token_num
+            model_configs.max_spec_tree_token_num
             if "max_spec_tree_token_num"
-            in self.model_configs.__dict__
+            in model_configs.__dict__
             else 20
         )
 


### PR DESCRIPTION
**Description of changes:**

fix `python/serve/serve.py` typo: 

```bash
  File "/usr/FlexFlow/python/flexflow/serve/serve.py", line 378, in compile
    in self.model_configs.__dict__
       ^^^^^^^^^^^^^^^^^^
AttributeError: 'LLM' object has no attribute 'model_configs'
```

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/FlexFlow/1358)
<!-- Reviewable:end -->
