### PR TITLE
Updated nonnegative_int tests to use _n literals 

### DIFF
--- a/lib/utils/test/src/utils/nonnegative_int/nonnegative_int.cc
+++ b/lib/utils/test/src/utils/nonnegative_int/nonnegative_int.cc
@@ -19,9 +19,9 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int == comparisons") {
-    nonnegative_int nn_int_1a = nonnegative_int{1};
-    nonnegative_int nn_int_1b = nonnegative_int{1};
-    nonnegative_int nn_int_2 = nonnegative_int{2};
+    nonnegative_int nn_int_1a = 1_n;
+    nonnegative_int nn_int_1b = 1_n;
+    nonnegative_int nn_int_2 = 2_n;
     SUBCASE("LHS: nonnegative_int, RHS: nonnegative_int, equal") {
       CHECK(nn_int_1a == nn_int_1b);
     }
@@ -43,9 +43,9 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int != comparisons") {
-    nonnegative_int nn_int_1a = nonnegative_int{1};
-    nonnegative_int nn_int_1b = nonnegative_int{1};
-    nonnegative_int nn_int_2 = nonnegative_int{2};
+    nonnegative_int nn_int_1a = 1_n;
+    nonnegative_int nn_int_1b = 1_n;
+    nonnegative_int nn_int_2 = 2_n;
     SUBCASE("LHS: nonnegative_int, RHS: nonnegative_int, equal") {
       CHECK_FALSE(nn_int_1a != nn_int_1b);
     }
@@ -67,9 +67,9 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int < comparisons") {
-    nonnegative_int nn_int_1a = nonnegative_int{1};
-    nonnegative_int nn_int_1b = nonnegative_int{1};
-    nonnegative_int nn_int_2 = nonnegative_int{2};
+    nonnegative_int nn_int_1a = 1_n;
+    nonnegative_int nn_int_1b = 1_n;
+    nonnegative_int nn_int_2 = 2_n;
     SUBCASE("LHS: nonnegative_int, RHS: nonnegative_int, less than") {
       CHECK(nn_int_1a < nn_int_2);
     }
@@ -100,9 +100,9 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int <= comparisons") {
-    nonnegative_int nn_int_1a = nonnegative_int{1};
-    nonnegative_int nn_int_1b = nonnegative_int{1};
-    nonnegative_int nn_int_2 = nonnegative_int{2};
+    nonnegative_int nn_int_1a = 1_n;
+    nonnegative_int nn_int_1b = 1_n;
+    nonnegative_int nn_int_2 = 2_n;
     SUBCASE("LHS: nonnegative_int, RHS: nonnegative_int, less than") {
       CHECK(nn_int_1a <= nn_int_2);
     }
@@ -133,9 +133,9 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int > comparisons") {
-    nonnegative_int nn_int_1a = nonnegative_int{1};
-    nonnegative_int nn_int_1b = nonnegative_int{1};
-    nonnegative_int nn_int_2 = nonnegative_int{2};
+    nonnegative_int nn_int_1a = 1_n;
+    nonnegative_int nn_int_1b = 1_n;
+    nonnegative_int nn_int_2 = 2_n;
     SUBCASE("LHS: nonnegative_int, RHS: nonnegative_int, less than") {
       CHECK_FALSE(nn_int_1a > nn_int_2);
     }
@@ -166,9 +166,9 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int >= comparisons") {
-    nonnegative_int nn_int_1a = nonnegative_int{1};
-    nonnegative_int nn_int_1b = nonnegative_int{1};
-    nonnegative_int nn_int_2 = nonnegative_int{2};
+    nonnegative_int nn_int_1a = 1_n;
+    nonnegative_int nn_int_1b = 1_n;
+    nonnegative_int nn_int_2 = 2_n;
     SUBCASE("LHS: nonnegative_int, RHS: nonnegative_int, less than") {
       CHECK_FALSE(nn_int_1a >= nn_int_2);
     }
