### PR TITLE
pip flexflow_python typo

### DIFF
--- a/python/flexflow/flexflow_python
+++ b/python/flexflow/flexflow_python
@@ -6,7 +6,7 @@ python_packages=$(python -c "from distutils import sysconfig; print(sysconfig.ge
 pylib_path="$(python "$python_packages"/flexflow/findpylib.py)"
 pylib_dir="$(dirname "$pylib_path")"
 export PATH="${python_packages}/flexflow/bin:${PATH}"
-export LD_LIBRARY_PATH="${python_packages}/flexflow/lib:${pylib_dir}:${PATH}"
+export LD_LIBRARY_PATH="${python_packages}/flexflow/lib:${pylib_dir}:${LD_LIBRARY_PATH}"
 legion_python_args=("$@" "-ll:py" "1")
 
 legion_python "${legion_python_args[@]}"


### PR DESCRIPTION
**Description of changes:**
Fixes LD_LIBRARY_PATH typo in pip's version of flexflow_python


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/FlexFlow/1461)
<!-- Reviewable:end -->
