### PR TITLE
Add v1 file format for MappedParallelComputationGraph and from_v1 conversion functions

### DIFF
--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_graph_output.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_graph_output.dtg.toml
@@ -10,10 +10,18 @@ features = [
   "fmt",
 ]
 
-[[fields]]
-name = "srcNode"
-type = "size_t"
+template_params = [
+  "SlotName",
+]
+
+includes = [
+  "utils/nonnegative_int/nonnegative_int.h",
+]
 
 [[fields]]
-name = "srcIdx"
-type = "size_t"
+name = "node"
+type = "::FlexFlow::nonnegative_int"
+
+[[fields]]
+name = "slot_name"
+type = "SlotName"

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.toml
@@ -17,8 +17,8 @@ template_params = [
 includes = [
   "<vector>",
   "<unordered_set>",
-  "pcg/file_format/v1/graphs/v1_graph_edge.dtg.h",
-  "pcg/file_format/v1/graphs/v1_graph_output.dtg.h",
+  "pcg/file_format/v1/graphs/v1_kwarg_graph_edge.dtg.h",
+  "pcg/file_format/v1/graphs/v1_kwarg_graph_output.dtg.h",
   "utils/nonnegative_int/nonnegative_int.h",
 ]
 
@@ -35,8 +35,8 @@ type = "std::vector<::FlexFlow::nonnegative_int>"
 
 [[fields]]
 name = "edges"
-type = "std::unordered_set<::FlexFlow::V1GraphEdge<SlotName>>"
+type = "std::unordered_set<::FlexFlow::V1KwargGraphEdge<SlotName>>"
 
 [[fields]]
 name = "outputs"
-type = "std::unordered_set<::FlexFlow::V1GraphOutput<SlotName>>"
+type = "std::unordered_set<::FlexFlow::V1KwargGraphOutput<SlotName>>"

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.toml
@@ -18,6 +18,7 @@ includes = [
   "<vector>",
   "<unordered_set>",
   "pcg/file_format/v1/graphs/v1_graph_edge.dtg.h",
+  "pcg/file_format/v1/graphs/v1_graph_output.dtg.h",
   "utils/nonnegative_int/nonnegative_int.h",
 ]
 
@@ -35,3 +36,7 @@ type = "std::vector<::FlexFlow::nonnegative_int>"
 [[fields]]
 name = "edges"
 type = "std::unordered_set<::FlexFlow::V1GraphEdge<SlotName>>"
+
+[[fields]]
+name = "outputs"
+type = "std::unordered_set<::FlexFlow::V1GraphOutput<SlotName>>"

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
@@ -50,7 +50,7 @@ V1KwargDataflowGraph<SlotName>
 template <typename SlotName>
 std::pair<KwargDataflowGraphView<SlotName>,
           std::unordered_map<nonnegative_int, Node>>
-    from_v1(V1KwargDataflowGraph<SlotName> const &v1) {
+    from_v1_including_node_numbering(V1KwargDataflowGraph<SlotName> const &v1) {
   std::unordered_map<nonnegative_int, Node> node_map =
       generate_map(v1.nodes, [](nonnegative_int n) {
         return Node{n.size_t_from_nonnegative_int()};
@@ -76,6 +76,12 @@ std::pair<KwargDataflowGraphView<SlotName>,
       };
   return std::pair{view_from_open_kwarg_dataflow_graph_data(graph_data),
                    node_map};
+}
+
+template <typename SlotName>
+KwargDataflowGraphView<SlotName>
+    from_v1(V1KwargDataflowGraph<SlotName> const &v1) {
+  return from_v1_including_node_numbering(v1).first;
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
@@ -5,6 +5,7 @@
 #include "pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.h"
 #include "utils/bidict/algorithms/bidict_from_enumerating.h"
 #include "utils/containers/enumerate.h"
+#include "utils/containers/generate_map.h"
 #include "utils/containers/sorted.h"
 #include "utils/containers/transform.h"
 #include "utils/containers/unordered_set_of.h"
@@ -47,15 +48,17 @@ V1KwargDataflowGraph<SlotName>
 }
 
 template <typename SlotName>
-KwargDataflowGraphView<SlotName>
-    from_v1(V1KwargDataflowGraph<SlotName> const &v1_g) {
-  std::unordered_set<Node> graph_nodes =
-      unordered_set_of(transform(v1_g.nodes, [](nonnegative_int n) {
+std::pair<KwargDataflowGraphView<SlotName>,
+          std::unordered_map<nonnegative_int, Node>>
+    from_v1(V1KwargDataflowGraph<SlotName> const &v1) {
+  std::unordered_map<nonnegative_int, Node> node_map =
+      generate_map(v1.nodes, [](nonnegative_int n) {
         return Node{n.size_t_from_nonnegative_int()};
-      }));
+      });
+  std::unordered_set<Node> node_set = unordered_set_of(values(node_map));
 
-  std::unordered_set<OpenKwargDataflowEdge<int, SlotName>> graph_edges =
-      transform(v1_g.edges, [](V1GraphEdge<SlotName> const &e) {
+  std::unordered_set<OpenKwargDataflowEdge<int, SlotName>> edges =
+      transform(v1.edges, [](V1GraphEdge<SlotName> const &e) {
         Node srcNode = Node{e.srcNode.size_t_from_nonnegative_int()};
         Node dstNode = Node{e.dstNode.size_t_from_nonnegative_int()};
         return OpenKwargDataflowEdge<int, SlotName>{KwargDataflowEdge<SlotName>{
@@ -66,12 +69,13 @@ KwargDataflowGraphView<SlotName>
 
   OpenKwargDataflowGraphData<int, SlotName> graph_data =
       OpenKwargDataflowGraphData<int, SlotName>{
-          /*nodes=*/graph_nodes,
-          /*edges=*/graph_edges,
+          /*nodes=*/node_set,
+          /*edges=*/edges,
           /*inputs=*/{},
           /*outputs=*/{},
       };
-  return view_from_open_kwarg_dataflow_graph_data(graph_data);
+  return std::pair{view_from_open_kwarg_dataflow_graph_data(graph_data),
+                   node_map};
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
@@ -67,12 +67,18 @@ std::pair<KwargDataflowGraphView<SlotName>,
         }};
       });
 
+  std::unordered_set<KwargDataflowOutput<SlotName>> outputs =
+      transform(v1.edges, [](V1GraphEdge<SlotName> const &e) {
+        Node srcNode = Node{e.srcNode.size_t_from_nonnegative_int()};
+        return KwargDataflowOutput<SlotName>{srcNode, e.srcSlot};
+      });
+
   OpenKwargDataflowGraphData<int, SlotName> graph_data =
       OpenKwargDataflowGraphData<int, SlotName>{
           /*nodes=*/node_set,
           /*edges=*/edges,
           /*inputs=*/{},
-          /*outputs=*/{},
+          /*outputs=*/outputs,
       };
   return std::pair{view_from_open_kwarg_dataflow_graph_data(graph_data),
                    node_map};

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
@@ -1,14 +1,19 @@
 #ifndef _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_GRAPHS_V1_KWARG_DATAFLOW_GRAPH_H
 #define _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_GRAPHS_V1_KWARG_DATAFLOW_GRAPH_H
 
+#include "pcg/file_format/v1/graphs/v1_graph_edge.dtg.h"
 #include "pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.h"
 #include "utils/bidict/algorithms/bidict_from_enumerating.h"
 #include "utils/containers/enumerate.h"
 #include "utils/containers/sorted.h"
+#include "utils/containers/transform.h"
+#include "utils/containers/unordered_set_of.h"
 #include "utils/containers/values.h"
 #include "utils/graph/kwarg_dataflow_graph/algorithms/get_all_kwarg_dataflow_edges.h"
 #include "utils/graph/kwarg_dataflow_graph/kwarg_dataflow_graph_view.h"
 #include "utils/graph/node/algorithms.h"
+#include "utils/graph/open_kwarg_dataflow_graph/algorithms/open_kwarg_dataflow_graph_data.dtg.h"
+#include "utils/graph/open_kwarg_dataflow_graph/algorithms/view_from_open_kwarg_dataflow_graph_data.h"
 #include "utils/integer_conversions.h"
 
 namespace FlexFlow {
@@ -39,6 +44,34 @@ V1KwargDataflowGraph<SlotName>
       sorted(values(nodes)),
       edges,
   };
+}
+
+template <typename SlotName>
+KwargDataflowGraphView<SlotName>
+    from_v1(V1KwargDataflowGraph<SlotName> const &v1_g) {
+  std::unordered_set<Node> graph_nodes =
+      unordered_set_of(transform(v1_g.nodes, [](nonnegative_int n) {
+        return Node{n.size_t_from_nonnegative_int()};
+      }));
+
+  std::unordered_set<OpenKwargDataflowEdge<int, SlotName>> graph_edges =
+      transform(v1_g.edges, [](V1GraphEdge<SlotName> const &e) {
+        Node srcNode = Node{e.srcNode.size_t_from_nonnegative_int()};
+        Node dstNode = Node{e.dstNode.size_t_from_nonnegative_int()};
+        return OpenKwargDataflowEdge<int, SlotName>{KwargDataflowEdge<SlotName>{
+            /*src=*/KwargDataflowOutput<SlotName>{srcNode, e.srcSlot},
+            /*dst=*/KwargDataflowInput<SlotName>{dstNode, e.dstSlot},
+        }};
+      });
+
+  OpenKwargDataflowGraphData<int, SlotName> graph_data =
+      OpenKwargDataflowGraphData<int, SlotName>{
+          /*nodes=*/graph_nodes,
+          /*edges=*/graph_edges,
+          /*inputs=*/{},
+          /*outputs=*/{},
+      };
+  return view_from_open_kwarg_dataflow_graph_data(graph_data);
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
@@ -2,6 +2,7 @@
 #define _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_GRAPHS_V1_KWARG_DATAFLOW_GRAPH_H
 
 #include "pcg/file_format/v1/graphs/v1_graph_edge.dtg.h"
+#include "pcg/file_format/v1/graphs/v1_graph_output.dtg.h"
 #include "pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.h"
 #include "utils/bidict/algorithms/bidict_from_enumerating.h"
 #include "utils/containers/enumerate.h"
@@ -11,6 +12,7 @@
 #include "utils/containers/unordered_set_of.h"
 #include "utils/containers/values.h"
 #include "utils/graph/kwarg_dataflow_graph/algorithms/get_all_kwarg_dataflow_edges.h"
+#include "utils/graph/kwarg_dataflow_graph/algorithms/get_all_kwarg_dataflow_outputs.h"
 #include "utils/graph/kwarg_dataflow_graph/kwarg_dataflow_graph_view.h"
 #include "utils/graph/node/algorithms.h"
 #include "utils/graph/open_kwarg_dataflow_graph/algorithms/open_kwarg_dataflow_graph_data.dtg.h"
@@ -33,17 +35,25 @@ template <typename SlotName>
 V1KwargDataflowGraph<SlotName>
     to_v1(KwargDataflowGraphView<SlotName> const &g,
           std::unordered_map<Node, nonnegative_int> const &nodes) {
-  std::unordered_set<V1GraphEdge<SlotName>> edges;
-  for (KwargDataflowEdge<SlotName> const &e : get_all_kwarg_dataflow_edges(g)) {
-    edges.insert(V1GraphEdge{nodes.at(e.src.node),
-                             e.src.slot_name,
-                             nodes.at(e.dst.node),
-                             e.dst.slot_name});
-  }
+  std::unordered_set<V1GraphEdge<SlotName>> edges =
+      transform(get_all_kwarg_dataflow_edges(g),
+                [&](KwargDataflowEdge<SlotName> const &e) {
+                  return V1GraphEdge{nodes.at(e.src.node),
+                                     e.src.slot_name,
+                                     nodes.at(e.dst.node),
+                                     e.dst.slot_name};
+                });
+
+  std::unordered_set<V1GraphOutput<SlotName>> outputs =
+      transform(get_all_kwarg_dataflow_outputs(g),
+                [&](KwargDataflowOutput<SlotName> const &o) {
+                  return V1GraphOutput{nodes.at(o.node), o.slot_name};
+                });
 
   return V1KwargDataflowGraph<SlotName>{
       sorted(values(nodes)),
       edges,
+      outputs,
   };
 }
 
@@ -68,9 +78,9 @@ std::pair<KwargDataflowGraphView<SlotName>,
       });
 
   std::unordered_set<KwargDataflowOutput<SlotName>> outputs =
-      transform(v1.edges, [](V1GraphEdge<SlotName> const &e) {
-        Node srcNode = Node{e.srcNode.size_t_from_nonnegative_int()};
-        return KwargDataflowOutput<SlotName>{srcNode, e.srcSlot};
+      transform(v1.outputs, [](V1GraphOutput<SlotName> const &o) {
+        Node n = Node{o.node.size_t_from_nonnegative_int()};
+        return KwargDataflowOutput<SlotName>{n, o.slot_name};
       });
 
   OpenKwargDataflowGraphData<int, SlotName> graph_data =

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h
@@ -1,9 +1,9 @@
 #ifndef _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_GRAPHS_V1_KWARG_DATAFLOW_GRAPH_H
 #define _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_GRAPHS_V1_KWARG_DATAFLOW_GRAPH_H
 
-#include "pcg/file_format/v1/graphs/v1_graph_edge.dtg.h"
-#include "pcg/file_format/v1/graphs/v1_graph_output.dtg.h"
 #include "pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.h"
+#include "pcg/file_format/v1/graphs/v1_kwarg_graph_edge.dtg.h"
+#include "pcg/file_format/v1/graphs/v1_kwarg_graph_output.dtg.h"
 #include "utils/bidict/algorithms/bidict_from_enumerating.h"
 #include "utils/containers/enumerate.h"
 #include "utils/containers/generate_map.h"
@@ -35,19 +35,20 @@ template <typename SlotName>
 V1KwargDataflowGraph<SlotName>
     to_v1(KwargDataflowGraphView<SlotName> const &g,
           std::unordered_map<Node, nonnegative_int> const &nodes) {
-  std::unordered_set<V1GraphEdge<SlotName>> edges =
+
+  std::unordered_set<V1KwargGraphEdge<SlotName>> edges =
       transform(get_all_kwarg_dataflow_edges(g),
                 [&](KwargDataflowEdge<SlotName> const &e) {
-                  return V1GraphEdge{nodes.at(e.src.node),
-                                     e.src.slot_name,
-                                     nodes.at(e.dst.node),
-                                     e.dst.slot_name};
+                  return V1KwargGraphEdge{nodes.at(e.src.node),
+                                          e.src.slot_name,
+                                          nodes.at(e.dst.node),
+                                          e.dst.slot_name};
                 });
 
-  std::unordered_set<V1GraphOutput<SlotName>> outputs =
+  std::unordered_set<V1KwargGraphOutput<SlotName>> outputs =
       transform(get_all_kwarg_dataflow_outputs(g),
                 [&](KwargDataflowOutput<SlotName> const &o) {
-                  return V1GraphOutput{nodes.at(o.node), o.slot_name};
+                  return V1KwargGraphOutput{nodes.at(o.node), o.slot_name};
                 });
 
   return V1KwargDataflowGraph<SlotName>{
@@ -68,7 +69,7 @@ std::pair<KwargDataflowGraphView<SlotName>,
   std::unordered_set<Node> node_set = unordered_set_of(values(node_map));
 
   std::unordered_set<OpenKwargDataflowEdge<int, SlotName>> edges =
-      transform(v1.edges, [](V1GraphEdge<SlotName> const &e) {
+      transform(v1.edges, [](V1KwargGraphEdge<SlotName> const &e) {
         Node srcNode = Node{e.srcNode.size_t_from_nonnegative_int()};
         Node dstNode = Node{e.dstNode.size_t_from_nonnegative_int()};
         return OpenKwargDataflowEdge<int, SlotName>{KwargDataflowEdge<SlotName>{
@@ -78,7 +79,7 @@ std::pair<KwargDataflowGraphView<SlotName>,
       });
 
   std::unordered_set<KwargDataflowOutput<SlotName>> outputs =
-      transform(v1.outputs, [](V1GraphOutput<SlotName> const &o) {
+      transform(v1.outputs, [](V1KwargGraphOutput<SlotName> const &o) {
         Node n = Node{o.node.size_t_from_nonnegative_int()};
         return KwargDataflowOutput<SlotName>{n, o.slot_name};
       });

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_graph_edge.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_graph_edge.dtg.toml
@@ -1,5 +1,5 @@
 namespace = "FlexFlow"
-name = "V1GraphOutput"
+name = "V1KwargGraphEdge"
 type = "struct"
 features = [
   "eq",
@@ -19,9 +19,17 @@ includes = [
 ]
 
 [[fields]]
-name = "node"
+name = "srcNode"
 type = "::FlexFlow::nonnegative_int"
 
 [[fields]]
-name = "slot_name"
+name = "srcSlot"
+type = "SlotName"
+
+[[fields]]
+name = "dstNode"
+type = "::FlexFlow::nonnegative_int"
+
+[[fields]]
+name = "dstSlot"
 type = "SlotName"

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_graph_output.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_kwarg_graph_output.dtg.toml
@@ -1,5 +1,5 @@
 namespace = "FlexFlow"
-name = "V1GraphEdge"
+name = "V1KwargGraphOutput"
 type = "struct"
 features = [
   "eq",
@@ -19,17 +19,9 @@ includes = [
 ]
 
 [[fields]]
-name = "srcNode"
+name = "node"
 type = "::FlexFlow::nonnegative_int"
 
 [[fields]]
-name = "srcSlot"
-type = "SlotName"
-
-[[fields]]
-name = "dstNode"
-type = "::FlexFlow::nonnegative_int"
-
-[[fields]]
-name = "dstSlot"
+name = "slot_name"
 type = "SlotName"

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.dtg.toml
@@ -19,7 +19,7 @@ template_params = [
 includes = [
   "<unordered_map>",
   "pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.dtg.h",
-  "pcg/file_format/v1/graphs/v1_graph_output.dtg.h",
+  "pcg/file_format/v1/graphs/v1_kwarg_graph_output.dtg.h",
   "utils/nonnegative_int/nonnegative_int.h",
 ]
 
@@ -36,7 +36,7 @@ type = "std::unordered_map<::FlexFlow::nonnegative_int, NodeLabel>"
 
 [[fields]]
 name = "output_labels"
-type = "std::unordered_map<::FlexFlow::V1GraphOutput<SlotName>, OutputLabel>"
+type = "std::unordered_map<::FlexFlow::V1KwargGraphOutput<SlotName>, OutputLabel>"
 
 [[fields]]
 name = "graph"

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.dtg.toml
@@ -36,7 +36,7 @@ type = "std::unordered_map<::FlexFlow::nonnegative_int, NodeLabel>"
 
 [[fields]]
 name = "output_labels"
-type = "std::unordered_map<::FlexFlow::nonnegative_int, std::unordered_map<SlotName, OutputLabel>>"
+type = "std::unordered_map<::FlexFlow::V1GraphOutput<SlotName>, OutputLabel>"
 
 [[fields]]
 name = "graph"

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -6,7 +6,14 @@
 #include "utils/bidict/algorithms/bidict_from_enumerating.h"
 #include "utils/containers/map_values.h"
 #include "utils/containers/transform.h"
+#include "utils/graph/digraph/algorithms/get_topological_ordering.h"
+#include "utils/graph/digraph/digraph.h"
+#include "utils/graph/digraph/directed_edge.dtg.h"
+#include "utils/graph/instances/adjacency_digraph.h"
+#include "utils/graph/instances/unordered_set_labelled_open_kwarg_dataflow_graph.h"
 #include "utils/graph/kwarg_dataflow_graph/algorithms/get_outgoing_kwarg_dataflow_outputs_for_node.h"
+#include "utils/graph/kwarg_dataflow_graph/kwarg_node_added_result.dtg.h"
+#include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph.h"
 #include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph_view.h"
 #include "utils/graph/node/algorithms.h"
 
@@ -48,6 +55,56 @@ template <typename NodeLabel, typename OutputLabel, typename SlotName>
 V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> to_v1(
     LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName> const &g) {
   return to_v1_including_node_numbering(g).first;
+}
+
+template <typename NodeLabel, typename OutputLabel, typename SlotName>
+LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> from_v1(
+    V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const &v1) {
+  // Build incoming-edge map
+  std::unordered_map<nonnegative_int, std::vector<V1GraphEdge<SlotName>>>
+      incoming;
+  for (nonnegative_int const &n : v1.graph.nodes) {
+    incoming[n] = {};
+  }
+  for (V1GraphEdge<SlotName> const &e : v1.graph.edges) {
+    incoming[e.dstNode].push_back(e);
+  }
+
+  // Build a DiGraph with V1 indices as Node raw_uids to get topological order
+  DiGraph dg = DiGraph::create<AdjacencyDiGraph>();
+  for (nonnegative_int const &n : v1.graph.nodes) {
+    dg.add_node_unsafe(Node{static_cast<size_t>(n.unwrap_nonnegative())});
+  }
+  for (V1GraphEdge<SlotName> const &e : v1.graph.edges) {
+    dg.add_edge(DirectedEdge{
+        Node{static_cast<size_t>(e.srcNode.unwrap_nonnegative())},
+        Node{static_cast<size_t>(e.dstNode.unwrap_nonnegative())}});
+  }
+
+  auto g = LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName>::
+      template create<UnorderedSetLabelledOpenKwargDataflowGraph<NodeLabel,
+                                                                 OutputLabel,
+                                                                 int,
+                                                                 SlotName>>();
+
+  std::unordered_map<nonnegative_int, Node> node_map;
+  for (Node const &topo_node : get_topological_ordering(dg)) {
+    nonnegative_int v1_idx{static_cast<size_t>(topo_node.raw_uid)};
+
+    std::unordered_map<SlotName, KwargDataflowOutput<SlotName>> inputs;
+    for (V1GraphEdge<SlotName> const &e : incoming.at(v1_idx)) {
+      inputs.emplace(
+          e.dstSlot,
+          KwargDataflowOutput<SlotName>{node_map.at(e.srcNode), e.srcSlot});
+    }
+
+    KwargNodeAddedResult<SlotName> result = g.add_node(
+        v1.node_labels.at(v1_idx), inputs, v1.output_labels.at(v1_idx));
+
+    node_map.emplace(v1_idx, result.node);
+  }
+
+  return g;
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -62,7 +62,15 @@ std::pair<LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
 
   std::unordered_map<Node, NodeLabel> node_labels = map_keys(
       v1.node_labels, [&](nonnegative_int n) { return node_map.at(n); });
+
   std::unordered_map<KwargDataflowOutput<SlotName>, OutputLabel> value_labels;
+  for (auto const &[nonneg_node, slot_map] : v1.output_labels) {
+    Node node = node_map.at(nonneg_node);
+    for (auto const &[slot_name, label] : slot_map) {
+      value_labels.emplace(KwargDataflowOutput<SlotName>{node, slot_name},
+                           label);
+    }
+  }
 
   return std::pair{kwarg_dataflow_graph_view_with_labelling(
                        graph_view, node_labels, value_labels),

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -92,15 +92,15 @@ LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> from_v1(
 
     std::unordered_map<SlotName, KwargDataflowOutput<SlotName>> inputs;
     for (V1GraphEdge<SlotName> const &e : incoming.at(v1_idx)) {
-      inputs.emplace(
+      inputs.insert(std::pair{
           e.dstSlot,
-          KwargDataflowOutput<SlotName>{node_map.at(e.srcNode), e.srcSlot});
+          KwargDataflowOutput<SlotName>{node_map.at(e.srcNode), e.srcSlot}});
     }
 
     KwargNodeAddedResult<SlotName> result = g.add_node(
         v1.node_labels.at(v1_idx), inputs, v1.output_labels.at(v1_idx));
 
-    node_map.emplace(v1_idx, result.node);
+    node_map.insert(std::pair{v1_idx, result.node});
   }
 
   return g;

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -7,18 +7,10 @@
 #include "utils/containers/map_keys.h"
 #include "utils/containers/map_values.h"
 #include "utils/containers/transform.h"
-#include "utils/containers/unordered_map_from_pairs.h"
-#include "utils/graph/digraph/algorithms/get_topological_ordering.h"
-#include "utils/graph/digraph/digraph.h"
-#include "utils/graph/digraph/directed_edge.dtg.h"
-#include "utils/graph/instances/adjacency_digraph.h"
-#include "utils/graph/instances/unordered_set_labelled_open_kwarg_dataflow_graph.h"
 #include "utils/graph/kwarg_dataflow_graph/algorithms/get_outgoing_kwarg_dataflow_outputs_for_node.h"
-#include "utils/graph/kwarg_dataflow_graph/kwarg_node_added_result.dtg.h"
 #include "utils/graph/labelled_kwarg_dataflow_graph/algorithms/kwarg_dataflow_graph_view_with_labelling.h"
 #include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph_view.h"
 #include "utils/graph/node/algorithms.h"
-#include "utils/nonnegative_int/nonnegative_int.h"
 
 namespace FlexFlow {
 

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -63,8 +63,7 @@ std::pair<LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
 
   std::unordered_map<KwargDataflowOutput<SlotName>, OutputLabel> value_labels =
       map_keys(v1.output_labels, [&](V1GraphOutput<SlotName> const &o) {
-        Node n = Node{o.node.size_t_from_nonnegative_int()};
-        return KwargDataflowOutput<SlotName>{n, o.slot_name};
+        return KwargDataflowOutput<SlotName>{node_map.at(o.node), o.slot_name};
       });
 
   return std::pair{kwarg_dataflow_graph_view_with_labelling(

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -55,9 +55,10 @@ V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> to_v1(
 template <typename NodeLabel, typename OutputLabel, typename SlotName>
 std::pair<LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
           std::unordered_map<nonnegative_int, Node>>
-    from_v1(V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const
-                &v1) {
-  auto [graph_view, node_map] = from_v1(v1.graph);
+    from_v1_including_node_numbering(
+        V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const
+            &v1) {
+  auto [graph_view, node_map] = from_v1_including_node_numbering(v1.graph);
 
   std::unordered_map<Node, NodeLabel> node_labels = map_keys(
       v1.node_labels, [&](nonnegative_int n) { return node_map.at(n); });
@@ -66,6 +67,12 @@ std::pair<LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
   return std::pair{kwarg_dataflow_graph_view_with_labelling(
                        graph_view, node_labels, value_labels),
                    node_map};
+}
+
+template <typename NodeLabel, typename OutputLabel, typename SlotName>
+LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName> from_v1(
+    V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const &v1) {
+  return from_v1_including_node_numbering(v1).first;
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -73,12 +73,11 @@ LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> from_v1(
   // Build a DiGraph with V1 indices as Node raw_uids to get topological order
   DiGraph dg = DiGraph::create<AdjacencyDiGraph>();
   for (nonnegative_int const &n : v1.graph.nodes) {
-    dg.add_node_unsafe(Node{static_cast<size_t>(n.unwrap_nonnegative())});
+    dg.add_node_unsafe(Node{n.size_t_from_nonnegative_int()});
   }
   for (V1GraphEdge<SlotName> const &e : v1.graph.edges) {
-    dg.add_edge(DirectedEdge{
-        Node{static_cast<size_t>(e.srcNode.unwrap_nonnegative())},
-        Node{static_cast<size_t>(e.dstNode.unwrap_nonnegative())}});
+    dg.add_edge(DirectedEdge{Node{e.srcNode.size_t_from_nonnegative_int()},
+                             Node{e.dstNode.size_t_from_nonnegative_int()}});
   }
 
   auto g = LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName>::
@@ -89,7 +88,7 @@ LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> from_v1(
 
   std::unordered_map<nonnegative_int, Node> node_map;
   for (Node const &topo_node : get_topological_ordering(dg)) {
-    nonnegative_int v1_idx{static_cast<size_t>(topo_node.raw_uid)};
+    nonnegative_int v1_idx{topo_node.raw_uid};
 
     std::unordered_map<SlotName, KwargDataflowOutput<SlotName>> inputs;
     for (V1GraphEdge<SlotName> const &e : incoming.at(v1_idx)) {

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -4,6 +4,7 @@
 #include "pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.h"
 #include "pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.dtg.h"
 #include "utils/bidict/algorithms/bidict_from_enumerating.h"
+#include "utils/containers/map_keys.h"
 #include "utils/containers/map_values.h"
 #include "utils/containers/transform.h"
 #include "utils/containers/unordered_map_from_pairs.h"
@@ -14,9 +15,10 @@
 #include "utils/graph/instances/unordered_set_labelled_open_kwarg_dataflow_graph.h"
 #include "utils/graph/kwarg_dataflow_graph/algorithms/get_outgoing_kwarg_dataflow_outputs_for_node.h"
 #include "utils/graph/kwarg_dataflow_graph/kwarg_node_added_result.dtg.h"
-#include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph.h"
+#include "utils/graph/labelled_kwarg_dataflow_graph/algorithms/kwarg_dataflow_graph_view_with_labelling.h"
 #include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph_view.h"
 #include "utils/graph/node/algorithms.h"
+#include "utils/nonnegative_int/nonnegative_int.h"
 
 namespace FlexFlow {
 
@@ -59,53 +61,19 @@ V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> to_v1(
 }
 
 template <typename NodeLabel, typename OutputLabel, typename SlotName>
-LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> from_v1(
-    V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const &v1) {
-  // Build incoming-edge map
-  std::unordered_map<nonnegative_int, std::vector<V1GraphEdge<SlotName>>>
-      incoming;
-  for (nonnegative_int const &n : v1.graph.nodes) {
-    incoming[n] = {};
-  }
-  for (V1GraphEdge<SlotName> const &e : v1.graph.edges) {
-    incoming[e.dstNode].push_back(e);
-  }
+std::pair<LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
+          std::unordered_map<nonnegative_int, Node>>
+    from_v1(V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const
+                &v1) {
+  auto [graph_view, node_map] = from_v1(v1.graph);
 
-  // Build a DiGraph with V1 indices as Node raw_uids to get topological order
-  DiGraph dg = DiGraph::create<AdjacencyDiGraph>();
-  for (nonnegative_int const &n : v1.graph.nodes) {
-    dg.add_node_unsafe(Node{n.size_t_from_nonnegative_int()});
-  }
-  for (V1GraphEdge<SlotName> const &e : v1.graph.edges) {
-    dg.add_edge(DirectedEdge{Node{e.srcNode.size_t_from_nonnegative_int()},
-                             Node{e.dstNode.size_t_from_nonnegative_int()}});
-  }
+  std::unordered_map<Node, NodeLabel> node_labels = map_keys(
+      v1.node_labels, [&](nonnegative_int n) { return node_map.at(n); });
+  std::unordered_map<KwargDataflowOutput<SlotName>, OutputLabel> value_labels;
 
-  auto g = LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName>::
-      template create<UnorderedSetLabelledOpenKwargDataflowGraph<NodeLabel,
-                                                                 OutputLabel,
-                                                                 int,
-                                                                 SlotName>>();
-
-  std::unordered_map<nonnegative_int, Node> node_map;
-  for (Node const &topo_node : get_topological_ordering(dg)) {
-    nonnegative_int v1_idx{topo_node.raw_uid};
-
-    std::unordered_map<SlotName, KwargDataflowOutput<SlotName>> inputs =
-        unordered_map_from_pairs(
-            transform(incoming.at(v1_idx), [&](V1GraphEdge<SlotName> const &e) {
-              return std::pair{e.dstSlot,
-                               KwargDataflowOutput<SlotName>{
-                                   node_map.at(e.srcNode), e.srcSlot}};
-            }));
-
-    KwargNodeAddedResult<SlotName> result = g.add_node(
-        v1.node_labels.at(v1_idx), inputs, v1.output_labels.at(v1_idx));
-
-    node_map.insert(std::pair{v1_idx, result.node});
-  }
-
-  return g;
+  return std::pair{kwarg_dataflow_graph_view_with_labelling(
+                       graph_view, node_labels, value_labels),
+                   node_map};
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -6,6 +6,7 @@
 #include "utils/bidict/algorithms/bidict_from_enumerating.h"
 #include "utils/containers/map_values.h"
 #include "utils/containers/transform.h"
+#include "utils/containers/unordered_map_from_pairs.h"
 #include "utils/graph/digraph/algorithms/get_topological_ordering.h"
 #include "utils/graph/digraph/digraph.h"
 #include "utils/graph/digraph/directed_edge.dtg.h"
@@ -90,12 +91,13 @@ LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> from_v1(
   for (Node const &topo_node : get_topological_ordering(dg)) {
     nonnegative_int v1_idx{topo_node.raw_uid};
 
-    std::unordered_map<SlotName, KwargDataflowOutput<SlotName>> inputs;
-    for (V1GraphEdge<SlotName> const &e : incoming.at(v1_idx)) {
-      inputs.insert(std::pair{
-          e.dstSlot,
-          KwargDataflowOutput<SlotName>{node_map.at(e.srcNode), e.srcSlot}});
-    }
+    std::unordered_map<SlotName, KwargDataflowOutput<SlotName>> inputs =
+        unordered_map_from_pairs(
+            transform(incoming.at(v1_idx), [&](V1GraphEdge<SlotName> const &e) {
+              return std::pair{e.dstSlot,
+                               KwargDataflowOutput<SlotName>{
+                                   node_map.at(e.srcNode), e.srcSlot}};
+            }));
 
     KwargNodeAddedResult<SlotName> result = g.add_node(
         v1.node_labels.at(v1_idx), inputs, v1.output_labels.at(v1_idx));

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -7,7 +7,8 @@
 #include "utils/containers/map_keys.h"
 #include "utils/containers/map_values.h"
 #include "utils/containers/transform.h"
-#include "utils/graph/kwarg_dataflow_graph/algorithms/get_outgoing_kwarg_dataflow_outputs_for_node.h"
+#include "utils/containers/unordered_map_from_pairs.h"
+#include "utils/graph/kwarg_dataflow_graph/algorithms/get_all_kwarg_dataflow_outputs.h"
 #include "utils/graph/labelled_kwarg_dataflow_graph/algorithms/kwarg_dataflow_graph_view_with_labelling.h"
 #include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph_view.h"
 #include "utils/graph/node/algorithms.h"
@@ -28,16 +29,13 @@ std::pair<V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName>,
   std::unordered_map<nonnegative_int, NodeLabel> node_labels = map_values(
       nodes.as_unordered_map(), [&](Node const &n) { return g.at(n); });
 
-  std::unordered_map<nonnegative_int, std::unordered_map<SlotName, OutputLabel>>
-      output_labels = map_values(
-          nodes.as_unordered_map(),
-          [&](Node const &n) -> std::unordered_map<SlotName, OutputLabel> {
-            return map_values(
-                get_outgoing_kwarg_dataflow_outputs_for_node(g, n),
-                [&](KwargDataflowOutput<SlotName> const &o) {
-                  return g.at(o);
-                });
-          });
+  std::unordered_map<V1GraphOutput<SlotName>, OutputLabel> output_labels =
+      unordered_map_from_pairs(transform(
+          get_all_kwarg_dataflow_outputs(g),
+          [&](KwargDataflowOutput<SlotName> const &o) {
+            return std::pair{V1GraphOutput{nodes.at_r(o.node), o.slot_name},
+                             g.at(o)};
+          }));
 
   return {
       V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName>{
@@ -63,14 +61,11 @@ std::pair<LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
   std::unordered_map<Node, NodeLabel> node_labels = map_keys(
       v1.node_labels, [&](nonnegative_int n) { return node_map.at(n); });
 
-  std::unordered_map<KwargDataflowOutput<SlotName>, OutputLabel> value_labels;
-  for (auto const &[nonneg_node, slot_map] : v1.output_labels) {
-    Node node = node_map.at(nonneg_node);
-    for (auto const &[slot_name, label] : slot_map) {
-      value_labels.emplace(KwargDataflowOutput<SlotName>{node, slot_name},
-                           label);
-    }
-  }
+  std::unordered_map<KwargDataflowOutput<SlotName>, OutputLabel> value_labels =
+      map_keys(v1.output_labels, [&](V1GraphOutput<SlotName> const &o) {
+        Node n = Node{o.node.size_t_from_nonnegative_int()};
+        return KwargDataflowOutput<SlotName>{n, o.slot_name};
+      });
 
   return std::pair{kwarg_dataflow_graph_view_with_labelling(
                        graph_view, node_labels, value_labels),

--- a/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h
@@ -29,13 +29,15 @@ std::pair<V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName>,
   std::unordered_map<nonnegative_int, NodeLabel> node_labels = map_values(
       nodes.as_unordered_map(), [&](Node const &n) { return g.at(n); });
 
-  std::unordered_map<V1GraphOutput<SlotName>, OutputLabel> output_labels =
-      unordered_map_from_pairs(transform(
-          get_all_kwarg_dataflow_outputs(g),
-          [&](KwargDataflowOutput<SlotName> const &o) {
-            return std::pair{V1GraphOutput{nodes.at_r(o.node), o.slot_name},
-                             g.at(o)};
-          }));
+  std::unordered_map<V1KwargGraphOutput<SlotName>, OutputLabel> output_labels =
+      unordered_map_from_pairs(
+          transform(get_all_kwarg_dataflow_outputs(g),
+                    [&](KwargDataflowOutput<SlotName> const &o) {
+                      return std::pair{
+                          V1KwargGraphOutput{nodes.at_r(o.node), o.slot_name},
+                          g.at(o),
+                      };
+                    }));
 
   return {
       V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName>{
@@ -62,13 +64,15 @@ std::pair<LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
       v1.node_labels, [&](nonnegative_int n) { return node_map.at(n); });
 
   std::unordered_map<KwargDataflowOutput<SlotName>, OutputLabel> value_labels =
-      map_keys(v1.output_labels, [&](V1GraphOutput<SlotName> const &o) {
+      map_keys(v1.output_labels, [&](V1KwargGraphOutput<SlotName> const &o) {
         return KwargDataflowOutput<SlotName>{node_map.at(o.node), o.slot_name};
       });
 
-  return std::pair{kwarg_dataflow_graph_view_with_labelling(
-                       graph_view, node_labels, value_labels),
-                   node_map};
+  return std::pair{
+      kwarg_dataflow_graph_view_with_labelling(
+          graph_view, node_labels, value_labels),
+      node_map,
+  };
 }
 
 template <typename NodeLabel, typename OutputLabel, typename SlotName>

--- a/lib/pcg/include/pcg/file_format/v1/v1_computation_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/v1_computation_graph.h
@@ -8,6 +8,7 @@
 namespace FlexFlow {
 
 V1ComputationGraph to_v1(ComputationGraph const &);
+ComputationGraph from_v1(V1ComputationGraph const &);
 
 std::pair<V1ComputationGraph, bidict<nonnegative_int, layer_guid_t>>
     to_v1_including_node_numbering(ComputationGraph const &);

--- a/lib/pcg/include/pcg/file_format/v1/v1_computation_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/v1_computation_graph.h
@@ -8,10 +8,11 @@
 namespace FlexFlow {
 
 V1ComputationGraph to_v1(ComputationGraph const &);
-ComputationGraph from_v1(V1ComputationGraph const &);
 
 std::pair<V1ComputationGraph, bidict<nonnegative_int, layer_guid_t>>
     to_v1_including_node_numbering(ComputationGraph const &);
+
+ComputationGraph from_v1(V1ComputationGraph const &);
 
 } // namespace FlexFlow
 

--- a/lib/pcg/include/pcg/file_format/v1/v1_mapped_operator_task_group.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/v1_mapped_operator_task_group.dtg.toml
@@ -1,0 +1,19 @@
+namespace = "FlexFlow"
+name = "V1MappedOperatorTaskGroup"
+type = "struct"
+features = [
+  "eq",
+  "hash",
+  "fmt",
+  "json",
+]
+
+includes = [
+  "pcg/machine_space_coordinate.dtg.h",
+  "pcg/mapped_parallel_computation_graph/operator_atomic_task_shard_binding.dtg.h",
+  "utils/bidict/bidict.h",
+]
+
+[[fields]]
+name = "shard_bindings"
+type = "::FlexFlow::bidict<::FlexFlow::MachineSpaceCoordinate, ::FlexFlow::OperatorAtomicTaskShardBinding>"

--- a/lib/pcg/include/pcg/file_format/v1/v1_mapped_operator_task_group.h
+++ b/lib/pcg/include/pcg/file_format/v1/v1_mapped_operator_task_group.h
@@ -1,0 +1,13 @@
+#ifndef _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_V1_MAPPED_OPERATOR_TASK_GROUP_H
+#define _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_V1_MAPPED_OPERATOR_TASK_GROUP_H
+
+#include "pcg/file_format/v1/v1_mapped_operator_task_group.dtg.h"
+#include "pcg/mapped_parallel_computation_graph/mapped_operator_task_group.h"
+
+namespace FlexFlow {
+
+V1MappedOperatorTaskGroup to_v1(MappedOperatorTaskGroup const &);
+
+} // namespace FlexFlow
+
+#endif

--- a/lib/pcg/include/pcg/file_format/v1/v1_mapped_operator_task_group.h
+++ b/lib/pcg/include/pcg/file_format/v1/v1_mapped_operator_task_group.h
@@ -7,6 +7,7 @@
 namespace FlexFlow {
 
 V1MappedOperatorTaskGroup to_v1(MappedOperatorTaskGroup const &);
+MappedOperatorTaskGroup from_v1(V1MappedOperatorTaskGroup const &);
 
 } // namespace FlexFlow
 

--- a/lib/pcg/include/pcg/file_format/v1/v1_mapped_parallel_computation_graph.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/v1_mapped_parallel_computation_graph.dtg.toml
@@ -1,0 +1,29 @@
+namespace = "FlexFlow"
+name = "V1MappedParallelComputationGraph"
+type = "struct"
+features = [
+  "eq",
+  "hash",
+  "fmt",
+  "json",
+]
+
+includes = [
+  "<unordered_map>",
+  "pcg/file_format/v1/v1_parallel_computation_graph.dtg.h",
+  "pcg/file_format/v1/v1_mapped_operator_task_group.dtg.h",
+  "pcg/parallel_computation_graph/parallel_layer_guid_t.dtg.h",
+]
+
+src_includes = [
+  "utils/hash/unordered_map.h",
+  "utils/fmt/unordered_map.h",
+]
+
+[[fields]]
+name = "pcg"
+type = "::FlexFlow::V1ParallelComputationGraph"
+
+[[fields]]
+name = "mapped_tasks"
+type = "std::unordered_map<::FlexFlow::parallel_layer_guid_t, ::FlexFlow::V1MappedOperatorTaskGroup>"

--- a/lib/pcg/include/pcg/file_format/v1/v1_mapped_parallel_computation_graph.dtg.toml
+++ b/lib/pcg/include/pcg/file_format/v1/v1_mapped_parallel_computation_graph.dtg.toml
@@ -9,21 +9,12 @@ features = [
 ]
 
 includes = [
-  "<unordered_map>",
-  "pcg/file_format/v1/v1_parallel_computation_graph.dtg.h",
-  "pcg/file_format/v1/v1_mapped_operator_task_group.dtg.h",
-  "pcg/parallel_computation_graph/parallel_layer_guid_t.dtg.h",
-]
-
-src_includes = [
-  "utils/hash/unordered_map.h",
-  "utils/fmt/unordered_map.h",
+  "pcg/mapped_parallel_computation_graph/mapped_parallel_layer_attrs.dtg.h",
+  "pcg/parallel_computation_graph/parallel_tensor_attrs.dtg.h",
+  "pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.dtg.h",
+  "op-attrs/tensor_slot_name.dtg.h",
 ]
 
 [[fields]]
-name = "pcg"
-type = "::FlexFlow::V1ParallelComputationGraph"
-
-[[fields]]
-name = "mapped_tasks"
-type = "std::unordered_map<::FlexFlow::parallel_layer_guid_t, ::FlexFlow::V1MappedOperatorTaskGroup>"
+name = "raw_graph"
+type = "::FlexFlow::V1LabelledKwargDataflowGraph<::FlexFlow::MappedParallelLayerAttrs, ::FlexFlow::ParallelTensorAttrs, ::FlexFlow::TensorSlotName>"

--- a/lib/pcg/include/pcg/file_format/v1/v1_mapped_parallel_computation_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/v1_mapped_parallel_computation_graph.h
@@ -7,6 +7,8 @@
 namespace FlexFlow {
 
 V1MappedParallelComputationGraph to_v1(MappedParallelComputationGraph const &);
+MappedParallelComputationGraph
+    from_v1(V1MappedParallelComputationGraph const &);
 
 } // namespace FlexFlow
 

--- a/lib/pcg/include/pcg/file_format/v1/v1_mapped_parallel_computation_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/v1_mapped_parallel_computation_graph.h
@@ -1,0 +1,13 @@
+#ifndef _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_V1_MAPPED_PARALLEL_COMPUTATION_GRAPH_H
+#define _FLEXFLOW_LIB_PCG_INCLUDE_PCG_FILE_FORMAT_V1_V1_MAPPED_PARALLEL_COMPUTATION_GRAPH_H
+
+#include "pcg/file_format/v1/v1_mapped_parallel_computation_graph.dtg.h"
+#include "pcg/mapped_parallel_computation_graph/mapped_parallel_computation_graph.dtg.h"
+
+namespace FlexFlow {
+
+V1MappedParallelComputationGraph to_v1(MappedParallelComputationGraph const &);
+
+} // namespace FlexFlow
+
+#endif

--- a/lib/pcg/include/pcg/file_format/v1/v1_parallel_computation_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/v1_parallel_computation_graph.h
@@ -7,6 +7,7 @@
 namespace FlexFlow {
 
 V1ParallelComputationGraph to_v1(ParallelComputationGraph const &);
+ParallelComputationGraph from_v1(V1ParallelComputationGraph const &);
 
 } // namespace FlexFlow
 

--- a/lib/pcg/include/pcg/file_format/v1/v1_parallel_computation_graph.h
+++ b/lib/pcg/include/pcg/file_format/v1/v1_parallel_computation_graph.h
@@ -7,6 +7,7 @@
 namespace FlexFlow {
 
 V1ParallelComputationGraph to_v1(ParallelComputationGraph const &);
+
 ParallelComputationGraph from_v1(V1ParallelComputationGraph const &);
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.cc
@@ -14,6 +14,9 @@ template V1KwargDataflowGraph<SlotName>
 
 template std::pair<KwargDataflowGraphView<SlotName>,
                    std::unordered_map<nonnegative_int, Node>>
+    from_v1_including_node_numbering(V1KwargDataflowGraph<SlotName> const &);
+
+template KwargDataflowGraphView<SlotName>
     from_v1(V1KwargDataflowGraph<SlotName> const &);
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.cc
@@ -12,4 +12,7 @@ template V1KwargDataflowGraph<SlotName>
     to_v1(KwargDataflowGraphView<SlotName> const &,
           std::unordered_map<Node, nonnegative_int> const &);
 
+template KwargDataflowGraphView<SlotName>
+    from_v1(V1KwargDataflowGraph<SlotName> const &);
+
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/graphs/v1_kwarg_dataflow_graph.cc
@@ -12,7 +12,8 @@ template V1KwargDataflowGraph<SlotName>
     to_v1(KwargDataflowGraphView<SlotName> const &,
           std::unordered_map<Node, nonnegative_int> const &);
 
-template KwargDataflowGraphView<SlotName>
+template std::pair<KwargDataflowGraphView<SlotName>,
+                   std::unordered_map<nonnegative_int, Node>>
     from_v1(V1KwargDataflowGraph<SlotName> const &);
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.cc
@@ -18,4 +18,7 @@ template std::pair<
 template V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> to_v1(
     LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName> const &);
 
+template LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> from_v1(
+    V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const &);
+
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.cc
@@ -21,6 +21,10 @@ template V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> to_v1(
 template std::pair<
     LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
     std::unordered_map<nonnegative_int, Node>>
+    from_v1_including_node_numbering(
+        V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const &);
+
+template LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>
     from_v1(
         V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const &);
 

--- a/lib/pcg/src/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.cc
@@ -18,7 +18,10 @@ template std::pair<
 template V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> to_v1(
     LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName> const &);
 
-template LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> from_v1(
-    V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const &);
+template std::pair<
+    LabelledKwargDataflowGraphView<NodeLabel, OutputLabel, SlotName>,
+    std::unordered_map<nonnegative_int, Node>>
+    from_v1(
+        V1LabelledKwargDataflowGraph<NodeLabel, OutputLabel, SlotName> const &);
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
@@ -10,6 +10,12 @@ V1ComputationGraph to_v1(ComputationGraph const &g) {
   };
 }
 
+ComputationGraph from_v1(V1ComputationGraph const &v1) {
+  return ComputationGraph{
+      from_v1(v1.raw_graph),
+  };
+}
+
 std::pair<V1ComputationGraph, bidict<nonnegative_int, layer_guid_t>>
     to_v1_including_node_numbering(ComputationGraph const &cg) {
   std::pair<

--- a/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
@@ -1,6 +1,7 @@
 #include "pcg/file_format/v1/v1_computation_graph.h"
 #include "pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h"
 #include "utils/bidict/algorithms/transform_values.h"
+#include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph.h"
 
 namespace FlexFlow {
 
@@ -11,9 +12,14 @@ V1ComputationGraph to_v1(ComputationGraph const &g) {
 }
 
 ComputationGraph from_v1(V1ComputationGraph const &v1) {
-  return ComputationGraph{
-      from_v1(v1.raw_graph),
-  };
+  LabelledKwargDataflowGraph<LayerAttrs, TensorAttrs, TensorSlotName>
+      raw_graph =
+          LabelledKwargDataflowGraph<LayerAttrs, TensorAttrs, TensorSlotName>::
+              create_copy_of<LabelledKwargDataflowGraph<LayerAttrs,
+                                                        TensorAttrs,
+                                                        TensorSlotName>>(
+                  from_v1(v1.raw_graph).first);
+  return ComputationGraph{raw_graph};
 }
 
 std::pair<V1ComputationGraph, bidict<nonnegative_int, layer_guid_t>>

--- a/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
@@ -1,6 +1,7 @@
 #include "pcg/file_format/v1/v1_computation_graph.h"
 #include "pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h"
 #include "utils/bidict/algorithms/transform_values.h"
+#include "utils/graph/instances/unordered_set_labelled_open_kwarg_dataflow_graph.h"
 #include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph.h"
 
 namespace FlexFlow {
@@ -12,14 +13,14 @@ V1ComputationGraph to_v1(ComputationGraph const &g) {
 }
 
 ComputationGraph from_v1(V1ComputationGraph const &v1) {
-  LabelledKwargDataflowGraph<LayerAttrs, TensorAttrs, TensorSlotName>
-      raw_graph =
-          LabelledKwargDataflowGraph<LayerAttrs, TensorAttrs, TensorSlotName>::
-              create_copy_of<LabelledKwargDataflowGraph<LayerAttrs,
-                                                        TensorAttrs,
-                                                        TensorSlotName>>(
-                  from_v1(v1.raw_graph).first);
-  return ComputationGraph{raw_graph};
+  return ComputationGraph{
+      LabelledKwargDataflowGraph<LayerAttrs, TensorAttrs, TensorSlotName>::
+          create_copy_of<
+              UnorderedSetLabelledOpenKwargDataflowGraph<LayerAttrs,
+                                                         TensorAttrs,
+                                                         int,
+                                                         TensorSlotName>>(
+              from_v1(v1.raw_graph).first)};
 }
 
 std::pair<V1ComputationGraph, bidict<nonnegative_int, layer_guid_t>>

--- a/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
@@ -35,7 +35,7 @@ ComputationGraph from_v1(V1ComputationGraph const &v1) {
                                                          TensorAttrs,
                                                          int,
                                                          TensorSlotName>>(
-              from_v1(v1.raw_graph).first)};
+              from_v1(v1.raw_graph))};
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_computation_graph.cc
@@ -12,17 +12,6 @@ V1ComputationGraph to_v1(ComputationGraph const &g) {
   };
 }
 
-ComputationGraph from_v1(V1ComputationGraph const &v1) {
-  return ComputationGraph{
-      LabelledKwargDataflowGraph<LayerAttrs, TensorAttrs, TensorSlotName>::
-          create_copy_of<
-              UnorderedSetLabelledOpenKwargDataflowGraph<LayerAttrs,
-                                                         TensorAttrs,
-                                                         int,
-                                                         TensorSlotName>>(
-              from_v1(v1.raw_graph).first)};
-}
-
 std::pair<V1ComputationGraph, bidict<nonnegative_int, layer_guid_t>>
     to_v1_including_node_numbering(ComputationGraph const &cg) {
   std::pair<
@@ -36,6 +25,17 @@ std::pair<V1ComputationGraph, bidict<nonnegative_int, layer_guid_t>>
       raw.second, [](Node const &n) { return layer_guid_t{n}; });
 
   return {v1_cg, v1_node_ids};
+}
+
+ComputationGraph from_v1(V1ComputationGraph const &v1) {
+  return ComputationGraph{
+      LabelledKwargDataflowGraph<LayerAttrs, TensorAttrs, TensorSlotName>::
+          create_copy_of<
+              UnorderedSetLabelledOpenKwargDataflowGraph<LayerAttrs,
+                                                         TensorAttrs,
+                                                         int,
+                                                         TensorSlotName>>(
+              from_v1(v1.raw_graph).first)};
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_mapped_operator_task_group.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_mapped_operator_task_group.cc
@@ -1,0 +1,9 @@
+#include "pcg/file_format/v1/v1_mapped_operator_task_group.h"
+
+namespace FlexFlow {
+
+V1MappedOperatorTaskGroup to_v1(MappedOperatorTaskGroup const &g) {
+  return V1MappedOperatorTaskGroup{g.get_shard_bindings()};
+}
+
+} // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_mapped_operator_task_group.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_mapped_operator_task_group.cc
@@ -6,4 +6,8 @@ V1MappedOperatorTaskGroup to_v1(MappedOperatorTaskGroup const &g) {
   return V1MappedOperatorTaskGroup{g.get_shard_bindings()};
 }
 
+MappedOperatorTaskGroup from_v1(V1MappedOperatorTaskGroup const &v1) {
+  return MappedOperatorTaskGroup{v1.shard_bindings};
+}
+
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
@@ -14,4 +14,13 @@ V1MappedParallelComputationGraph
   };
 }
 
+MappedParallelComputationGraph
+    from_v1(V1MappedParallelComputationGraph const &v1) {
+  return MappedParallelComputationGraph{
+      from_v1(v1.pcg),
+      map_values(v1.mapped_tasks,
+                 [](V1MappedOperatorTaskGroup const &g) { return from_v1(g); }),
+  };
+}
+
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
@@ -1,0 +1,17 @@
+#include "pcg/file_format/v1/v1_mapped_parallel_computation_graph.h"
+#include "pcg/file_format/v1/v1_mapped_operator_task_group.h"
+#include "pcg/file_format/v1/v1_parallel_computation_graph.h"
+#include "utils/containers/map_values.h"
+
+namespace FlexFlow {
+
+V1MappedParallelComputationGraph
+    to_v1(MappedParallelComputationGraph const &mpcg) {
+  return V1MappedParallelComputationGraph{
+      to_v1(mpcg.pcg),
+      map_values(mpcg.mapped_tasks,
+                 [](MappedOperatorTaskGroup const &g) { return to_v1(g); }),
+  };
+}
+
+} // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
@@ -1,26 +1,29 @@
 #include "pcg/file_format/v1/v1_mapped_parallel_computation_graph.h"
-#include "pcg/file_format/v1/v1_mapped_operator_task_group.h"
-#include "pcg/file_format/v1/v1_parallel_computation_graph.h"
-#include "utils/containers/map_values.h"
+#include "pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h"
+#include "utils/graph/instances/unordered_set_labelled_open_kwarg_dataflow_graph.h"
+#include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph.h"
 
 namespace FlexFlow {
 
 V1MappedParallelComputationGraph
     to_v1(MappedParallelComputationGraph const &mpcg) {
   return V1MappedParallelComputationGraph{
-      to_v1(mpcg.pcg),
-      map_values(mpcg.mapped_tasks,
-                 [](MappedOperatorTaskGroup const &g) { return to_v1(g); }),
+      to_v1<MappedParallelLayerAttrs, ParallelTensorAttrs, TensorSlotName>(
+          mpcg.raw_graph),
   };
 }
 
 MappedParallelComputationGraph
     from_v1(V1MappedParallelComputationGraph const &v1) {
   return MappedParallelComputationGraph{
-      from_v1(v1.pcg),
-      map_values(v1.mapped_tasks,
-                 [](V1MappedOperatorTaskGroup const &g) { return from_v1(g); }),
-  };
+      LabelledKwargDataflowGraph<MappedParallelLayerAttrs,
+                                 ParallelTensorAttrs,
+                                 TensorSlotName>::
+          create_copy_of<UnorderedSetLabelledOpenKwargDataflowGraph<
+              MappedParallelLayerAttrs,
+              ParallelTensorAttrs,
+              int,
+              TensorSlotName>>(from_v1(v1.raw_graph))};
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
@@ -10,4 +10,10 @@ V1ParallelComputationGraph to_v1(ParallelComputationGraph const &g) {
   };
 }
 
+ParallelComputationGraph from_v1(V1ParallelComputationGraph const &v1) {
+  return ParallelComputationGraph{
+      from_v1(v1.raw_graph),
+  };
+}
+
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
@@ -22,7 +22,7 @@ ParallelComputationGraph from_v1(V1ParallelComputationGraph const &v1) {
                                                          ParallelTensorAttrs,
                                                          int,
                                                          TensorSlotName>>(
-              from_v1(v1.raw_graph).first)};
+              from_v1(v1.raw_graph))};
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
@@ -1,5 +1,6 @@
 #include "pcg/file_format/v1/v1_parallel_computation_graph.h"
 #include "pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h"
+#include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph.h"
 
 namespace FlexFlow {
 
@@ -11,9 +12,17 @@ V1ParallelComputationGraph to_v1(ParallelComputationGraph const &g) {
 }
 
 ParallelComputationGraph from_v1(V1ParallelComputationGraph const &v1) {
-  return ParallelComputationGraph{
-      from_v1(v1.raw_graph),
-  };
+  LabelledKwargDataflowGraph<ParallelLayerAttrs,
+                             ParallelTensorAttrs,
+                             TensorSlotName>
+      raw_graph = LabelledKwargDataflowGraph<ParallelLayerAttrs,
+                                             ParallelTensorAttrs,
+                                             TensorSlotName>::
+          create_copy_of<LabelledKwargDataflowGraph<ParallelLayerAttrs,
+                                                    ParallelTensorAttrs,
+                                                    TensorSlotName>>(
+              from_v1(v1.raw_graph).first);
+  return ParallelComputationGraph{raw_graph};
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
+++ b/lib/pcg/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
@@ -1,5 +1,6 @@
 #include "pcg/file_format/v1/v1_parallel_computation_graph.h"
 #include "pcg/file_format/v1/graphs/v1_labelled_kwarg_dataflow_graph.h"
+#include "utils/graph/instances/unordered_set_labelled_open_kwarg_dataflow_graph.h"
 #include "utils/graph/labelled_kwarg_dataflow_graph/labelled_kwarg_dataflow_graph.h"
 
 namespace FlexFlow {
@@ -12,17 +13,16 @@ V1ParallelComputationGraph to_v1(ParallelComputationGraph const &g) {
 }
 
 ParallelComputationGraph from_v1(V1ParallelComputationGraph const &v1) {
-  LabelledKwargDataflowGraph<ParallelLayerAttrs,
-                             ParallelTensorAttrs,
-                             TensorSlotName>
-      raw_graph = LabelledKwargDataflowGraph<ParallelLayerAttrs,
-                                             ParallelTensorAttrs,
-                                             TensorSlotName>::
-          create_copy_of<LabelledKwargDataflowGraph<ParallelLayerAttrs,
-                                                    ParallelTensorAttrs,
-                                                    TensorSlotName>>(
-              from_v1(v1.raw_graph).first);
-  return ParallelComputationGraph{raw_graph};
+  return ParallelComputationGraph{
+      LabelledKwargDataflowGraph<ParallelLayerAttrs,
+                                 ParallelTensorAttrs,
+                                 TensorSlotName>::
+          create_copy_of<
+              UnorderedSetLabelledOpenKwargDataflowGraph<ParallelLayerAttrs,
+                                                         ParallelTensorAttrs,
+                                                         int,
+                                                         TensorSlotName>>(
+              from_v1(v1.raw_graph).first)};
 }
 
 } // namespace FlexFlow

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_computation_graph.cc
@@ -1,6 +1,8 @@
 #include "pcg/file_format/v1/v1_computation_graph.h"
+#include "pcg/computation_graph.h"
 #include "pcg/computation_graph_builder.h"
 #include <doctest/doctest.h>
+#include <nlohmann/json.hpp>
 
 using namespace ::FlexFlow;
 
@@ -25,6 +27,14 @@ TEST_SUITE(FF_TEST_SUITE) {
     }();
 
     V1ComputationGraph v1_cg = to_v1(cg);
-    nlohmann::json j = v1_cg;
+
+    SUBCASE("serializes to JSON") {
+      nlohmann::json j = v1_cg;
+    }
+
+    SUBCASE("round-trips via from_v1") {
+      ComputationGraph result = from_v1(v1_cg);
+      CHECK(computation_graphs_are_isomorphic(cg, result));
+    }
   }
 }

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_computation_graph.cc
@@ -30,6 +30,8 @@ TEST_SUITE(FF_TEST_SUITE) {
 
     SUBCASE("serializes to JSON") {
       nlohmann::json j = v1_cg;
+      V1ComputationGraph result = j.get<V1ComputationGraph>();
+      CHECK(result == v1_cg);
     }
 
     SUBCASE("round-trips via from_v1") {

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
@@ -1,0 +1,69 @@
+#include "pcg/file_format/v1/v1_mapped_parallel_computation_graph.h"
+#include "op-attrs/parallel_tensor_space_coordinate.dtg.h"
+#include "op-attrs/tensor_slot_name.dtg.h"
+#include "pcg/device_type.dtg.h"
+#include "pcg/machine_space_coordinate.dtg.h"
+#include "pcg/mapped_parallel_computation_graph/mapped_operator_task_group.h"
+#include "pcg/mapped_parallel_computation_graph/mapped_parallel_computation_graph.dtg.h"
+#include "pcg/mapped_parallel_computation_graph/operator_atomic_task_shard_binding.dtg.h"
+#include "pcg/parallel_computation_graph/parallel_computation_graph.h"
+#include "pcg/parallel_computation_graph/parallel_layer_added_result.dtg.h"
+#include "utils/bidict/bidict.h"
+#include <doctest/doctest.h>
+#include <nlohmann/json.hpp>
+
+using namespace ::FlexFlow;
+
+TEST_SUITE(FF_TEST_SUITE) {
+  TEST_CASE("V1MappedParallelComputationGraph") {
+    MappedParallelComputationGraph mpcg = [] {
+      ParallelComputationGraph pcg = empty_parallel_computation_graph();
+
+      TensorShape input_shape = TensorShape{
+          TensorDims{
+              FFOrdered{
+                  12_p,
+                  16_p,
+              },
+          },
+          DataType::FLOAT,
+      };
+
+      ParallelLayerAddedResult result = pcg_add_input_layer(pcg, input_shape);
+      parallel_layer_guid_t layer = result.parallel_layer;
+
+      MachineSpaceCoordinate coord = MachineSpaceCoordinate{
+          /*node_idx=*/0_n,
+          /*device_idx=*/0_n,
+          /*device_type=*/DeviceType::GPU,
+      };
+
+      OperatorAtomicTaskShardBinding binding = OperatorAtomicTaskShardBinding{
+          /*tensor_coords=*/{
+              {
+                  TensorSlotName::OUTPUT,
+                  ParallelTensorSpaceCoordinate{
+                      /*sum_component=*/0_n,
+                      /*discard_copy_component=*/0_n,
+                      /*shard_components=*/FFOrdered<nonnegative_int>{0_n, 0_n},
+                  },
+              },
+          },
+      };
+
+      MappedOperatorTaskGroup task_group = MappedOperatorTaskGroup{
+          bidict<MachineSpaceCoordinate, OperatorAtomicTaskShardBinding>{
+              {coord, binding},
+          },
+      };
+
+      return MappedParallelComputationGraph{
+          /*pcg=*/pcg,
+          /*mapped_tasks=*/{{layer, task_group}},
+      };
+    }();
+
+    V1MappedParallelComputationGraph v1_mpcg = to_v1(mpcg);
+    nlohmann::json j = v1_mpcg;
+  }
+}

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
@@ -2,6 +2,7 @@
 #include "op-attrs/parallel_tensor_space_coordinate.dtg.h"
 #include "op-attrs/tensor_slot_name.dtg.h"
 #include "pcg/device_type.dtg.h"
+#include "pcg/file_format/v1/v1_mapped_operator_task_group.h"
 #include "pcg/machine_space_coordinate.dtg.h"
 #include "pcg/mapped_parallel_computation_graph/mapped_operator_task_group.h"
 #include "pcg/mapped_parallel_computation_graph/mapped_parallel_computation_graph.dtg.h"
@@ -16,54 +17,65 @@ using namespace ::FlexFlow;
 
 TEST_SUITE(FF_TEST_SUITE) {
   TEST_CASE("V1MappedParallelComputationGraph") {
-    MappedParallelComputationGraph mpcg = [] {
-      ParallelComputationGraph pcg = empty_parallel_computation_graph();
+    ParallelComputationGraph pcg = empty_parallel_computation_graph();
 
-      TensorShape input_shape = TensorShape{
-          TensorDims{
-              FFOrdered{
-                  12_p,
-                  16_p,
-              },
-          },
-          DataType::FLOAT,
-      };
+    TensorShape input_shape = TensorShape{
+        TensorDims{
+            FFOrdered{
+                12_p,
+                16_p,
+            },
+        },
+        DataType::FLOAT,
+    };
 
-      ParallelLayerAddedResult result = pcg_add_input_layer(pcg, input_shape);
-      parallel_layer_guid_t layer = result.parallel_layer;
+    ParallelLayerAddedResult result = pcg_add_input_layer(pcg, input_shape);
+    parallel_layer_guid_t layer = result.parallel_layer;
 
-      MachineSpaceCoordinate coord = MachineSpaceCoordinate{
-          /*node_idx=*/0_n,
-          /*device_idx=*/0_n,
-          /*device_type=*/DeviceType::GPU,
-      };
+    MachineSpaceCoordinate coord = MachineSpaceCoordinate{
+        /*node_idx=*/0_n,
+        /*device_idx=*/0_n,
+        /*device_type=*/DeviceType::GPU,
+    };
 
-      OperatorAtomicTaskShardBinding binding = OperatorAtomicTaskShardBinding{
-          /*tensor_coords=*/{
-              {
-                  TensorSlotName::OUTPUT,
-                  ParallelTensorSpaceCoordinate{
-                      /*sum_component=*/0_n,
-                      /*discard_copy_component=*/0_n,
-                      /*shard_components=*/FFOrdered<nonnegative_int>{0_n, 0_n},
-                  },
-              },
-          },
-      };
+    OperatorAtomicTaskShardBinding binding = OperatorAtomicTaskShardBinding{
+        /*tensor_coords=*/{
+            {
+                TensorSlotName::OUTPUT,
+                ParallelTensorSpaceCoordinate{
+                    /*sum_component=*/0_n,
+                    /*discard_copy_component=*/0_n,
+                    /*shard_components=*/FFOrdered<nonnegative_int>{0_n, 0_n},
+                },
+            },
+        },
+    };
 
-      MappedOperatorTaskGroup task_group = MappedOperatorTaskGroup{
-          bidict<MachineSpaceCoordinate, OperatorAtomicTaskShardBinding>{
-              {coord, binding},
-          },
-      };
+    MappedOperatorTaskGroup task_group = MappedOperatorTaskGroup{
+        bidict<MachineSpaceCoordinate, OperatorAtomicTaskShardBinding>{
+            {coord, binding},
+        },
+    };
 
-      return MappedParallelComputationGraph{
-          /*pcg=*/pcg,
-          /*mapped_tasks=*/{{layer, task_group}},
-      };
-    }();
+    MappedParallelComputationGraph mpcg = MappedParallelComputationGraph{
+        /*pcg=*/pcg,
+        /*mapped_tasks=*/{{layer, task_group}},
+    };
 
     V1MappedParallelComputationGraph v1_mpcg = to_v1(mpcg);
-    nlohmann::json j = v1_mpcg;
+
+    SUBCASE("serializes to JSON") {
+      nlohmann::json j = v1_mpcg;
+    }
+
+    SUBCASE("MappedOperatorTaskGroup round-trips via from_v1") {
+      MappedOperatorTaskGroup result = from_v1(to_v1(task_group));
+      CHECK(result == task_group);
+    }
+
+    SUBCASE("MappedParallelComputationGraph round-trips via from_v1") {
+      MappedParallelComputationGraph result = from_v1(v1_mpcg);
+      CHECK(pcgs_are_isomorphic(mpcg.pcg, result.pcg));
+    }
   }
 }

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
@@ -66,6 +66,8 @@ TEST_SUITE(FF_TEST_SUITE) {
 
     SUBCASE("serializes to JSON") {
       nlohmann::json j = v1_mpcg;
+      V1MappedParallelComputationGraph result = j.get<V1MappedParallelComputationGraph>();
+      CHECK(result == v1_mpcg);
     }
 
     SUBCASE("MappedOperatorTaskGroup round-trips via from_v1") {

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
@@ -66,7 +66,8 @@ TEST_SUITE(FF_TEST_SUITE) {
 
     SUBCASE("serializes to JSON") {
       nlohmann::json j = v1_mpcg;
-      V1MappedParallelComputationGraph result = j.get<V1MappedParallelComputationGraph>();
+      V1MappedParallelComputationGraph result =
+          j.get<V1MappedParallelComputationGraph>();
       CHECK(result == v1_mpcg);
     }
 

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_mapped_parallel_computation_graph.cc
@@ -6,6 +6,7 @@
 #include "pcg/machine_space_coordinate.dtg.h"
 #include "pcg/mapped_parallel_computation_graph/mapped_operator_task_group.h"
 #include "pcg/mapped_parallel_computation_graph/mapped_parallel_computation_graph.dtg.h"
+#include "pcg/mapped_parallel_computation_graph/mapped_parallel_computation_graph.h"
 #include "pcg/mapped_parallel_computation_graph/operator_atomic_task_shard_binding.dtg.h"
 #include "pcg/parallel_computation_graph/parallel_computation_graph.h"
 #include "pcg/parallel_computation_graph/parallel_layer_added_result.dtg.h"
@@ -57,10 +58,10 @@ TEST_SUITE(FF_TEST_SUITE) {
         },
     };
 
-    MappedParallelComputationGraph mpcg = MappedParallelComputationGraph{
-        /*pcg=*/pcg,
-        /*mapped_tasks=*/{{layer, task_group}},
-    };
+    MappedParallelComputationGraph mpcg =
+        mapped_pcg_from_pcg_and_mapped_op_task_groups(
+            /*pcg=*/pcg,
+            /*mapped_tasks=*/{{layer, task_group}});
 
     V1MappedParallelComputationGraph v1_mpcg = to_v1(mpcg);
 
@@ -78,7 +79,7 @@ TEST_SUITE(FF_TEST_SUITE) {
 
     SUBCASE("MappedParallelComputationGraph round-trips via from_v1") {
       MappedParallelComputationGraph result = from_v1(v1_mpcg);
-      CHECK(pcgs_are_isomorphic(mpcg.pcg, result.pcg));
+      CHECK(mapped_pcgs_are_isomorphic(mpcg, result));
     }
   }
 }

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
@@ -1,6 +1,8 @@
 #include "pcg/file_format/v1/v1_parallel_computation_graph.h"
+#include "pcg/parallel_computation_graph/parallel_computation_graph.h"
 #include "pcg/parallel_computation_graph/parallel_computation_graph_builder.h"
 #include <doctest/doctest.h>
+#include <nlohmann/json.hpp>
 
 using namespace ::FlexFlow;
 
@@ -29,6 +31,14 @@ TEST_SUITE(FF_TEST_SUITE) {
     }();
 
     V1ParallelComputationGraph v1_pcg = to_v1(pcg);
-    nlohmann::json j = v1_pcg;
+
+    SUBCASE("serializes to JSON") {
+      nlohmann::json j = v1_pcg;
+    }
+
+    SUBCASE("round-trips via from_v1") {
+      ParallelComputationGraph result = from_v1(v1_pcg);
+      CHECK(pcgs_are_isomorphic(pcg, result));
+    }
   }
 }

--- a/lib/pcg/test/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
+++ b/lib/pcg/test/src/pcg/file_format/v1/v1_parallel_computation_graph.cc
@@ -34,6 +34,8 @@ TEST_SUITE(FF_TEST_SUITE) {
 
     SUBCASE("serializes to JSON") {
       nlohmann::json j = v1_pcg;
+      V1ParallelComputationGraph result = j.get<V1ParallelComputationGraph>();
+      CHECK(result == v1_pcg);
     }
 
     SUBCASE("round-trips via from_v1") {

--- a/lib/utils/include/utils/nonnegative_int/nonnegative_int.h
+++ b/lib/utils/include/utils/nonnegative_int/nonnegative_int.h
@@ -17,6 +17,7 @@ public:
   explicit nonnegative_int(unsigned long long int value);
 
   explicit operator int() const noexcept;
+  explicit operator size_t() const noexcept;
 
   bool operator<(nonnegative_int const &other) const;
   bool operator==(nonnegative_int const &other) const;
@@ -55,6 +56,9 @@ public:
 
   nonnegative_int operator%(nonnegative_int const &other) const;
   nonnegative_int &operator%=(nonnegative_int const &other);
+
+  int int_from_nonnegative_int() const;
+  size_t size_t_from_nonnegative_int() const;
 
   friend std::ostream &operator<<(std::ostream &os, nonnegative_int const &n);
 

--- a/lib/utils/src/utils/nonnegative_int/nonnegative_int.cc
+++ b/lib/utils/src/utils/nonnegative_int/nonnegative_int.cc
@@ -24,6 +24,10 @@ nonnegative_int::operator int() const noexcept {
   return this->value_;
 }
 
+nonnegative_int::operator size_t() const noexcept {
+  return static_cast<size_t>(this->value_);
+}
+
 bool nonnegative_int::operator<(nonnegative_int const &other) const {
   return this->value_ < other.value_;
 }
@@ -149,6 +153,14 @@ nonnegative_int nonnegative_int::operator%(nonnegative_int const &other) const {
 nonnegative_int &nonnegative_int::operator%=(nonnegative_int const &other) {
   this->value_ %= other.value_;
   return *this;
+}
+
+int nonnegative_int::int_from_nonnegative_int() const {
+  return this->value_;
+}
+
+size_t nonnegative_int::size_t_from_nonnegative_int() const {
+  return static_cast<size_t>(this->value_);
 }
 
 std::ostream &operator<<(std::ostream &os, nonnegative_int const &n) {

--- a/lib/utils/test/src/utils/nonnegative_int/nonnegative_int.cc
+++ b/lib/utils/test/src/utils/nonnegative_int/nonnegative_int.cc
@@ -315,6 +315,24 @@ TEST_SUITE(FF_TEST_SUITE) {
     CHECK(result == correct);
   }
 
+  TEST_CASE("nonnegative_int::int_from_nonnegative_int()") {
+    nonnegative_int input = nonnegative_int{3};
+
+    int result = input.int_from_nonnegative_int();
+    int correct = 3;
+
+    CHECK(result == correct);
+  }
+
+  TEST_CASE("nonnegative_int::size_t_from_nonnegative_int()") {
+    nonnegative_int input = nonnegative_int{3};
+
+    size_t result = input.size_t_from_nonnegative_int();
+    size_t correct = 3;
+
+    CHECK(result == correct);
+  }
+
   TEST_CASE("adl_serializer<nonnegative_int>") {
     SUBCASE("to_json") {
       nonnegative_int input = nonnegative_int{5};


### PR DESCRIPTION
Adds two things:

 * `V1MappedParallelComputationGraph`
 * `from_v1` conversion from v1 back to normal objects

Originally written with Claude, but the code got almost entirely ripped out and rewritten so essentially everything is done by hand at this point. Some of the v1 object representations also changed to make serialization possible or more convenient.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1634)
<!-- Reviewable:end -->
