### PR TITLE
Coutinuous batching schedulers

### DIFF
--- a/include/flexflow/request_manager.h
+++ b/include/flexflow/request_manager.h
@@ -130,6 +130,7 @@ struct Request {
     RUNNING = 102,   // running inference
     COMPLETED = 103, // finished and verified
     FINISHING = 104, // finishing request, but not yet verified
+    PREEMPTED = 105, // preempted request
   };
   BatchConfig::RequestGuid guid;
   int batch_index = -1;
@@ -346,9 +347,11 @@ public:
   void set_spec_infer_old_version(bool spec_infer_old_version);
   void set_greedy_schedule(bool greedy_schedule);
   void set_equal_schedule(bool equal_schedule);
+  void set_fcfs_slo(bool fcfs_slo);
   bool get_spec_infer_old_version();
   bool get_greedy_schedule();
   bool get_equal_schedule();
+  bool get_fcfs_slo();
   inline double get_slo_constraint(Request &request);
   double get_request_expected_latency(Request &request);
   Request &get_request_with_guid(RequestGuid guid);
@@ -465,6 +468,7 @@ private:
   bool spec_infer_old_version = false;
   bool greedy_schedule = false;
   bool equal_schedule = false;
+  bool fcfs_slo = false;
 
   std::unique_ptr<Tokenizer> tokenizer_;
   bool verbose;

--- a/include/flexflow/request_manager.h
+++ b/include/flexflow/request_manager.h
@@ -130,7 +130,6 @@ struct Request {
     RUNNING = 102,   // running inference
     COMPLETED = 103, // finished and verified
     FINISHING = 104, // finishing request, but not yet verified
-    PREEMPTED = 105, // preempted request
   };
   BatchConfig::RequestGuid guid;
   int batch_index = -1;
@@ -348,10 +347,12 @@ public:
   void set_greedy_schedule(bool greedy_schedule);
   void set_equal_schedule(bool equal_schedule);
   void set_fcfs_slo(bool fcfs_slo);
+  void set_stta(bool stta);
   bool get_spec_infer_old_version();
   bool get_greedy_schedule();
   bool get_equal_schedule();
   bool get_fcfs_slo();
+  bool get_stta();
   inline double get_slo_constraint(Request &request);
   double get_request_expected_latency(Request &request);
   Request &get_request_with_guid(RequestGuid guid);
@@ -469,6 +470,7 @@ private:
   bool greedy_schedule = false;
   bool equal_schedule = false;
   bool fcfs_slo = false;
+  bool stta = false; // The smallest time to attain policy
 
   std::unique_ptr<Tokenizer> tokenizer_;
   bool verbose;
@@ -501,9 +503,7 @@ private:
   int num_running_requests = 0;
   // Available requests in the batch config
   bool request_available[BatchConfig::MAX_NUM_REQUESTS];
-  bool request_preempted[BatchConfig::MAX_NUM_REQUESTS];
   int num_available_requests = 0;
-  int num_preempted_requests = 0;
   int ssm_completed = true;
   int ssm_tree_depth = 0;
 
@@ -532,6 +532,7 @@ private:
   BatchConfig prepare_llm_prefilling_batch();
   BatchConfig prepare_decoding_batch();
   BatchConfig prepare_decoding_batch_fcfs_slo();
+  BatchConfig prepare_decoding_batch_stta();
   /* ---------- Incremental Decoding Helper Functions ---------- */
 
   /* ---------- Spec Decoding Helper Functions ---------- */

--- a/include/flexflow/request_manager.h
+++ b/include/flexflow/request_manager.h
@@ -501,7 +501,9 @@ private:
   int num_running_requests = 0;
   // Available requests in the batch config
   bool request_available[BatchConfig::MAX_NUM_REQUESTS];
+  bool request_preempted[BatchConfig::MAX_NUM_REQUESTS];
   int num_available_requests = 0;
+  int num_preempted_requests = 0;
   int ssm_completed = true;
   int ssm_tree_depth = 0;
 
@@ -529,6 +531,7 @@ private:
   bool update_llm_decode_results(InferenceResult const &result);
   BatchConfig prepare_llm_prefilling_batch();
   BatchConfig prepare_decoding_batch();
+  BatchConfig prepare_decoding_batch_fcfs_slo();
   /* ---------- Incremental Decoding Helper Functions ---------- */
 
   /* ---------- Spec Decoding Helper Functions ---------- */