@@ -199,76 +199,76 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int::operator+(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{1} + nonnegative_int{2};
-    nonnegative_int correct = nonnegative_int{3};
+    nonnegative_int result = 1_n + 2_n;
+    nonnegative_int correct = 3_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::operator++() (pre-increment)") {
-    nonnegative_int input = nonnegative_int{1};
+    nonnegative_int input = 1_n;
 
     nonnegative_int result = ++input;
-    nonnegative_int correct = nonnegative_int{2};
+    nonnegative_int correct = 2_n;
 
     CHECK(result == correct);
     CHECK(input == correct);
   }
 
   TEST_CASE("nonnegative_int::operator++(int) (post-increment)") {
-    nonnegative_int input = nonnegative_int{1};
+    nonnegative_int input = 1_n;
 
     nonnegative_int result = input++;
-    nonnegative_int correct_input = nonnegative_int{2};
-    nonnegative_int correct_result = nonnegative_int{1};
+    nonnegative_int correct_input = 2_n;
+    nonnegative_int correct_result = 1_n;
 
     CHECK(result == correct_result);
     CHECK(input == correct_input);
   }
 
   TEST_CASE("nonnegative_int::operator+=(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{1};
-    result += nonnegative_int{3};
+    nonnegative_int result = 1_n;
+    result += 3_n;
 
-    nonnegative_int correct = nonnegative_int{4};
+    nonnegative_int correct = 4_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::operator*(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{2} * nonnegative_int{3};
-    nonnegative_int correct = nonnegative_int{6};
+    nonnegative_int result = 2_n * 3_n;
+    nonnegative_int correct = 6_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::operator*=(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{3};
-    result *= nonnegative_int{6};
+    nonnegative_int result = 3_n;
+    result *= 6_n;
 
-    nonnegative_int correct = nonnegative_int{18};
+    nonnegative_int correct = 18_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::operator/(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{5} / nonnegative_int{2};
-    nonnegative_int correct = nonnegative_int{2};
+    nonnegative_int result = 5_n / 2_n;
+    nonnegative_int correct = 2_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::operator/=(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{13};
-    result /= nonnegative_int{3};
+    nonnegative_int result = 13_n;
+    result /= 3_n;
 
-    nonnegative_int correct = nonnegative_int{4};
+    nonnegative_int correct = 4_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("operator/(float, nonnegative_int)") {
-    float result = 5.0 / nonnegative_int{2};
+    float result = 5.0 / 2_n;
     float correct = 5.0 / 2;
 
     CHECK(result == correct);
@@ -276,7 +276,7 @@ TEST_SUITE(FF_TEST_SUITE) {
 
   TEST_CASE("operator/=(float, nonnegative_int)") {
     float result = 13.0;
-    result /= nonnegative_int{3};
+    result /= 3_n;
 
     float correct = 13.0 / 3;
 
@@ -284,39 +284,39 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int::operator/(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{5} / nonnegative_int{2};
-    nonnegative_int correct = nonnegative_int{2};
+    nonnegative_int result = 5_n / 2_n;
+    nonnegative_int correct = 2_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::operator/=(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{13};
-    result /= nonnegative_int{3};
+    nonnegative_int result = 13_n;
+    result /= 3_n;
 
-    nonnegative_int correct = nonnegative_int{4};
+    nonnegative_int correct = 4_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::operator%(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{5} % nonnegative_int{2};
-    nonnegative_int correct = nonnegative_int{1};
+    nonnegative_int result = 5_n % 2_n;
+    nonnegative_int correct = 1_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::operator%=(nonnegative_int)") {
-    nonnegative_int result = nonnegative_int{15};
-    result %= nonnegative_int{4};
+    nonnegative_int result = 15_n;
+    result %= 4_n;
 
-    nonnegative_int correct = nonnegative_int{3};
+    nonnegative_int correct = 3_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative_int::int_from_nonnegative_int()") {
-    nonnegative_int input = nonnegative_int{3};
+    nonnegative_int input = 3_n;
 
     int result = input.int_from_nonnegative_int();
     int correct = 3;
@@ -325,7 +325,7 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("nonnegative_int::size_t_from_nonnegative_int()") {
-    nonnegative_int input = nonnegative_int{3};
+    nonnegative_int input = 3_n;
 
     size_t result = input.size_t_from_nonnegative_int();
     size_t correct = 3;
@@ -335,7 +335,7 @@ TEST_SUITE(FF_TEST_SUITE) {
 
   TEST_CASE("adl_serializer<nonnegative_int>") {
     SUBCASE("to_json") {
-      nonnegative_int input = nonnegative_int{5};
+      nonnegative_int input = 5_n;
 
       nlohmann::json result = input;
       nlohmann::json correct = 5;
@@ -347,16 +347,16 @@ TEST_SUITE(FF_TEST_SUITE) {
       nlohmann::json input = 5;
 
       nonnegative_int result = input.template get<nonnegative_int>();
-      nonnegative_int correct = nonnegative_int{5};
+      nonnegative_int correct = 5_n;
 
       CHECK(result == correct);
     }
   }
 
   TEST_CASE("std::hash<nonnegative_int>") {
-    nonnegative_int nn_int_1a = nonnegative_int{1};
-    nonnegative_int nn_int_1b = nonnegative_int{1};
-    nonnegative_int nn_int_2 = nonnegative_int{2};
+    nonnegative_int nn_int_1a = 1_n;
+    nonnegative_int nn_int_1b = 1_n;
+    nonnegative_int nn_int_2 = 2_n;
     std::hash<nonnegative_int> hash_fn;
     SUBCASE("Identical values have the same hash") {
       CHECK(hash_fn(nn_int_1a) == hash_fn(nn_int_1b));
@@ -376,13 +376,13 @@ TEST_SUITE(FF_TEST_SUITE) {
 
   TEST_CASE("_n suffix") {
     nonnegative_int result = 5_n;
-    nonnegative_int correct = nonnegative_int{5};
+    nonnegative_int correct = 5_n;
 
     CHECK(result == correct);
   }
 
   TEST_CASE("nonnegative int >> operator") {
-    nonnegative_int nn_int_1 = nonnegative_int{1};
+    nonnegative_int nn_int_1 = 1_n;
     std::ostringstream oss;
     oss << nn_int_1;
 
@@ -390,7 +390,7 @@ TEST_SUITE(FF_TEST_SUITE) {
   }
 
   TEST_CASE("fmt::to_string(nonnegative_int)") {
-    nonnegative_int nn_int_1 = nonnegative_int{1};
+    nonnegative_int nn_int_1 = 1_n;
     CHECK(fmt::to_string(nn_int_1) == "1");
   }
 }

--- a/lib/utils/test/src/utils/nonnegative_int/nonnegative_int.cc
+++ b/lib/utils/test/src/utils/nonnegative_int/nonnegative_int.cc
@@ -22,9 +22,7 @@ TEST_SUITE(FF_TEST_SUITE) {
     nonnegative_int nn_int_1a = 1_n;
     nonnegative_int nn_int_1b = 1_n;
     nonnegative_int nn_int_2 = 2_n;
-    SUBCASE("LHS: nonnegative_int, RHS: nonnegative_int, equal") {
-      CHECK(nn_int_1a == nn_int_1b);
-    }
+CHECK(1_n == 1_n);
     SUBCASE("LHS: nonnegative_int, RHS: nonnegative_int, not equal") {
       CHECK_FALSE(nn_int_1a == nn_int_2);
     }


### PR DESCRIPTION
…nsertions(+), 60

 deletions(-)
khoang21@sapling2:~/ff$ git push -u origin use-nonnegative-int-literals# Please enter the commit message for your changes. Lines starting Username for 'https://github.com': khoang05# with '#' will be ignored, and an empty message aborts the commit. Password for 'https://khoang05@github.com': # remote: Invalid username or token. Password authentication is not supported for Git operations.# On branch use-nonnegative-int-literals fatal: Authentication failed for 'https://github.com/flexflow/flexflow-train.git/'# Changes to be committed: khoang21@sapling2:~/ff$ git remote -v# modified: lib/utils/test/src/utils/nonnegative_int/nonnegative_int.cc origin https://github.com/flexflow/flexflow-train.git (fetch)# origin https://github.com/flexflow/flexflow-train.git (push) khoang21@sapling2:~/ff$ git remote set-url origin https://github.com/khoang05/flexflow-train.git khoang21@sapling2:~/ff$ git push -u origin use-nonnegative-int-literals Username for 'https://github.com': khoang05 Password for 'https://khoang05@github.com':

**Description of changes:**



**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1658)
<!-- Reviewable:end -->