--- a/inference/incr_decoding/incr_decoding.cc
+++ b/inference/incr_decoding/incr_decoding.cc
@@ -62,7 +62,8 @@ void parse_input_args(char **argv,
                       double &request_per_second,
                       std::string &emission_file_path,
                       bool &add_special_tokens,
-                      bool &fcfs_slo) {
+                      bool &fcfs_slo,
+                      bool &stta) {
   for (int i = 1; i < argc; i++) {
     // llm model type
     if (!strcmp(argv[i], "-llm-model")) {
@@ -185,6 +186,10 @@ void parse_input_args(char **argv,
       fcfs_slo = true;
       continue;
     }
+    if (!strcmp(argv[i], "--stta")) {
+      stta = true;
+      continue;
+    }
   }
   if (paths.cache_folder_path.empty()) {
     char const *ff_cache_path = std::getenv("FF_CACHE_PATH");
@@ -232,6 +237,7 @@ void FlexFlow::top_level_task(Task const *task,
   double request_per_second = 1.0;
   bool add_special_tokens = true;
   bool fcfs_slo = false;
+  bool stta = false;
   std::string emission_file_path;
 
   InputArgs const &command_args = HighLevelRuntime::get_input_args();
@@ -263,7 +269,8 @@ void FlexFlow::top_level_task(Task const *task,
                    request_per_second,
                    emission_file_path,
                    add_special_tokens,
-                   fcfs_slo);
+                   fcfs_slo,
+                   stta);
   if (max_tokens_per_ssm_batch == -1) {
     max_tokens_per_ssm_batch = max_tokens_per_batch;
   }
@@ -359,6 +366,7 @@ void FlexFlow::top_level_task(Task const *task,
   rm->set_verbose(verbose);
   rm->set_streaming_cache(streaming_cache);
   rm->set_fcfs_slo(fcfs_slo);
+  rm->set_stta(stta);
   rm->register_tokenizer(
       model_type, bos_token_id, eos_token_ids, tokenizer_filepath);
   rm->register_output_filepath(file_paths.output_file_path);

--- a/inference/incr_decoding/incr_decoding.cc
+++ b/inference/incr_decoding/incr_decoding.cc
@@ -61,7 +61,8 @@ void parse_input_args(char **argv,
                       int &replica,
                       double &request_per_second,
                       std::string &emission_file_path,
-                      bool &add_special_tokens) {
+                      bool &add_special_tokens,
+                      bool &fcfs_slo) {
   for (int i = 1; i < argc; i++) {
     // llm model type
     if (!strcmp(argv[i], "-llm-model")) {
@@ -180,6 +181,10 @@ void parse_input_args(char **argv,
       add_special_tokens = false;
       continue;
     }
+    if (!strcmp(argv[i], "--fcfs-slo")) {
+      fcfs_slo = true;
+      continue;
+    }
   }
   if (paths.cache_folder_path.empty()) {
     char const *ff_cache_path = std::getenv("FF_CACHE_PATH");
@@ -226,6 +231,7 @@ void FlexFlow::top_level_task(Task const *task,
   int replica = 1;
   double request_per_second = 1.0;
   bool add_special_tokens = true;
+  bool fcfs_slo = false;
   std::string emission_file_path;
 
   InputArgs const &command_args = HighLevelRuntime::get_input_args();
@@ -256,7 +262,8 @@ void FlexFlow::top_level_task(Task const *task,
                    replica,
                    request_per_second,
                    emission_file_path,
-                   add_special_tokens);
+                   add_special_tokens,
+                   fcfs_slo);
   if (max_tokens_per_ssm_batch == -1) {
     max_tokens_per_ssm_batch = max_tokens_per_batch;
   }
@@ -351,6 +358,7 @@ void FlexFlow::top_level_task(Task const *task,
   rm->set_max_tree_width(16);
   rm->set_verbose(verbose);
   rm->set_streaming_cache(streaming_cache);
+  rm->set_fcfs_slo(fcfs_slo);
   rm->register_tokenizer(
       model_type, bos_token_id, eos_token_ids, tokenizer_filepath);
   rm->register_output_filepath(file_paths.output_file_path);

--- a/src/runtime/request_manager.cc
+++ b/src/runtime/request_manager.cc
@@ -346,6 +346,10 @@ void RequestManager::set_equal_schedule(bool equal_schedule_) {
   equal_schedule = equal_schedule_;
 }
 
+void RequestManager::set_fcfs_slo(bool fcfs_slo_) {
+  fcfs_slo = fcfs_slo_;
+}
+
 bool RequestManager::get_spec_infer_old_version() {
   return spec_infer_old_version;
 }
@@ -356,6 +360,10 @@ bool RequestManager::get_greedy_schedule() {
 
 bool RequestManager::get_equal_schedule() {
   return equal_schedule;
+}
+
+bool RequestManager::get_fcfs_slo() {
+  return fcfs_slo;
 }
 
 inline double RequestManager::get_slo_constraint(Request &request) {

--- a/src/runtime/request_manager.cc
+++ b/src/runtime/request_manager.cc
@@ -350,6 +350,10 @@ void RequestManager::set_fcfs_slo(bool fcfs_slo_) {
   fcfs_slo = fcfs_slo_;
 }
 
+void RequestManager::set_stta(bool stta_) {
+  stta = stta_;
+}
+
 bool RequestManager::get_spec_infer_old_version() {
   return spec_infer_old_version;
 }
@@ -364,6 +368,10 @@ bool RequestManager::get_equal_schedule() {
 
 bool RequestManager::get_fcfs_slo() {
   return fcfs_slo;
+}
+
+bool RequestManager::get_stta() {
+  return stta;
 }
 
 inline double RequestManager::get_slo_constraint(Request &request) {
@@ -1168,8 +1176,10 @@ BatchConfig RequestManager::prepare_next_batch() {
       }
       break;
     case DECODING:
-      if get_fcfs_slo () {
+      if (get_fcfs_slo()) {
         return prepare_decoding_batch_fcfs_slo();
+      } else if (get_stta()) {
+        return prepare_decoding_batch_stta();
       } else {
         return prepare_decoding_batch();
       }
@@ -1418,63 +1428,160 @@ BatchConfig RequestManager::prepare_decoding_batch_fcfs_slo() {
   bc.prompt_phase = false;
 
   // Check if there are any requests whose SLO is in the fastest category
+  std::fill(request_available,
+            request_available + get_max_requests_per_batch(),
+            false);
+  num_available_requests = 0;
+  std::vector<Request> fcfs_request_queue;
+  for (int request_index = 0; request_index < get_max_requests_per_batch();
+       request_index++) {
+    if (guid_of_requests[request_index] == INVALID_GUID) {
+      continue;
+    }
+    Request &request = all_requests[guid_of_requests[request_index]];
+    assert(request.status == Request::RUNNING);
+    fcfs_request_queue.push_back(request);
+  }
+
+  // Sort the requests in the FCFS queue based on the decoding time in
+  // descending order
+  std::sort(fcfs_request_queue.begin(),
+            fcfs_request_queue.end(),
+            [](Request const &a, Request const &b) {
+              return a.decode_latency_ms < b.decode_latency_ms;
+            });
+
+  // Include the requests one by one until:
+  // 1. If the batch includes a request whose SLO is in the fastest category,
+  // limit the number of requests in the batch to 8.
+  // 2. If the batch does not include a request whose SLO is in the fastest
+  // category, keep adding requests until a request whose SLO is in the fastest
+  // category is met (do not include it).
+  bool has_fastest_slo = false;
+  for (Request &request : fcfs_request_queue) {
+    if (has_fastest_slo and num_available_requests >= 8) {
+      break;
+    }
+    if (request.get_slo_ratio() <= 1.0) {
+      has_fastest_slo = true;
+      if (num_available_requests >= 8) {
+        break;
+      }
+    }
+    request_load_onto_batch(request.batch_index);
+  }
+
   std::copy(std::begin(request_available),
             std::end(request_available),
             std::begin(bc.request_available));
   bc.num_available_requests = num_available_requests;
-  bool has_fastest_slo = false;
+
   for (int request_index = 0; request_index < get_max_requests_per_batch();
        request_index++) {
-
     if (!request_available[request_index]) {
       continue;
     }
     Request &request = all_requests[guid_of_requests[request_index]];
     assert(request.status == Request::RUNNING);
 
-    if (request.get_slo_ratio() <= 1.0) {
-      has_fastest_slo = true;
+    // Per Request Info
+    bc.requestsInfo[request_index].first_token_index_in_request =
+        request.llm_cache_size;
+    bc.requestsInfo[request_index].first_token_offset_in_batch = bc.num_tokens;
+    bc.requestsInfo[request_index].num_tokens_in_batch = 1;
+
+    // Copy the streaming cache info
+    bc.streamingCacheInfo[request_index] = request.streaming_cache_info;
+
+    request.first_token_offset_in_batch = bc.num_tokens;
+    request.num_tokens_in_batch = 1;
+
+    // Per Token Info
+    bc.tokensInfo[bc.num_tokens].request_index = request_index;
+    bc.tokensInfo[bc.num_tokens].abs_index_in_request = request.llm_cache_size;
+    bc.tokensInfo[bc.num_tokens].abs_depth_in_request = request.llm_cache_size;
+    bc.tokensInfo[bc.num_tokens].token_id = request.tokens.back();
+
+    bc.num_tokens++;
+
+    if (profiling_requests[request.guid].llm_decoding_steps == 0) {
+      profiling_requests[request.guid].start_decoding_time =
+          Realm::Clock::current_time_in_microseconds();
+    }
+  }
+
+  if (verbose) {
+    std::cout << "prepare_decoding_batch_fcfs_slo NEW batchconfig:"
+              << std::endl;
+    bc.print();
+  }
+  profiling.llm_step_start = Realm::Clock::current_time_in_microseconds();
+  return bc;
+}
+
+BatchConfig RequestManager::prepare_decoding_batch_stta() {
+  // This function is called when the request_manager_status is DECODING. It
+  // fills the last token of each request in the current batch to the
+  // BatchConfig for the LLM to decode.
+  if (verbose) {
+    std::cout << "\n############### prepare_decoding_batch_stta "
+                 "##############\n";
+  }
+
+  BatchConfig bc;
+  bc.inference_mode = InferenceMode::INC_DECODING_MODE;
+  bc.prompt_phase = false;
+
+  // Check if there are any requests whose SLO is in the fastest category
+  std::fill(request_available,
+            request_available + get_max_requests_per_batch(),
+            false);
+  num_available_requests = 0;
+  std::vector<std::pair<double, int>> tta_2_batch_index;
+  for (int request_index = 0; request_index < get_max_requests_per_batch();
+       request_index++) {
+    if (guid_of_requests[request_index] == INVALID_GUID) {
+      continue;
+    }
+    Request &request = all_requests[guid_of_requests[request_index]];
+    assert(request.status == Request::RUNNING);
+    tta_2_batch_index.push_back(std::make_pair(
+        get_request_expected_latency(request) - request.decode_latency_ms,
+        request_index));
+  }
+
+  // Sort the requests in the queue based on the time to attain SLO in ascending
+  // order
+  std::sort(tta_2_batch_index.begin(),
+            tta_2_batch_index.end(),
+            [](std::pair<double, int> const &a,
+               std::pair<double, int> const &b) { return a.first < b.first; });
+
+  // Include the requests one by one until:
+  // 1. If the batch includes a request whose SLO is in the fastest category,
+  // limit the number of requests in the batch to 8.
+  // 2. If the batch does not include a request whose SLO is in the fastest
+  // category, keep adding requests until a request whose SLO is in the fastest
+  // category is met (do not include it).
+  bool has_fastest_slo = false;
+  for (auto const &[tta, request_index] : tta_2_batch_index) {
+    Request &request = all_requests[guid_of_requests[request_index]];
+    if (has_fastest_slo and num_available_requests >= 8) {
       break;
     }
-  }
-
-  // If there are requests with the fastest SLO, we limit the number of requests
-  // to be decoded in this batch to 8
-  if (has_fastest_slo) {
-    int num_fastest_slo_requests = 0;
-    for (int request_index = 0; request_index < get_max_requests_per_batch();
-         request_index++) {
-      if (!request_available[request_index]) {
-        continue;
-      }
-      Request &request = all_requests[guid_of_requests[request_index]];
-      assert(request.status == Request::RUNNING);
-
-      if (request.get_slo_ratio() <= 1.0) {
-        num_fastest_slo_requests++;
+    if (request.get_slo_ratio() <= 1.0) {
+      has_fastest_slo = true;
+      if (num_available_requests >= 8) {
+        break;
       }
     }
-
-    if (num_fastest_slo_requests > 8) {
-      int num_remaining_requests = 0;
-      std::vector<std::pair<long long, int>> start_time_and_request_index;
-      for (int request_index = 0; request_index < get_max_requests_per_batch();
-           request_index++) {
-        if (!request_available[request_index]) {
-          continue;
-        }
-        Request &request = all_requests[guid_of_requests[request_index]];
-        assert(request.status == Request::RUNNING);
-
-        if (request.get_slo_ratio() > 1.0) {
-          request_available[request_index] = false;
-          num_available_requests--;
-          num_remaining_requests++;
-        }
-      }
-      bc.num_available_requests -= num_remaining_requests;
-    }
+    request_load_onto_batch(request_index);
   }
+
+  std::copy(std::begin(request_available),
+            std::end(request_available),
+            std::begin(bc.request_available));
+  bc.num_available_requests = num_available_requests;
 
   for (int request_index = 0; request_index < get_max_requests_per_batch();
        request_index++) {


### PR DESCRIPTION
Support two simple SLO-aware scheduling policy based on continuous batching: FCFS and Smallest Time to Attain (STTA).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/FlexFlow/1554)
<!-- Reviewable:end -->
